### PR TITLE
Update Kubernetes local deployment permissions to include 'patch' verb for statefulsets

### DIFF
--- a/deployment/k8s/local-deployment.yml
+++ b/deployment/k8s/local-deployment.yml
@@ -84,7 +84,7 @@ metadata:
 rules:
   - apiGroups: ["apps"]
     resources: ["statefulsets"]
-    verbs: ["get", "list", "create", "update", "delete", "watch"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
   - apiGroups: [""]
     resources: ["services", "pods"]
     verbs: ["get", "list", "create", "update", "delete", "watch"]


### PR DESCRIPTION
Update Kubernetes local deployment permissions to include 'patch' verb for statefulsets