### PR TITLE
[MCP Authentication] Add Sub Path Protected Resource Metadata (PRM) Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ To allow Azure CLI & VS Code to work as the client for token acquisition.
 | `resourceGroup`   | The name of the resource group. Must contain only lowercase letters and numbers (alphanumeric).                 |
 | `clientId`        | The Entra ID (Azure AD) client ID from your app registration.                                                    |
 | `location`        | *(Optional)* The Azure region where resources will be deployed.<br/>Defaults to the resource group's location.   |
-| `resourceLabel`   | *(Optional)* A lowercase alphanumeric string used as a suffix for naming resources and as the DNS label.<br/>If not provided, it will be the resourceGroup name.<br/>**Recommendation:** Set this value as the default the same with resource group name and make sure resouce group name contains only lower alphanumeric. |
+| `resourceLabel`   | *(Optional)* A lowercase alphanumeric string used as a suffix for naming resources and as the DNS label.<br/>If not provided, it will be the resourceGroup name.<br/>**Recommendation:** Set this value as the default the same with resource group name and make sure resource group name contains only lower alphanumeric. |
 
 
 The deployment will:

--- a/dotnet/Microsoft.McpGateway.Service/src/McpSubPathAwareAuthenticationHandler.cs
+++ b/dotnet/Microsoft.McpGateway.Service/src/McpSubPathAwareAuthenticationHandler.cs
@@ -1,0 +1,181 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
+using ModelContextProtocol.Authentication;
+
+namespace ModelContextProtocol.AspNetCore.Authentication;
+
+/// <summary>
+/// Authentication handler for MCP protocol that adds resource metadata to challenge responses
+/// and handles resource metadata endpoint requests.
+/// </summary>
+public class McpSubPathAwareAuthenticationHandler : AuthenticationHandler<McpAuthenticationOptions>, IAuthenticationRequestHandler
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="McpAuthenticationHandler"/> class.
+    /// </summary>
+    public McpSubPathAwareAuthenticationHandler(
+        IOptionsMonitor<McpAuthenticationOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder)
+        : base(options, logger, encoder)
+    {
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> HandleRequestAsync()
+    {
+        // Check if the request is for the resource metadata endpoint
+        string requestPath = Request.Path.Value ?? string.Empty;
+
+        string expectedMetadataPath = Options.ResourceMetadataUri?.ToString() ?? string.Empty;
+        if (Options.ResourceMetadataUri != null && !Options.ResourceMetadataUri.IsAbsoluteUri)
+        {
+            // For relative URIs, it's just the path component.
+            expectedMetadataPath = Options.ResourceMetadataUri.OriginalString;
+        }
+
+        // If the path doesn't match, let the request continue through the pipeline
+        if (!requestPath.StartsWith(expectedMetadataPath, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        return await HandleResourceMetadataRequestAsync();
+    }
+
+    /// <summary>
+    /// Gets the base URL from the current request, including scheme, host, and path base.
+    /// </summary>
+    private string GetBaseUrl() => $"{Request.Scheme}://{Request.Host}{Request.PathBase}";
+
+    private string GetCurrentPath() => Request.Path.HasValue ? Request.Path.Value! : string.Empty;
+
+    /// <summary>
+    /// Gets the absolute URI for the resource metadata endpoint.
+    /// </summary>
+    private string GetAbsoluteResourceMetadataUri()
+    {
+        var resourceMetadataUri = Options.ResourceMetadataUri;
+
+        string currentPath = resourceMetadataUri?.ToString() ?? string.Empty;
+
+        if (resourceMetadataUri != null && resourceMetadataUri.IsAbsoluteUri)
+        {
+            return currentPath;
+        }
+
+        // For relative URIs, combine with the base URL
+        string baseUrl = GetBaseUrl();
+        string relativePath = resourceMetadataUri?.OriginalString.TrimStart('/') ?? string.Empty;
+
+        if (!Uri.TryCreate($"{baseUrl.TrimEnd('/')}/{relativePath}", UriKind.Absolute, out var absoluteUri))
+        {
+            throw new InvalidOperationException($"Could not create absolute URI for resource metadata. Base URL: {baseUrl}, Relative Path: {relativePath}");
+        }
+
+        var currentRequestPath = GetCurrentPath();
+        return $"{absoluteUri}{currentRequestPath}";
+    }
+
+    private async Task<bool> HandleResourceMetadataRequestAsync()
+    {
+        var resourceMetadata = Options.ResourceMetadata;
+
+        if (Options.Events.OnResourceMetadataRequest is not null)
+        {
+            var resourceMetadataUri = Options.ResourceMetadataUri;
+            var prefix = new PathString(resourceMetadataUri.IsAbsoluteUri ? resourceMetadataUri.AbsolutePath : resourceMetadataUri.OriginalString);
+
+            if (!Request.Path.StartsWithSegments(prefix, out var subPath))
+            {
+                throw new InvalidOperationException($"Request path '{Request.Path}' does not start with '{prefix}'.");
+            }
+
+            var context = new ResourceMetadataRequestContext(Request.HttpContext, Scheme, Options)
+            {
+                ResourceMetadata = CloneResourceMetadata(resourceMetadata, subPath),
+            };
+
+            await Options.Events.OnResourceMetadataRequest(context);
+
+            if (context.Result is not null)
+            {
+                if (context.Result.Handled)
+                {
+                    return true;
+                }
+                else if (context.Result.Skipped)
+                {
+                    return false;
+                }
+                else if (context.Result.Failure is not null)
+                {
+                    throw new AuthenticationFailureException("An error occurred from the OnResourceMetadataRequest event.", context.Result.Failure);
+                }
+            }
+
+            resourceMetadata = context.ResourceMetadata;
+        }
+
+        if (resourceMetadata == null)
+        {
+            throw new InvalidOperationException(
+                "ResourceMetadata has not been configured. Please set McpAuthenticationOptions.ResourceMetadata or ensure context.ResourceMetadata is set inside McpAuthenticationOptions.Events.OnResourceMetadataRequest.");
+        }
+
+        await Results.Json(resourceMetadata, McpJsonUtilities.DefaultOptions.GetTypeInfo(typeof(ProtectedResourceMetadata))).ExecuteAsync(Context);
+        return true;
+    }
+
+    /// <inheritdoc />
+    // If no forwarding is configured, this handler doesn't perform authentication
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync() => Task.FromResult(AuthenticateResult.NoResult());
+
+    /// <inheritdoc />
+    protected override Task HandleChallengeAsync(AuthenticationProperties properties)
+    {
+        // Get the absolute URI for the resource metadata
+        string rawPrmDocumentUri = GetAbsoluteResourceMetadataUri();
+
+        properties ??= new AuthenticationProperties();
+
+        // Store the resource_metadata in properties in case other handlers need it
+        properties.Items["resource_metadata"] = rawPrmDocumentUri;
+
+        // Add the WWW-Authenticate header with Bearer scheme and resource metadata
+        string headerValue = $"Bearer realm=\"{Scheme.Name}\", resource_metadata=\"{rawPrmDocumentUri}\"";
+        Response.Headers.Append("WWW-Authenticate", headerValue);
+
+        return base.HandleChallengeAsync(properties);
+    }
+
+    internal static ProtectedResourceMetadata? CloneResourceMetadata(ProtectedResourceMetadata? resourceMetadata, string subPath)
+    {
+        if (resourceMetadata is null)
+        {
+            return null;
+        }
+
+        return new ProtectedResourceMetadata
+        {
+            Resource = new Uri(resourceMetadata.Resource, subPath),
+            AuthorizationServers = [.. resourceMetadata.AuthorizationServers],
+            BearerMethodsSupported = [.. resourceMetadata.BearerMethodsSupported],
+            ScopesSupported = [.. resourceMetadata.ScopesSupported],
+            JwksUri = resourceMetadata.JwksUri,
+            ResourceSigningAlgValuesSupported = resourceMetadata.ResourceSigningAlgValuesSupported is not null ? [.. resourceMetadata.ResourceSigningAlgValuesSupported] : null,
+            ResourceName = resourceMetadata.ResourceName,
+            ResourceDocumentation = resourceMetadata.ResourceDocumentation,
+            ResourcePolicyUri = resourceMetadata.ResourcePolicyUri,
+            ResourceTosUri = resourceMetadata.ResourceTosUri,
+            TlsClientCertificateBoundAccessTokens = resourceMetadata.TlsClientCertificateBoundAccessTokens,
+            AuthorizationDetailsTypesSupported = resourceMetadata.AuthorizationDetailsTypesSupported is not null ? [.. resourceMetadata.AuthorizationDetailsTypesSupported] : null,
+            DpopSigningAlgValuesSupported = resourceMetadata.DpopSigningAlgValuesSupported is not null ? [.. resourceMetadata.DpopSigningAlgValuesSupported] : null,
+            DpopBoundAccessTokensRequired = resourceMetadata.DpopBoundAccessTokensRequired
+        };
+    }
+}

--- a/dotnet/Microsoft.McpGateway.Service/src/Program.cs
+++ b/dotnet/Microsoft.McpGateway.Service/src/Program.cs
@@ -38,7 +38,10 @@ else
         options.DefaultChallengeScheme = McpAuthenticationDefaults.AuthenticationScheme;
         options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
     })
-    .AddMcp(options =>
+    .AddScheme<McpAuthenticationOptions, McpSubPathAwareAuthenticationHandler>(
+        McpAuthenticationDefaults.AuthenticationScheme,
+        McpAuthenticationDefaults.DisplayName,
+    options =>
     {
         options.ResourceMetadata = new()
         {

--- a/mcp-proxy-server/README.md
+++ b/mcp-proxy-server/README.md
@@ -25,10 +25,10 @@ With this, you can transform **local-only MCP servers** into **cloud-accessible 
 
 - Configure permissions for the workload identity principal (If setting up a local mcp server)
 `mg-identity-<identifier>-workload`. 
-This identity is created by deployment. The MCP server will use the workload identity for upstream resouce access.
+This identity is created by deployment. The MCP server will use the workload identity for upstream resource access.
 
 ### Proxying Local Servers
-For starting a local MCP server in stdio and proxying the traffice through gateway to it.
+For starting a local MCP server in stdio and proxying the traffic through gateway to it.
 Set server startup command and arguments in environment variables:
   - `MCP_COMMAND`
   - `MCP_ARGS`
@@ -38,7 +38,7 @@ Set `useWorkloadIdentity` to be true if need the server to use the workload iden
   > **Note:** When using a bridged local server, certain system packages may be missing by default. To address this, you can install the required packages within a custom Dockerfile and build your own `mcp-proxy` image.
 
 ### Proxying Remote Servers
-For proxying another internal mcp server hosted in streamable HTTP. Set the target ednpoint in environment variable
+For proxying another internal mcp server hosted in streamable HTTP. Set the target endpoint in environment variable
   - `MCP_PROXY_URL`
 
 
@@ -49,7 +49,7 @@ Example payloads to send to `mcp-gateway` using the `POST /adapters` endpoint to
 #### Example 1: Bridged [Azure MCP Server](https://github.com/microsoft/mcp/tree/main/servers/Azure.Mcp.Server)
 ```json
 {
-  "name": "ado-remote",
+  "name": "azure-remote",
   "imageName": "mcp-proxy",
   "imageVersion": "1.0.0",
   "environmentVariables": {
@@ -58,14 +58,14 @@ Example payloads to send to `mcp-gateway` using the `POST /adapters` endpoint to
     "AZURE_MCP_INCLUDE_PRODUCTION_CREDENTIALS": "true",
     "DOTNET_SYSTEM_GLOBALIZATION_INVARIANT": "1"
   },
-  "description": "Bridged ADO local MCP server"
+  "description": "Bridged Azure local MCP server"
 }
 ```
 
 #### Example 2: Bridged [Azure AI Foundry MCP Server](https://github.com/azure-ai-foundry/mcp-foundry)
 ```json
 {
-  "name": "foundry",
+  "name": "foundry-remote",
   "imageName": "mcp-proxy",
   "imageVersion": "1.0.0",
   "environmentVariables": {


### PR DESCRIPTION
Temporarily Patch MCP .NET SDK’s `McpAuthenticationHandler` ([source](https://github.com/modelcontextprotocol/csharp-sdk/blob/ab6d3e1ac51c129d311d19afe2925e434372bbd8/src/ModelContextProtocol.AspNetCore/Authentication/McpAuthenticationHandler.cs#L57)) where the Protected Resource Metadata (PRM) URL does not include the requested resource’s subpath.

When constructing the PRM URL, append the original request path after the well-known suffix.
In the PRM response, set resource to the exact original resource URL with sub path

Expected in [RFC 9728 §3.1](https://datatracker.ietf.org/doc/html/rfc9728/#section-3.1) The PRM URL must be built by **inserting the well-known suffix between the host and the resource’s existing path.

For a resource hosted on a subpath:

Input (client request):

```
https://exmaple.com/test/mcp
```

Expected PRM URL:

```
https://exmaple.com/.well-known/oauth-protected-resource/test/mcp
```

And in the PRM response, the `resource` value should echo the original resource URL:

```json
{
  "resource": "https://exmaple.com/test/mcp",
  ...
}
```