### PR TITLE
Update Header Forwarding, update readme

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      pull-requests: write
+
     steps:
     - name: Checkout source
       uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ To remove all deployed resources, delete the Azure resource group:
 az group delete --name <resourceGroupName> --yes
 ```
 
-## 7. Production Onboarding (Follow-up)
+### 7. Production Onboarding (Follow-up)
 
 - **TLS Configuration**  
   Set up HTTPS on Azure Application Gateway (AAG) listener using valid TLS certificates.

--- a/dotnet/Microsoft.McpGateway.Service/src/HttpProxy.cs
+++ b/dotnet/Microsoft.McpGateway.Service/src/HttpProxy.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.McpGateway.Service
 {
@@ -18,6 +19,10 @@ namespace Microsoft.McpGateway.Service
 
             foreach (var header in context.Request.Headers)
             {
+                // Skip the inbound Authorization header
+                if (string.Equals(header.Key, HeaderNames.Authorization, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
                 if (!requestMessage.Headers.TryAddWithoutValidation(header.Key, [.. header.Value]))
                     requestMessage.Content?.Headers.TryAddWithoutValidation(header.Key, [.. header.Value]);
             }
@@ -35,7 +40,7 @@ namespace Microsoft.McpGateway.Service
             foreach (var header in response.Content.Headers)
                 context.Response.Headers[header.Key] = header.Value.ToArray();
 
-            context.Response.Headers.Remove("transfer-encoding");
+            context.Response.Headers.Remove(HeaderNames.TransferEncoding);
 
             return response.Content.CopyToAsync(context.Response.Body, cancellationToken);
         }


### PR DESCRIPTION
Remove the authorization header when forwarding requests to the MCP servers, as the server is not trusted.