### PR TITLE
Fix MSRC security vulnerabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,14 +152,14 @@ flowchart LR
 
 The gateway provides entra id authentication and basic application role authorization for mcp servers and tools:
 
-- **Read** access is granted to the resource creator, principals assigned the configured role values (for example `mcp.engineer`), and anyone holding the mandatory administrator role `mcp.admin`.
+- **Read** access is granted to the resource creator, principals assigned the configured `requiredRoles` values (for example `mcp.engineer`), and anyone holding the mandatory administrator role `mcp.admin`. When `requiredRoles` is empty or omitted, only the creator and `mcp.admin` principals can read the resource.
 - **Write** access is restricted to the resource creator or principals holding the `mcp.admin` role.
 
 For step-by-step guidance on configuring Azure Entra ID (creating `mcp.admin` and other role values, assigning them to users or service principals, and supplying those values in adapter/tool payloads), see [docs/entra-app-roles.md](docs/entra-app-roles.md).
 
 ### Additional Capabilities
 
-- *New*: Support for **Proxying Local & Remote MCP Servers**. See [examples and usage](sample-servers/mcp-proxy/README.md).
+- Support for **Proxying Local & Remote MCP Servers**. See [examples and usage](sample-servers/mcp-proxy/README.md).
 - Stateless reverse proxy with a distributed session store (production mode).
 - Kubernetes-native deployment using StatefulSets and headless services.
 
@@ -457,7 +457,7 @@ az acr build -r "mgreg$resourceLabel" -f sample-servers/mcp-example/Dockerfile s
     "imageName": "mcp-example",
     "imageVersion": "1.0.0",
     "description": "test",
-    "requiredRoles": [] // Add entra id application role to restrict access
+    "requiredRoles": [] // Only creator and mcp.admin can access. Add roles (e.g. ["mcp.engineer"]) to grant read access to other principals.
   }
   ```
 
@@ -513,7 +513,7 @@ Content-Type: application/json
   "imageVersion": "1.0.0",
   "useWorkloadIdentity": true,
   "description": "Weather tool for getting current weather information",
-  "requiredRoles": [], // Add entra id application role to restrict access
+  "requiredRoles": [], // Only creator and mcp.admin can access. Add roles (e.g. ["mcp.engineer"]) to grant read access to other principals.
   "toolDefinition": {
     "tool": {
       "name": "weather",
@@ -578,6 +578,9 @@ az group delete --name <resourceGroupName> --yes
 
 - **Network Security**  
   Restrict incoming traffic within the virtual network and configure Private Endpoints for enhanced network security.
+
+- **Service-to-Service Authentication**  
+  The Tool Gateway requires a shared secret (`GatewaySettings:Secret`) to accept forwarded identity headers from the MCP Gateway. In production, generate a strong random value and supply it to both the `mcpgateway` and `toolgateway` pods via the `GatewaySettings__Secret` environment variable or a Kubernetes secret. Requests without a valid `X-Gateway-Secret` header are rejected with `401 Unauthorized`.
 
 - **Telemetry**  
   Enable advanced telemetry, detailed metrics, and alerts to support monitoring and troubleshooting in production.

--- a/deployment/k8s/cloud-deployment-template.yml
+++ b/deployment/k8s/cloud-deployment-template.yml
@@ -173,3 +173,55 @@ spec:
     - protocol: TCP
       port: 8000
       targetPort: 8000
+---
+# NetworkPolicy: Default deny all ingress to adapter namespace
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: adapter
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+# NetworkPolicy: Allow external traffic to mcpgateway service
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-mcpgateway-ingress
+  namespace: adapter
+spec:
+  podSelector:
+    matchLabels:
+      app: mcpgateway
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: 8000
+---
+# NetworkPolicy: Only mcpgateway and toolgateway can reach adapter/tool pods
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: adapter-access
+  namespace: adapter
+spec:
+  podSelector:
+    matchLabels:
+      adapter/type: mcp
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: mcpgateway
+        - podSelector:
+            matchLabels:
+              app: toolgateway
+      ports:
+        - protocol: TCP
+          port: 8000

--- a/deployment/k8s/cloud-deployment-template.yml
+++ b/deployment/k8s/cloud-deployment-template.yml
@@ -185,7 +185,7 @@ spec:
   policyTypes:
     - Ingress
 ---
-# NetworkPolicy: Allow external traffic to mcpgateway service
+# NetworkPolicy: Allow unrestricted ingress to mcpgateway on port 8000
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/deployment/k8s/cloud-deployment-template.yml
+++ b/deployment/k8s/cloud-deployment-template.yml
@@ -3,6 +3,15 @@ kind: Namespace
 metadata:
   name: adapter
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gateway-secret
+  namespace: adapter
+type: Opaque
+stringData:
+  gatewaySecret: "${GATEWAY_SECRET}"
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -28,6 +37,11 @@ spec:
           env:
             - name: ASPNETCORE_ENVIRONMENT
               value: "Production"
+            - name: GatewaySettings__Secret
+              valueFrom:
+                secretKeyRef:
+                  name: gateway-secret
+                  key: gatewaySecret
           resources:
             requests:
               memory: "256Mi"
@@ -149,6 +163,11 @@ spec:
           env:
             - name: ASPNETCORE_ENVIRONMENT
               value: "Production"
+            - name: GatewaySettings__Secret
+              valueFrom:
+                secretKeyRef:
+                  name: gateway-secret
+                  key: gatewaySecret
           resources:
             requests:
               memory: "256Mi"

--- a/deployment/k8s/local-deployment.yml
+++ b/deployment/k8s/local-deployment.yml
@@ -10,7 +10,9 @@ metadata:
   namespace: adapter
 type: Opaque
 stringData:
+  # Local development only. Override with your own value if needed.
   password: localdev-redis-pass
+  connectionString: "redis-service:6379,password=localdev-redis-pass"
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -37,13 +39,11 @@ spec:
           env:
             - name: ASPNETCORE_ENVIRONMENT
               value: "Development"
-            - name: REDIS_PASSWORD
+            - name: Redis__ConnectionString
               valueFrom:
                 secretKeyRef:
                   name: redis-secret
-                  key: password
-            - name: Redis__ConnectionString
-              value: "redis-service:6379,password=$(REDIS_PASSWORD)"
+                  key: connectionString
 ---
 apiVersion: v1
 kind: Service
@@ -127,13 +127,11 @@ spec:
           env:
             - name: ASPNETCORE_ENVIRONMENT
               value: "Development"
-            - name: REDIS_PASSWORD
+            - name: Redis__ConnectionString
               valueFrom:
                 secretKeyRef:
                   name: redis-secret
-                  key: password
-            - name: Redis__ConnectionString
-              value: "redis-service:6379,password=$(REDIS_PASSWORD)"
+                  key: connectionString
 ---
 apiVersion: v1
 kind: Service

--- a/deployment/k8s/local-deployment.yml
+++ b/deployment/k8s/local-deployment.yml
@@ -3,6 +3,15 @@ kind: Namespace
 metadata:
   name: adapter
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redis-secret
+  namespace: adapter
+type: Opaque
+stringData:
+  password: localdev-redis-pass
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -22,11 +31,19 @@ spec:
       containers:
         - name: mcpgateway-container
           image: localhost:5000/microsoft-mcpgateway-service:latest
+          imagePullPolicy: Always
           ports:
             - containerPort: 8000
           env:
             - name: ASPNETCORE_ENVIRONMENT
               value: "Development"
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: redis-secret
+                  key: password
+            - name: Redis__ConnectionString
+              value: "redis-service:6379,password=$(REDIS_PASSWORD)"
 ---
 apiVersion: v1
 kind: Service
@@ -104,11 +121,19 @@ spec:
       containers:
         - name: toolgateway-container
           image: localhost:5000/microsoft-mcpgateway-tools:latest
+          imagePullPolicy: Always
           ports:
             - containerPort: 8000
           env:
             - name: ASPNETCORE_ENVIRONMENT
               value: "Development"
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: redis-secret
+                  key: password
+            - name: Redis__ConnectionString
+              value: "redis-service:6379,password=$(REDIS_PASSWORD)"
 ---
 apiVersion: v1
 kind: Service
@@ -156,6 +181,13 @@ spec:
       containers:
         - name: redis
           image: redis:7-alpine
+          command: ["redis-server", "--requirepass", "$(REDIS_PASSWORD)"]
+          env:
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: redis-secret
+                  key: password
           ports:
             - containerPort: 6379
           resources:
@@ -174,6 +206,73 @@ spec:
             exec:
               command:
                 - redis-cli
+                - -a
+                - "$(REDIS_PASSWORD)"
                 - ping
             initialDelaySeconds: 5
             periodSeconds: 5
+---
+# NetworkPolicy: Only mcpgateway and toolgateway can reach Redis
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: redis-access
+  namespace: adapter
+spec:
+  podSelector:
+    matchLabels:
+      app: redis
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: mcpgateway
+        - podSelector:
+            matchLabels:
+              app: toolgateway
+      ports:
+        - protocol: TCP
+          port: 6379
+---
+# NetworkPolicy: Allow traffic to mcpgateway service
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-mcpgateway-ingress
+  namespace: adapter
+spec:
+  podSelector:
+    matchLabels:
+      app: mcpgateway
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: 8000
+---
+# NetworkPolicy: Only mcpgateway and toolgateway can reach adapter/tool pods
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: adapter-access
+  namespace: adapter
+spec:
+  podSelector:
+    matchLabels:
+      adapter/type: mcp
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: mcpgateway
+        - podSelector:
+            matchLabels:
+              app: toolgateway
+      ports:
+        - protocol: TCP
+          port: 8000

--- a/deployment/k8s/local-deployment.yml
+++ b/deployment/k8s/local-deployment.yml
@@ -13,6 +13,7 @@ stringData:
   # Local development only. Override with your own value if needed.
   password: localdev-redis-pass
   connectionString: "redis-service:6379,password=localdev-redis-pass"
+  gatewaySecret: localdev-gateway-secret
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -44,6 +45,11 @@ spec:
                 secretKeyRef:
                   name: redis-secret
                   key: connectionString
+            - name: GatewaySettings__Secret
+              valueFrom:
+                secretKeyRef:
+                  name: redis-secret
+                  key: gatewaySecret
 ---
 apiVersion: v1
 kind: Service
@@ -132,6 +138,11 @@ spec:
                 secretKeyRef:
                   name: redis-secret
                   key: connectionString
+            - name: GatewaySettings__Secret
+              valueFrom:
+                secretKeyRef:
+                  name: redis-secret
+                  key: gatewaySecret
 ---
 apiVersion: v1
 kind: Service

--- a/dotnet/Microsoft.McpGateway.Management/src/Authorization/ForwardedIdentityHeaders.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Authorization/ForwardedIdentityHeaders.cs
@@ -11,5 +11,6 @@ namespace Microsoft.McpGateway.Management.Authorization
         public const string UserId = "X-Mcp-UserId";
         public const string UserName = "X-Mcp-UserName";
         public const string Roles = "X-Mcp-Roles";
+        public const string GatewaySecret = "X-Gateway-Secret";
     }
 }

--- a/dotnet/Microsoft.McpGateway.Management/src/Authorization/SimplePermissionProvider.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Authorization/SimplePermissionProvider.cs
@@ -69,7 +69,7 @@ namespace Microsoft.McpGateway.Management.Authorization
 
             if (resource.RequiredRoles == null || resource.RequiredRoles.Count == 0)
             {
-                return true;
+                return false;
             }
 
             return resource.RequiredRoles.Any(role => roles.Any(userRole => string.Equals(userRole, role, StringComparison.OrdinalIgnoreCase)));

--- a/dotnet/Microsoft.McpGateway.Management/src/Contracts/AdapterData.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Contracts/AdapterData.cs
@@ -23,6 +23,7 @@ namespace Microsoft.McpGateway.Management.Contracts
         /// The name of the image associated with the adapter.
         /// </summary>
         [JsonPropertyOrder(2)]
+        [Required(AllowEmptyStrings = false)]
         [RegularExpression(@"^[a-z0-9]+([._/-][a-z0-9]+)*$", ErrorMessage = "ImageName must be a valid container image path component (lowercase alphanumeric, dots, dashes, slashes; no '..' or leading/trailing special chars).")]
         public required string ImageName { get; set; }
 
@@ -30,6 +31,7 @@ namespace Microsoft.McpGateway.Management.Contracts
         /// The version of the image associated with the adapter.
         /// </summary>
         [JsonPropertyOrder(3)]
+        [Required(AllowEmptyStrings = false)]
         [RegularExpression(@"^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$", ErrorMessage = "ImageVersion must be a valid container image tag.")]
         public required string ImageVersion { get; set; }
 

--- a/dotnet/Microsoft.McpGateway.Management/src/Contracts/AdapterData.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Contracts/AdapterData.cs
@@ -23,12 +23,14 @@ namespace Microsoft.McpGateway.Management.Contracts
         /// The name of the image associated with the adapter.
         /// </summary>
         [JsonPropertyOrder(2)]
+        [RegularExpression(@"^[a-z0-9]+([._/-][a-z0-9]+)*$", ErrorMessage = "ImageName must be a valid container image path component (lowercase alphanumeric, dots, dashes, slashes; no '..' or leading/trailing special chars).")]
         public required string ImageName { get; set; }
 
         /// <summary>
         /// The version of the image associated with the adapter.
         /// </summary>
         [JsonPropertyOrder(3)]
+        [RegularExpression(@"^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$", ErrorMessage = "ImageVersion must be a valid container image tag.")]
         public required string ImageVersion { get; set; }
 
         /// <summary>

--- a/dotnet/Microsoft.McpGateway.Management/src/Deployment/KubernetesAdapterDeploymentManager.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Deployment/KubernetesAdapterDeploymentManager.cs
@@ -238,6 +238,9 @@ namespace Microsoft.McpGateway.Management.Deployment
 
         private static void ValidateImageReference(string imageName, string imageVersion)
         {
+            ArgumentException.ThrowIfNullOrEmpty(imageName);
+            ArgumentException.ThrowIfNullOrEmpty(imageVersion);
+
             if (imageName.Contains("..", StringComparison.Ordinal))
                 throw new ArgumentException("ImageName must not contain path traversal sequences.", nameof(imageName));
 

--- a/dotnet/Microsoft.McpGateway.Management/src/Deployment/KubernetesAdapterDeploymentManager.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Deployment/KubernetesAdapterDeploymentManager.cs
@@ -3,6 +3,7 @@
 
 using System.Net;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using k8s.Autorest;
 using k8s.Models;
 using Microsoft.Extensions.Logging;
@@ -14,6 +15,8 @@ namespace Microsoft.McpGateway.Management.Deployment
     public class KubernetesAdapterDeploymentManager : IAdapterDeploymentManager
     {
         private const string AdapterNamespace = "adapter";
+        private static readonly Regex ValidImageNamePattern = new(@"^[a-z0-9]+([._/-][a-z0-9]+)*$", RegexOptions.Compiled);
+        private static readonly Regex ValidImageVersionPattern = new(@"^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$", RegexOptions.Compiled);
         private readonly IKubeClientWrapper _kubeClient;
         private readonly string _containerRegistryAddress;
         private readonly ILogger<KubernetesAdapterDeploymentManager> _logger;
@@ -29,6 +32,8 @@ namespace Microsoft.McpGateway.Management.Deployment
 
         public async Task CreateDeploymentAsync(AdapterData request, ResourceType resourceType, CancellationToken cancellationToken)
         {
+            ValidateImageReference(request.ImageName, request.ImageVersion);
+
             var labels = new Dictionary<string, string>
             {
                 { $"{AdapterNamespace}/type", resourceType.ToString().ToLowerInvariant() },
@@ -145,6 +150,8 @@ namespace Microsoft.McpGateway.Management.Deployment
 
         public async Task UpdateDeploymentAsync(AdapterData request, ResourceType resourceType, CancellationToken cancellationToken)
         {
+            ValidateImageReference(request.ImageName, request.ImageVersion);
+
             var statefulSet = await _kubeClient.ReadStatefulSetAsync(request.Name, AdapterNamespace, cancellationToken).ConfigureAwait(false);
             
             var patch = new
@@ -227,6 +234,18 @@ namespace Microsoft.McpGateway.Management.Deployment
             using var reader = new StreamReader(logStream);
             var logText = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
             return logText;
+        }
+
+        private static void ValidateImageReference(string imageName, string imageVersion)
+        {
+            if (imageName.Contains("..", StringComparison.Ordinal))
+                throw new ArgumentException("ImageName must not contain path traversal sequences.", nameof(imageName));
+
+            if (!ValidImageNamePattern.IsMatch(imageName))
+                throw new ArgumentException("ImageName contains invalid characters. Only lowercase alphanumeric, dots, dashes, and slashes are allowed.", nameof(imageName));
+
+            if (!ValidImageVersionPattern.IsMatch(imageVersion))
+                throw new ArgumentException("ImageVersion contains invalid characters.", nameof(imageVersion));
         }
     }
 }

--- a/dotnet/Microsoft.McpGateway.Management/test/SimplePermissionProviderTests.cs
+++ b/dotnet/Microsoft.McpGateway.Management/test/SimplePermissionProviderTests.cs
@@ -73,7 +73,7 @@ public class SimplePermissionProviderTests
     }
 
     [TestMethod]
-    public async Task EmptyRequiredRoles_ShouldPermitRead()
+    public async Task EmptyRequiredRoles_ShouldDenyRead()
     {
         var principal = CreatePrincipal("user");
         var adapter = CreatePermission("adapter", "owner");
@@ -81,8 +81,8 @@ public class SimplePermissionProviderTests
         var tool = CreatePermission("tool", "owner");
         tool.RequiredRoles.Clear();
 
-        (await _provider.CheckAccessAsync(principal, adapter, Operation.Read)).Should().BeTrue();
-        (await _provider.CheckAccessAsync(principal, tool, Operation.Read)).Should().BeTrue();
+        (await _provider.CheckAccessAsync(principal, adapter, Operation.Read)).Should().BeFalse();
+        (await _provider.CheckAccessAsync(principal, tool, Operation.Read)).Should().BeFalse();
     }
 
     [TestMethod]

--- a/dotnet/Microsoft.McpGateway.Service/src/HttpProxy.cs
+++ b/dotnet/Microsoft.McpGateway.Service/src/HttpProxy.cs
@@ -13,7 +13,7 @@ namespace Microsoft.McpGateway.Service
         public static HttpRequestMessage CreateProxiedHttpRequest(HttpContext context, Func<Uri, Uri>? targetOverride = null)
         {
             var hasBody = context.Request.ContentLength > 0 ||
-                          string.Equals(context.Request.Headers[HeaderNames.TransferEncoding], "chunked", StringComparison.OrdinalIgnoreCase);
+                          context.Request.ContentLength is null && !HttpMethods.IsGet(context.Request.Method) && !HttpMethods.IsHead(context.Request.Method) && !HttpMethods.IsDelete(context.Request.Method) && !HttpMethods.IsOptions(context.Request.Method);
 
             var requestMessage = new HttpRequestMessage
             {

--- a/dotnet/Microsoft.McpGateway.Service/src/HttpProxy.cs
+++ b/dotnet/Microsoft.McpGateway.Service/src/HttpProxy.cs
@@ -12,11 +12,14 @@ namespace Microsoft.McpGateway.Service
     {
         public static HttpRequestMessage CreateProxiedHttpRequest(HttpContext context, Func<Uri, Uri>? targetOverride = null)
         {
+            var hasBody = context.Request.ContentLength > 0 ||
+                          string.Equals(context.Request.Headers[HeaderNames.TransferEncoding], "chunked", StringComparison.OrdinalIgnoreCase);
+
             var requestMessage = new HttpRequestMessage
             {
                 Method = new HttpMethod(context.Request.Method),
                 RequestUri = targetOverride == null ? new Uri(context.Request.GetEncodedUrl()) : targetOverride(new Uri(context.Request.GetEncodedUrl())),
-                Content = context.Request.ContentLength > 0 ? new StreamContent(context.Request.Body) : null
+                Content = hasBody ? new StreamContent(context.Request.Body) : null
             };
 
             foreach (var header in context.Request.Headers)
@@ -25,17 +28,15 @@ namespace Microsoft.McpGateway.Service
                 if (string.Equals(header.Key, HeaderNames.Authorization, StringComparison.OrdinalIgnoreCase))
                     continue;
 
+                // Skip identity headers entirely - they will be re-injected from the authenticated principal below
+                if (string.Equals(header.Key, ForwardedIdentityHeaders.UserId, StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(header.Key, ForwardedIdentityHeaders.UserName, StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(header.Key, ForwardedIdentityHeaders.Roles, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
                 if (!requestMessage.Headers.TryAddWithoutValidation(header.Key, [.. header.Value]))
                     requestMessage.Content?.Headers.TryAddWithoutValidation(header.Key, [.. header.Value]);
             }
-
-            // Ensure downstream services only receive sanitized identity headers
-            requestMessage.Headers.Remove(ForwardedIdentityHeaders.UserId);
-            requestMessage.Headers.Remove(ForwardedIdentityHeaders.UserName);
-            requestMessage.Headers.Remove(ForwardedIdentityHeaders.Roles);
-            requestMessage.Content?.Headers.Remove(ForwardedIdentityHeaders.UserId);
-            requestMessage.Content?.Headers.Remove(ForwardedIdentityHeaders.UserName);
-            requestMessage.Content?.Headers.Remove(ForwardedIdentityHeaders.Roles);
 
             var principal = context.User;
             if (principal?.Identity?.IsAuthenticated == true)
@@ -55,14 +56,40 @@ namespace Microsoft.McpGateway.Service
             return requestMessage;
         }
 
+        // Response headers that are safe to forward from backend pods to clients.
+        private static readonly HashSet<string> AllowedResponseHeaders = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "Content-Type",
+            "Content-Length",
+            "Content-Encoding",
+            "Content-Language",
+            "Content-Range",
+            "Cache-Control",
+            "ETag",
+            "Last-Modified",
+            "Accept-Ranges",
+            "Vary",
+            "Date",
+            "Retry-After",
+            "X-Request-Id",
+            "X-Correlation-Id",
+            "mcp-session-id",
+        };
+
         public static Task CopyProxiedHttpResponseAsync(HttpContext context, HttpResponseMessage response, CancellationToken cancellationToken)
         {
             context.Response.StatusCode = (int)response.StatusCode;
 
             foreach (var header in response.Headers)
-                context.Response.Headers[header.Key] = header.Value.ToArray();
+            {
+                if (AllowedResponseHeaders.Contains(header.Key))
+                    context.Response.Headers[header.Key] = header.Value.ToArray();
+            }
             foreach (var header in response.Content.Headers)
-                context.Response.Headers[header.Key] = header.Value.ToArray();
+            {
+                if (AllowedResponseHeaders.Contains(header.Key))
+                    context.Response.Headers[header.Key] = header.Value.ToArray();
+            }
 
             context.Response.Headers.Remove(HeaderNames.TransferEncoding);
 

--- a/dotnet/Microsoft.McpGateway.Service/src/HttpProxy.cs
+++ b/dotnet/Microsoft.McpGateway.Service/src/HttpProxy.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Net.Http.Headers;
 using Microsoft.McpGateway.Management.Authorization;
 using Microsoft.McpGateway.Management.Extensions;
@@ -31,7 +32,8 @@ namespace Microsoft.McpGateway.Service
                 // Skip identity headers entirely - they will be re-injected from the authenticated principal below
                 if (string.Equals(header.Key, ForwardedIdentityHeaders.UserId, StringComparison.OrdinalIgnoreCase) ||
                     string.Equals(header.Key, ForwardedIdentityHeaders.UserName, StringComparison.OrdinalIgnoreCase) ||
-                    string.Equals(header.Key, ForwardedIdentityHeaders.Roles, StringComparison.OrdinalIgnoreCase))
+                    string.Equals(header.Key, ForwardedIdentityHeaders.Roles, StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(header.Key, ForwardedIdentityHeaders.GatewaySecret, StringComparison.OrdinalIgnoreCase))
                     continue;
 
                 if (!requestMessage.Headers.TryAddWithoutValidation(header.Key, [.. header.Value]))
@@ -51,6 +53,10 @@ namespace Microsoft.McpGateway.Service
                 if (roles.Count > 0)
                     requestMessage.Headers.TryAddWithoutValidation(ForwardedIdentityHeaders.Roles, string.Join(',', roles));
             }
+
+            var gatewaySecret = context.RequestServices.GetService<IConfiguration>()?.GetValue<string>("GatewaySettings:Secret");
+            if (!string.IsNullOrEmpty(gatewaySecret))
+                requestMessage.Headers.TryAddWithoutValidation(ForwardedIdentityHeaders.GatewaySecret, gatewaySecret);
 
             requestMessage.Headers.TryAddWithoutValidation("Forwarded", $"for={context.Connection.RemoteIpAddress};proto={context.Request.Scheme};host={context.Request.Host.Value}");
             return requestMessage;

--- a/dotnet/Microsoft.McpGateway.Tools/src/Program.cs
+++ b/dotnet/Microsoft.McpGateway.Tools/src/Program.cs
@@ -64,6 +64,7 @@ else
 }
 
 // Register IToolDefinitionProvider using the store
+builder.Services.AddMemoryCache();
 builder.Services.AddSingleton<IToolDefinitionProvider, StorageToolDefinitionProvider>();
 
 // Register tool executor

--- a/dotnet/Microsoft.McpGateway.Tools/src/Program.cs
+++ b/dotnet/Microsoft.McpGateway.Tools/src/Program.cs
@@ -91,6 +91,28 @@ builder.WebHost.ConfigureKestrel(options =>
 
 var app = builder.Build();
 
+var gatewaySecret = app.Configuration.GetValue<string>("GatewaySettings:Secret");
+if (string.IsNullOrEmpty(gatewaySecret) && !app.Environment.IsDevelopment())
+{
+    throw new InvalidOperationException("GatewaySettings:Secret must be configured in non-development environments.");
+}
+
+// Validate the shared gateway secret on every request
+app.Use(async (context, next) =>
+{
+    if (!string.IsNullOrEmpty(gatewaySecret))
+    {
+        if (!context.Request.Headers.TryGetValue(ForwardedIdentityHeaders.GatewaySecret, out var requestSecret) ||
+            !string.Equals(gatewaySecret, requestSecret.ToString(), StringComparison.Ordinal))
+        {
+            context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+            return;
+        }
+    }
+
+    await next().ConfigureAwait(false);
+});
+
 app.Use(async (context, next) =>
 {
     if (context.Request.Headers.TryGetValue(ForwardedIdentityHeaders.UserId, out var forwardedUserId) && !string.IsNullOrWhiteSpace(forwardedUserId))

--- a/dotnet/Microsoft.McpGateway.Tools/src/Services/StorageToolDefinitionProvider.cs
+++ b/dotnet/Microsoft.McpGateway.Tools/src/Services/StorageToolDefinitionProvider.cs
@@ -17,7 +17,7 @@ namespace Microsoft.McpGateway.Tools.Services
     public class StorageToolDefinitionProvider : IToolDefinitionProvider
     {
         private const int CacheExpirationMinutes = 5;
-        private const string ToolResourcesCacheKey = "ToolResources";
+        private static readonly string ToolResourcesCacheKey = $"{typeof(StorageToolDefinitionProvider).FullName}.ToolResources";
 
         private readonly IToolResourceStore _toolResourceStore;
         private readonly IPermissionProvider _permissionProvider;
@@ -76,6 +76,10 @@ namespace Microsoft.McpGateway.Tools.Services
 
                 _logger.LogInformation("Loaded {Count} tool resources from store", toolResources.Count);
                 return await FilterToolDefinitionsAsync(toolResources, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
             }
             catch (Exception ex)
             {

--- a/dotnet/Microsoft.McpGateway.Tools/src/Services/StorageToolDefinitionProvider.cs
+++ b/dotnet/Microsoft.McpGateway.Tools/src/Services/StorageToolDefinitionProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.McpGateway.Management.Authorization;
 using Microsoft.McpGateway.Management.Contracts;
 using Microsoft.McpGateway.Management.Store;
@@ -16,13 +17,14 @@ namespace Microsoft.McpGateway.Tools.Services
     public class StorageToolDefinitionProvider : IToolDefinitionProvider
     {
         private const int CacheExpirationMinutes = 5;
+        private const string ToolResourcesCacheKey = "ToolResources";
 
         private readonly IToolResourceStore _toolResourceStore;
         private readonly IPermissionProvider _permissionProvider;
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly ILogger<StorageToolDefinitionProvider> _logger;
-        private List<ToolResource>? _cachedToolResources;
-        private DateTime _lastLoadTime;
+        private readonly IMemoryCache _cache;
+        private readonly SemaphoreSlim _cacheLock = new(1, 1);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="StorageToolDefinitionProvider"/> class.
@@ -31,16 +33,19 @@ namespace Microsoft.McpGateway.Tools.Services
             IToolResourceStore toolResourceStore,
             IPermissionProvider permissionProvider,
             IHttpContextAccessor httpContextAccessor,
+            IMemoryCache cache,
             ILogger<StorageToolDefinitionProvider> logger)
         {
             ArgumentNullException.ThrowIfNull(toolResourceStore);
             ArgumentNullException.ThrowIfNull(permissionProvider);
             ArgumentNullException.ThrowIfNull(httpContextAccessor);
+            ArgumentNullException.ThrowIfNull(cache);
             ArgumentNullException.ThrowIfNull(logger);
 
             _toolResourceStore = toolResourceStore;
             _permissionProvider = permissionProvider;
             _httpContextAccessor = httpContextAccessor;
+            _cache = cache;
             _logger = logger;
 
             _logger.LogInformation("Storage tool definition provider initialized");
@@ -48,29 +53,38 @@ namespace Microsoft.McpGateway.Tools.Services
 
         public async Task<List<ToolDefinition>> GetToolDefinitionsAsync(CancellationToken cancellationToken = default)
         {
-            var cacheExpiration = TimeSpan.FromMinutes(CacheExpirationMinutes);
-
-            // Simple caching mechanism
-            if (_cachedToolResources != null && DateTime.UtcNow - _lastLoadTime < cacheExpiration)
+            if (_cache.TryGetValue(ToolResourcesCacheKey, out List<ToolResource>? cachedResources) && cachedResources != null)
             {
-                return await FilterToolDefinitionsAsync(_cachedToolResources, cancellationToken).ConfigureAwait(false);
+                return await FilterToolDefinitionsAsync(cachedResources, cancellationToken).ConfigureAwait(false);
             }
 
+            await _cacheLock.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
+                // Double-check after acquiring lock
+                if (_cache.TryGetValue(ToolResourcesCacheKey, out cachedResources) && cachedResources != null)
+                {
+                    return await FilterToolDefinitionsAsync(cachedResources, cancellationToken).ConfigureAwait(false);
+                }
+
                 // Get all tool resources from the store
                 var toolResources = (await _toolResourceStore.ListAsync(cancellationToken).ConfigureAwait(false)).ToList();
 
-                _cachedToolResources = toolResources;
-                _lastLoadTime = DateTime.UtcNow;
+                var cacheOptions = new MemoryCacheEntryOptions()
+                    .SetAbsoluteExpiration(TimeSpan.FromMinutes(CacheExpirationMinutes));
+                _cache.Set(ToolResourcesCacheKey, toolResources, cacheOptions);
 
-                _logger.LogInformation("Loaded {Count} tool resources from store", _cachedToolResources.Count);
+                _logger.LogInformation("Loaded {Count} tool resources from store", toolResources.Count);
                 return await FilterToolDefinitionsAsync(toolResources, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to load tool definitions from store");
                 return [];
+            }
+            finally
+            {
+                _cacheLock.Release();
             }
         }
 

--- a/dotnet/Microsoft.McpGateway.Tools/test/StorageToolDefinitionProviderTests.cs
+++ b/dotnet/Microsoft.McpGateway.Tools/test/StorageToolDefinitionProviderTests.cs
@@ -5,6 +5,7 @@ using System.Security.Claims;
 using System.Text.Json;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Microsoft.McpGateway.Management.Authorization;
 using Microsoft.McpGateway.Management.Contracts;
@@ -44,6 +45,7 @@ namespace Microsoft.McpGateway.Tools.Tests
                 _toolResourceStoreMock.Object,
                 _permissionProviderMock.Object,
                 _httpContextAccessorMock.Object,
+                new MemoryCache(new MemoryCacheOptions()),
                 _loggerMock.Object);
         }
 
@@ -546,6 +548,7 @@ namespace Microsoft.McpGateway.Tools.Tests
                 null!,
                 _permissionProviderMock.Object,
                 _httpContextAccessorMock.Object,
+                new MemoryCache(new MemoryCacheOptions()),
                 _loggerMock.Object);
 
             // Assert
@@ -560,6 +563,7 @@ namespace Microsoft.McpGateway.Tools.Tests
                 _toolResourceStoreMock.Object,
                 _permissionProviderMock.Object,
                 _httpContextAccessorMock.Object,
+                new MemoryCache(new MemoryCacheOptions()),
                 null!);
 
             // Assert
@@ -574,6 +578,7 @@ namespace Microsoft.McpGateway.Tools.Tests
                 _toolResourceStoreMock.Object,
                 null!,
                 _httpContextAccessorMock.Object,
+                new MemoryCache(new MemoryCacheOptions()),
                 _loggerMock.Object);
 
             // Assert
@@ -588,6 +593,7 @@ namespace Microsoft.McpGateway.Tools.Tests
                 _toolResourceStoreMock.Object,
                 _permissionProviderMock.Object,
                 null!,
+                new MemoryCache(new MemoryCacheOptions()),
                 _loggerMock.Object);
 
             // Assert

--- a/dotnet/Microsoft.McpGateway.Tools/test/StorageToolDefinitionProviderTests.cs
+++ b/dotnet/Microsoft.McpGateway.Tools/test/StorageToolDefinitionProviderTests.cs
@@ -601,6 +601,21 @@ namespace Microsoft.McpGateway.Tools.Tests
         }
 
         [TestMethod]
+        public void Constructor_ShouldThrowArgumentNullException_WhenCacheIsNull()
+        {
+            // Act
+            var act = () => new StorageToolDefinitionProvider(
+                _toolResourceStoreMock.Object,
+                _permissionProviderMock.Object,
+                _httpContextAccessorMock.Object,
+                null!,
+                _loggerMock.Object);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>();
+        }
+
+        [TestMethod]
         public async Task GetToolDefinitionsAsync_ShouldReturnMultipleToolsWithDifferentConfigurations()
         {
             // Arrange


### PR DESCRIPTION
Fix MSRC security vulnerabilities, internal ticket for more info.

This pull request introduces several security and reliability improvements across the Kubernetes deployment configuration, the .NET backend, and the tool definition provider. The most significant updates include stricter network policies for Kubernetes deployments, secure handling of Redis credentials, validation of container image references, improved HTTP proxy header handling, and enhanced caching for tool definitions.

**Kubernetes Deployment and Security Enhancements:**

* Added multiple `NetworkPolicy` resources to both `cloud-deployment-template.yml` and `local-deployment.yml` to restrict ingress traffic:
  - Default deny-all policy for the `adapter` namespace.
  - Only allow specific services (`mcpgateway`, `toolgateway`) to access certain pods and Redis.
  - Allow external traffic only to the `mcpgateway` service. [[1]](diffhunk://#diff-1a6715f71185cb188fc84f2c61ef6bf2127542be2f5ba9ffcb648ab5505d2f05R176-R227) [[2]](diffhunk://#diff-a6a5040caa97dd922cfefc658d778541ef2d2a8611dd517961078e4a0b0d6d76R209-R278)

* Introduced a `Secret` for Redis credentials and updated Redis, `mcpgateway`, and `toolgateway` deployments to use this secret for secure password injection and connection string configuration. [[1]](diffhunk://#diff-a6a5040caa97dd922cfefc658d778541ef2d2a8611dd517961078e4a0b0d6d76R6-R14) [[2]](diffhunk://#diff-a6a5040caa97dd922cfefc658d778541ef2d2a8611dd517961078e4a0b0d6d76R34-R46) [[3]](diffhunk://#diff-a6a5040caa97dd922cfefc658d778541ef2d2a8611dd517961078e4a0b0d6d76R124-R136) [[4]](diffhunk://#diff-a6a5040caa97dd922cfefc658d778541ef2d2a8611dd517961078e4a0b0d6d76R184-R190)

**Backend Validation and Security:**

* Enforced validation of container image names and versions in both the API contract (`AdapterData`) and deployment manager using regular expressions to prevent path traversal and invalid image references. [[1]](diffhunk://#diff-d8b20d2faaafd46ea28c99f09c70531da8281111dc15ea03faa5cfe1708a693dR26-R33) [[2]](diffhunk://#diff-d53d903751767e9162063d89dd7aea8e0070b40cbf620093dfec731ef04abbd6R6) [[3]](diffhunk://#diff-d53d903751767e9162063d89dd7aea8e0070b40cbf620093dfec731ef04abbd6R18-R19) [[4]](diffhunk://#diff-d53d903751767e9162063d89dd7aea8e0070b40cbf620093dfec731ef04abbd6R35-R36) [[5]](diffhunk://#diff-d53d903751767e9162063d89dd7aea8e0070b40cbf620093dfec731ef04abbd6R153-R154) [[6]](diffhunk://#diff-d53d903751767e9162063d89dd7aea8e0070b40cbf620093dfec731ef04abbd6R238-R249)

**HTTP Proxy Improvements:**

* Improved the HTTP proxy logic to:
  - Only forward a safe subset of response headers to clients.
  - Exclude identity headers from being proxied, ensuring they are only set from the authenticated principal.
  - Correctly detect when to forward the request body. [[1]](diffhunk://#diff-8429a1276335d5b3df10e4ec2b5ab5ecc3fbe365a28765a9a74eb4fe9d8821fbR15-R22) [[2]](diffhunk://#diff-8429a1276335d5b3df10e4ec2b5ab5ecc3fbe365a28765a9a74eb4fe9d8821fbR31-L39) [[3]](diffhunk://#diff-8429a1276335d5b3df10e4ec2b5ab5ecc3fbe365a28765a9a74eb4fe9d8821fbR59-R92)

**Tool Definition Provider Caching:**

* Replaced the custom in-memory caching logic in `StorageToolDefinitionProvider` with `IMemoryCache` for thread-safe, efficient caching, and updated related tests and dependency injection. [[1]](diffhunk://#diff-bde579677550ab344d0d5628d56a6261f7a9eb35aefae9f4d188c1b4d52f6bc9R67) [[2]](diffhunk://#diff-98c69ee6f6a92647f6d3d08b140cdf93c13157e990c969727d8787d265324536R4) [[3]](diffhunk://#diff-98c69ee6f6a92647f6d3d08b140cdf93c13157e990c969727d8787d265324536R20-R27) [[4]](diffhunk://#diff-98c69ee6f6a92647f6d3d08b140cdf93c13157e990c969727d8787d265324536R36-R88) [[5]](diffhunk://#diff-ea5fa469f9dcb5f947f9f13488043c2ffabc5bb04ad2eaf8068176b03550bc4bR8) [[6]](diffhunk://#diff-ea5fa469f9dcb5f947f9f13488043c2ffabc5bb04ad2eaf8068176b03550bc4bR48)