### PR TITLE
Configure multi-architecture Docker builds (amd64/arm64)

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -19,6 +19,12 @@ jobs:
     - name: Checkout source
       uses: actions/checkout@v3
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
     - name: Log in to the Container registry
       uses: docker/login-action@v3
       with:
@@ -26,16 +32,20 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Setup .NET SDK
-      uses: actions/setup-dotnet@v4
+    - name: Build and push mcp-gateway multi-arch image
+      uses: docker/build-push-action@v5
       with:
-        dotnet-version: '8.x'
+        context: .
+        file: ./dotnet/Microsoft.McpGateway.Service/Dockerfile
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: ghcr.io/${{ github.repository_owner }}/mcp-gateway:latest
 
-    - name: Restore dependencies
-      run: dotnet restore dotnet/Microsoft.McpGateway.sln --runtime linux-x64
-
-    - name: Publish and push the mcp-gateway container image
-      run: dotnet publish dotnet/Microsoft.McpGateway.Service/src/Microsoft.McpGateway.Service.csproj --configuration Release --no-restore /p:PublishProfile=github.pubxml /p:ContainerRepository=${{ github.repository_owner }}/mcp-gateway
-
-    - name: Publish and push the tool-gateway container image
-      run: dotnet publish dotnet/Microsoft.McpGateway.Tools/src/Microsoft.McpGateway.Tools.csproj --configuration Release --no-restore /p:PublishProfile=github.pubxml /p:ContainerRepository=${{ github.repository_owner }}/tool-gateway
+    - name: Build and push tool-gateway multi-arch image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: ./dotnet/Microsoft.McpGateway.Tools/Dockerfile
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: ghcr.io/${{ github.repository_owner }}/tool-gateway:latest

--- a/dotnet/Microsoft.McpGateway.Service/Dockerfile
+++ b/dotnet/Microsoft.McpGateway.Service/Dockerfile
@@ -1,0 +1,33 @@
+# Build stage
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+
+# Copy solution and project files
+COPY dotnet/Directory.Packages.props dotnet/
+COPY dotnet/Microsoft.McpGateway.sln dotnet/
+COPY dotnet/Microsoft.McpGateway.Management/src/Microsoft.McpGateway.Management.csproj dotnet/Microsoft.McpGateway.Management/src/
+COPY dotnet/Microsoft.McpGateway.Service/src/Microsoft.McpGateway.Service.csproj dotnet/Microsoft.McpGateway.Service/src/
+
+# Restore dependencies
+RUN dotnet restore dotnet/Microsoft.McpGateway.Service/src/Microsoft.McpGateway.Service.csproj
+
+# Copy the rest of the source code
+COPY dotnet/Microsoft.McpGateway.Management/src dotnet/Microsoft.McpGateway.Management/src/
+COPY dotnet/Microsoft.McpGateway.Service/src dotnet/Microsoft.McpGateway.Service/src/
+
+# Build and publish the application
+WORKDIR /src/dotnet/Microsoft.McpGateway.Service/src
+RUN dotnet publish Microsoft.McpGateway.Service.csproj -c Release -o /app/publish --no-restore
+
+# Runtime stage
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
+WORKDIR /app
+
+# Copy published application from build stage
+COPY --from=build /app/publish .
+
+# Expose port
+EXPOSE 8000
+
+# Set entrypoint
+ENTRYPOINT ["dotnet", "Microsoft.McpGateway.Service.dll"]

--- a/dotnet/Microsoft.McpGateway.Tools/Dockerfile
+++ b/dotnet/Microsoft.McpGateway.Tools/Dockerfile
@@ -1,0 +1,33 @@
+# Build stage
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+
+# Copy solution and project files
+COPY dotnet/Directory.Packages.props dotnet/
+COPY dotnet/Microsoft.McpGateway.sln dotnet/
+COPY dotnet/Microsoft.McpGateway.Management/src/Microsoft.McpGateway.Management.csproj dotnet/Microsoft.McpGateway.Management/src/
+COPY dotnet/Microsoft.McpGateway.Tools/src/Microsoft.McpGateway.Tools.csproj dotnet/Microsoft.McpGateway.Tools/src/
+
+# Restore dependencies
+RUN dotnet restore dotnet/Microsoft.McpGateway.Tools/src/Microsoft.McpGateway.Tools.csproj
+
+# Copy the rest of the source code
+COPY dotnet/Microsoft.McpGateway.Management/src dotnet/Microsoft.McpGateway.Management/src/
+COPY dotnet/Microsoft.McpGateway.Tools/src dotnet/Microsoft.McpGateway.Tools/src/
+
+# Build and publish the application
+WORKDIR /src/dotnet/Microsoft.McpGateway.Tools/src
+RUN dotnet publish Microsoft.McpGateway.Tools.csproj -c Release -o /app/publish --no-restore
+
+# Runtime stage
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
+WORKDIR /app
+
+# Copy published application from build stage
+COPY --from=build /app/publish .
+
+# Expose port
+EXPOSE 8000
+
+# Set entrypoint
+ENTRYPOINT ["dotnet", "Microsoft.McpGateway.Tools.dll"]


### PR DESCRIPTION
This PR adds multi-architecture support (amd64/arm64) to the Docker image builds, replacing the previous `dotnet publish` approach with Docker Buildx.

### Changes

**Dockerfiles**
- Added multi-stage Dockerfiles for `Microsoft.McpGateway.Service` and `Microsoft.McpGateway.Tools`
- Build stage: .NET SDK 8.0 with optimized layer caching
- Runtime stage: ASP.NET 8.0 runtime (smaller image size)
- Exposes port 8000

**GitHub Actions Workflow**
- Added QEMU and Docker Buildx setup
- Replaced `dotnet publish` with `docker/build-push-action@v5`
- Platforms: `linux/amd64,linux/arm64`
- Removed .NET SDK setup (no longer needed)

### Benefits

✅ **Multi-Architecture Support**: Works on AMD64 and ARM64 (Apple Silicon, AWS Graviton)  
✅ **Optimized Layer Caching**: Multi-stage builds leverage Docker cache  
✅ **Smaller Images**: Runtime stage uses only ASP.NET runtime  
✅ **Automatic Manifest List**: Docker automatically creates manifest lists

### Testing

Both images have been built and validated locally:
- ✅ `mcp-gateway` - multi-stage build completes successfully
- ✅ `tool-gateway` - multi-stage build completes successfully

### Usage

```bash
docker pull ghcr.io/microsoft/mcp-gateway:latest
# Automatically pulls the correct architecture (AMD64 or ARM64)

docker manifest inspect ghcr.io/microsoft/mcp-gateway:latest
# Shows both architectures in manifest
```

### Validation Results

Tested on: https://github.com/raniellyferreira/mcp-gateway/pull/1