### PR TITLE
feat: add agent and session subsystem (preview)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This project provides:
 - **Tools**: Registered resources with MCP tool definitions that can be dynamically routed via the tool gateway router. Each tool includes metadata about its execution endpoint and input schema.
 - **Tool Gateway Router**: An MCP server that acts as an intelligent router, directing tool execution requests to the appropriate registered tool servers based on tool definitions. Multiple router instances may run behind the gateway for session affinity.
 - **Session-Aware Stateful Routing**: Ensures that all requests with a given `session_id` are consistently routed to the same MCP server instance.
+- **Agents & Sessions (Preview)**: Optional, opt-in resources for running LLM-driven agents on top of registered MCP tools. *Agents* are metadata (system prompt + model + allowed tool list); *Sessions* are individual runs that stream events over Server-Sent Events. Disabled unless `FoundrySettings:Endpoint` is configured.
 
 ## Architecture
 
@@ -138,6 +139,15 @@ flowchart LR
 - `PUT /tools/{name}` — Update a tool deployment and definition.
 - `DELETE /tools/{name}` — Remove a registered tool.
 
+#### Agent and Session Management (Preview, opt-in)
+
+Available only when `FoundrySettings:Endpoint` is configured. See [Agents and Sessions](#agents-and-sessions-preview) below for details.
+
+- `POST /agents`, `GET /agents`, `GET|PUT|DELETE /agents/{name}` — CRUD for agent definitions.
+- `POST /sessions`, `GET /sessions`, `GET|DELETE /sessions/{id}` — CRUD for sessions.
+- `POST /sessions/run` — Start a session and stream events (SSE).
+- `POST /sessions/{id}/messages` — Continue an existing session with a new user message; streams events (SSE).
+
 ### Data Plane – Gateway Routing for MCP Servers
 
 #### Direct MCP Server Access
@@ -186,6 +196,79 @@ The MCP Gateway now supports **tool registration** with dynamic routing capabili
    - The router analyzes the tool call in the request
    - Based on the tool definition, it forwards the execution to the correct registered tool server
    - Results are returned through the router back to the client
+
+### Agents and Sessions (Preview)
+
+> **Preview / single-replica.** This subsystem is opt-in and intended for evaluation and single-pod deployments. Built-in tools execute in-process inside the gateway pod, and per-session state (working directory, disk-quota counters) is local to that pod. Do not enable this in a multi-replica or multi-tenant production deployment without adding an out-of-process sandbox and shared session storage.
+
+The gateway can optionally run LLM-driven *agents* that call registered MCP tools and a small set of built-in tools (`bash`, `read_file`, `write_file`). The feature is **disabled by default** and is only registered when `FoundrySettings:Endpoint` is set in configuration; without it the `/agents` and `/sessions` endpoints return 404 / 503 and the rest of the gateway is unaffected.
+
+#### Enabling
+
+Add a `FoundrySettings` section to `appsettings.json` (or supply via environment variables):
+
+```json
+{
+  "FoundrySettings": {
+    "Endpoint": "https://<your-resource>.cognitiveservices.azure.com/",
+    "DeploymentName": "gpt-4o"
+  }
+}
+```
+
+Authentication uses `DefaultAzureCredential`; grant the gateway's identity (managed identity in AKS, or your local user via `az login`) the *Cognitive Services User* role on the target resource. Tool-emitting models are required for any agent with a non-empty `tools` array — `gpt-4o`-class deployments are recommended.
+
+#### Defining an agent
+
+```http
+POST /agents
+Authorization: Bearer <token>
+Content-Type: application/json
+```
+```json
+{
+  "name": "weather-helper",
+  "model": "gpt-4o",
+  "system": "You answer weather questions concisely.",
+  "tools": ["mcp:weather"],
+  "description": "Demo agent backed by the weather MCP tool."
+}
+```
+
+`tools` entries are either bare built-in names (`bash`, `read`, `write`) or `mcp:<tool-name>` for tools registered via `/tools`.
+
+#### Running a session
+
+```http
+POST /sessions/run
+Authorization: Bearer <token>
+Content-Type: application/json
+Accept: text/event-stream
+```
+```json
+{ "agentName": "weather-helper", "input": "What's the weather in Seattle?" }
+```
+
+The response is a Server-Sent Events stream; each event is `event: <type>\ndata: <json>\n\n`. Event types include `Started`, `ToolCallRequested`, `ToolCallCompleted`, `TokenDelta`, and `Completed`.
+
+To continue an existing session with a follow-up message:
+
+```http
+POST /sessions/{id}/messages
+Content-Type: application/json
+
+{ "input": "And in Portland?" }
+```
+
+#### Built-in tools and limits
+
+When an agent lists `bash` / `read` / `write` in its `tools`, those built-ins run **in the gateway pod** under a per-session working directory. They are guarded by:
+
+- A regex denylist for clearly dangerous shell operations (`sudo`, network egress, mounts, package managers, etc.). This is *defense-in-depth*, not a sandbox.
+- 30s default / 120s max bash timeout; 16 KiB output cap per stream; 256 KiB max file size; 4 MiB total writes per session.
+- Path resolution rejects absolute paths and `..` traversal.
+
+For multi-tenant or production use, replace these with a real per-session sandbox (e.g. ephemeral pod, gVisor, firejail) — see the inline comments in `BuiltinToolExecutor.cs`.
 
 ## Getting Started - Local Deployment
 

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ The MCP Gateway now supports **tool registration** with dynamic routing capabili
 
 > **Preview / single-replica.** This subsystem is opt-in and intended for evaluation and single-pod deployments. Built-in tools execute in-process inside the gateway pod, and per-session state (working directory, disk-quota counters) is local to that pod. Do not enable this in a multi-replica or multi-tenant production deployment without adding an out-of-process sandbox and shared session storage.
 
-The gateway can optionally run LLM-driven *agents* that call registered MCP tools and a small set of built-in tools (`bash`, `read_file`, `write_file`). The feature is **disabled by default** and is only registered when `FoundrySettings:Endpoint` is set in configuration; without it the `/agents` and `/sessions` endpoints return 404 / 503 and the rest of the gateway is unaffected.
+The gateway can optionally run LLM-driven *agents* that call registered MCP tools and a small set of built-in tools (`builtin:bash`, `builtin:read_file`, `builtin:write_file`). The agent CRUD endpoints (`/agents`, `/sessions` GET/DELETE/LIST) are always available, but **streaming session execution** (`POST /sessions/run`, `POST /sessions/{id}/messages`) is only enabled when `FoundrySettings:Endpoint` is configured. Without it, a streaming request fails fast with an `error` SSE event saying that Foundry must be configured.
 
 #### Enabling
 
@@ -235,7 +235,12 @@ Content-Type: application/json
 }
 ```
 
-`tools` entries are either bare built-in names (`bash`, `read`, `write`) or `mcp:<tool-name>` for tools registered via `/tools`.
+`tools` entries are namespaced by prefix:
+- `mcp:<tool-name>` — routes to a tool registered via `/tools`.
+- `agent:<agent-name>` — delegates to another agent (subagent / Task pattern).
+- `builtin:bash`, `builtin:read_file`, `builtin:write_file` — in-process built-ins (see *Built-in tools and limits* below).
+
+Referenced `mcp:` and `agent:` resources are validated at agent create/update time: the call fails if the resource does not exist or the caller lacks read access, so an agent can never reference tools or peer agents the creator could not invoke directly.
 
 #### Running a session
 
@@ -249,7 +254,7 @@ Accept: text/event-stream
 { "agentName": "weather-helper", "input": "What's the weather in Seattle?" }
 ```
 
-The response is a Server-Sent Events stream; each event is `event: <type>\ndata: <json>\n\n`. Event types include `Started`, `ToolCallRequested`, `ToolCallCompleted`, `TokenDelta`, and `Completed`.
+The response is a Server-Sent Events stream; each event is `event: <type>\ndata: <json>\n\n`. Event types include `Started`, `ToolCallStarted`, `ToolCallCompleted`, `TokenDelta`, `Completed`, and `Failed`.
 
 To continue an existing session with a follow-up message:
 
@@ -262,7 +267,7 @@ Content-Type: application/json
 
 #### Built-in tools and limits
 
-When an agent lists `bash` / `read` / `write` in its `tools`, those built-ins run **in the gateway pod** under a per-session working directory. They are guarded by:
+When an agent lists `builtin:bash` / `builtin:read_file` / `builtin:write_file` in its `tools`, those built-ins run **in the gateway pod** under a per-session working directory. They are guarded by:
 
 - A regex denylist for clearly dangerous shell operations (`sudo`, network egress, mounts, package managers, etc.). This is *defense-in-depth*, not a sandbox.
 - 30s default / 120s max bash timeout; 16 KiB output cap per stream; 256 KiB max file size; 4 MiB total writes per session.

--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -17,5 +17,8 @@
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="ModelContextProtocol" Version="0.4.0-preview.3" />
     <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="0.4.0-preview.3" />
+    <PackageVersion Include="Azure.AI.OpenAI" Version="2.1.0" />
+    <PackageVersion Include="Azure.Identity" Version="1.13.1" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.10" />
   </ItemGroup>
 </Project>

--- a/dotnet/Microsoft.McpGateway.Management/src/Contracts/AgentData.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Contracts/AgentData.cs
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.McpGateway.Management.Contracts
+{
+    /// <summary>
+    /// Represents the data for an agent definition. Agents are pure metadata
+    /// (system prompt + model + tool list); unlike adapters/tools they do not
+    /// run as a Kubernetes pod.
+    /// </summary>
+    public class AgentData
+    {
+        /// <summary>
+        /// The name of the agent. Must contain only lowercase letters, numbers, and dashes.
+        /// </summary>
+        [JsonPropertyOrder(1)]
+        [RegularExpression("^[a-z0-9-]+$", ErrorMessage = "Name must contain only lowercase letters, numbers and dashes.")]
+        public required string Name { get; set; }
+
+        /// <summary>
+        /// The model identifier the agent should use (e.g. "claude-opus-4-7", "gpt-4o").
+        /// </summary>
+        [JsonPropertyOrder(2)]
+        [Required(AllowEmptyStrings = false)]
+        public required string Model { get; set; }
+
+        /// <summary>
+        /// The system prompt that defines the agent's behavior.
+        /// </summary>
+        [JsonPropertyOrder(3)]
+        [Required(AllowEmptyStrings = false)]
+        public required string System { get; set; }
+
+        /// <summary>
+        /// Names of tools the agent is allowed to call. Built-in tools use bare
+        /// names (e.g. "bash", "read", "write"); MCP-routed tools use the
+        /// "mcp:&lt;tool-name&gt;" prefix.
+        /// </summary>
+        [JsonPropertyOrder(4)]
+        public IList<string> Tools { get; set; } = [];
+
+        /// <summary>
+        /// Optional skill identifiers (paths under aifd-workspace/) to mount.
+        /// </summary>
+        [JsonPropertyOrder(5)]
+        public IList<string> Skills { get; set; } = [];
+
+        /// <summary>
+        /// A description of the agent.
+        /// </summary>
+        [JsonPropertyOrder(6)]
+        public string Description { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Free-form metadata (owner, domain, tags, ...).
+        /// </summary>
+        [JsonPropertyOrder(7)]
+        public Dictionary<string, string> Metadata { get; set; } = [];
+
+        /// <summary>
+        /// Optional list of roles allowed to access this agent besides the creator and admins.
+        /// </summary>
+        [JsonPropertyOrder(8)]
+        public IList<string> RequiredRoles { get; set; } = [];
+
+        public AgentData(
+            string name,
+            string model,
+            string system,
+            IEnumerable<string>? tools = null,
+            IEnumerable<string>? skills = null,
+            string description = "",
+            Dictionary<string, string>? metadata = null,
+            IEnumerable<string>? requiredRoles = null)
+        {
+            ArgumentException.ThrowIfNullOrEmpty(name);
+            ArgumentException.ThrowIfNullOrEmpty(model);
+            ArgumentException.ThrowIfNullOrEmpty(system);
+
+            Name = name;
+            Model = model;
+            System = system;
+            Tools = tools?.ToList() ?? [];
+            Skills = skills?.ToList() ?? [];
+            Description = description;
+            Metadata = metadata ?? [];
+            RequiredRoles = requiredRoles?.Where(static role => !string.IsNullOrWhiteSpace(role)).Select(static role => role.Trim()).Distinct(StringComparer.OrdinalIgnoreCase).ToList() ?? [];
+        }
+
+        public AgentData() { }
+    }
+}

--- a/dotnet/Microsoft.McpGateway.Management/src/Contracts/AgentData.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Contracts/AgentData.cs
@@ -36,9 +36,14 @@ namespace Microsoft.McpGateway.Management.Contracts
         public required string System { get; set; }
 
         /// <summary>
-        /// Names of tools the agent is allowed to call. Built-in tools use bare
-        /// names (e.g. "bash", "read", "write"); MCP-routed tools use the
-        /// "mcp:&lt;tool-name&gt;" prefix.
+        /// Names of tools the agent is allowed to call. Each entry must be
+        /// prefixed with one of:
+        /// <list type="bullet">
+        ///   <item><description><c>mcp:&lt;tool-name&gt;</c> — a tool registered via <c>/tools</c>.</description></item>
+        ///   <item><description><c>agent:&lt;agent-name&gt;</c> — a peer agent invoked as a subagent.</description></item>
+        ///   <item><description><c>builtin:&lt;name&gt;</c> — in-process built-in (e.g. <c>builtin:bash</c>, <c>builtin:read_file</c>, <c>builtin:write_file</c>).</description></item>
+        /// </list>
+        /// Unprefixed entries are skipped at resolution time.
         /// </summary>
         [JsonPropertyOrder(4)]
         public IList<string> Tools { get; set; } = [];

--- a/dotnet/Microsoft.McpGateway.Management/src/Contracts/AgentResource.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Contracts/AgentResource.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Linq;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.McpGateway.Management.Contracts
+{
+    /// <summary>
+    /// Represents an agent resource with persistence metadata.
+    /// </summary>
+    public class AgentResource : AgentData, IManagedResource
+    {
+        [JsonPropertyOrder(-1)]
+        [JsonPropertyName("id")]
+        public required string Id { get; set; }
+
+        /// <summary>
+        /// The ID of the user who created the agent.
+        /// </summary>
+        [JsonPropertyOrder(30)]
+        public required string CreatedBy { get; set; }
+
+        /// <summary>
+        /// The date and time when the agent was created.
+        /// </summary>
+        [JsonPropertyOrder(31)]
+        public DateTimeOffset CreatedAt { get; set; }
+
+        /// <summary>
+        /// The date and time when the agent was last updated.
+        /// </summary>
+        [JsonPropertyOrder(32)]
+        public DateTimeOffset LastUpdatedAt { get; set; }
+
+        public static AgentResource Create(AgentData data, string createdBy, DateTimeOffset createdAt) =>
+            new()
+            {
+                Id = data.Name,
+                Name = data.Name,
+                Model = data.Model,
+                System = data.System,
+                Tools = data.Tools?.ToList() ?? [],
+                Skills = data.Skills?.ToList() ?? [],
+                Description = data.Description,
+                Metadata = data.Metadata ?? [],
+                RequiredRoles = data.RequiredRoles?.ToList() ?? [],
+                CreatedBy = createdBy,
+                CreatedAt = createdAt,
+                LastUpdatedAt = DateTimeOffset.UtcNow,
+            };
+
+        public AgentResource() { }
+    }
+}

--- a/dotnet/Microsoft.McpGateway.Management/src/Contracts/SessionData.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Contracts/SessionData.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.McpGateway.Management.Contracts
+{
+    /// <summary>
+    /// Represents the data submitted by a caller to start a session against an agent.
+    /// </summary>
+    public class SessionData
+    {
+        /// <summary>
+        /// The name of the agent definition to execute.
+        /// </summary>
+        [JsonPropertyOrder(1)]
+        [Required(AllowEmptyStrings = false)]
+        [RegularExpression("^[a-z0-9-]+$", ErrorMessage = "AgentName must contain only lowercase letters, numbers and dashes.")]
+        public required string AgentName { get; set; }
+
+        /// <summary>
+        /// The initial user task / prompt for this session.
+        /// </summary>
+        [JsonPropertyOrder(2)]
+        [Required(AllowEmptyStrings = false)]
+        public required string Input { get; set; }
+
+        /// <summary>
+        /// Optional human-readable title for the session.
+        /// </summary>
+        [JsonPropertyOrder(3)]
+        public string Title { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Optional list of roles allowed to access this session besides the creator and admins.
+        /// </summary>
+        [JsonPropertyOrder(4)]
+        public IList<string> RequiredRoles { get; set; } = [];
+
+        public SessionData(
+            string agentName,
+            string input,
+            string title = "",
+            IEnumerable<string>? requiredRoles = null)
+        {
+            ArgumentException.ThrowIfNullOrEmpty(agentName);
+            ArgumentException.ThrowIfNullOrEmpty(input);
+
+            AgentName = agentName;
+            Input = input;
+            Title = title;
+            RequiredRoles = requiredRoles?.Where(static role => !string.IsNullOrWhiteSpace(role)).Select(static role => role.Trim()).Distinct(StringComparer.OrdinalIgnoreCase).ToList() ?? [];
+        }
+
+        public SessionData() { }
+    }
+}

--- a/dotnet/Microsoft.McpGateway.Management/src/Contracts/SessionMessage.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Contracts/SessionMessage.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.McpGateway.Management.Contracts
+{
+    /// <summary>
+    /// One message in a session's conversation history. Provider-agnostic
+    /// (does not depend on OpenAI types) so it survives round-trip through
+    /// Cosmos and any future model swap.
+    /// </summary>
+    public class SessionMessage
+    {
+        [JsonPropertyName("role")]
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        public SessionMessageRole Role { get; set; }
+
+        [JsonPropertyName("content")]
+        public string Content { get; set; } = string.Empty;
+
+        /// <summary>For Tool messages: id of the tool_call this message answers.</summary>
+        [JsonPropertyName("toolCallId")]
+        public string? ToolCallId { get; set; }
+
+        /// <summary>For Tool messages: name of the tool that produced this content.</summary>
+        [JsonPropertyName("toolName")]
+        public string? ToolName { get; set; }
+    }
+
+    public enum SessionMessageRole
+    {
+        System,
+        User,
+        Assistant,
+        Tool,
+    }
+}

--- a/dotnet/Microsoft.McpGateway.Management/src/Contracts/SessionResource.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Contracts/SessionResource.cs
@@ -1,0 +1,102 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Linq;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.McpGateway.Management.Contracts
+{
+    /// <summary>
+    /// Represents a session: one execution of an agent definition.
+    /// The agent definition is snapshotted at create time so that later edits
+    /// to the agent do not affect in-flight or replayed sessions.
+    /// </summary>
+    public class SessionResource : SessionData, IManagedResource
+    {
+        [JsonPropertyOrder(-1)]
+        [JsonPropertyName("id")]
+        public required string Id { get; set; }
+
+        /// <summary>
+        /// Resource identifier exposed to <see cref="IManagedResource"/> consumers
+        /// (permission checks, logging). Sessions identify themselves by their Id.
+        /// </summary>
+        [JsonIgnore]
+        string IManagedResource.Name => Id;
+
+        /// <summary>
+        /// Snapshot of the agent definition at the moment the session was created.
+        /// </summary>
+        [JsonPropertyOrder(10)]
+        public required AgentResource AgentSnapshot { get; set; }
+
+        /// <summary>
+        /// Current lifecycle state.
+        /// </summary>
+        [JsonPropertyOrder(11)]
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        public SessionStatus Status { get; set; } = SessionStatus.Pending;
+
+        /// <summary>
+        /// Optional final result text (set when status reaches Completed).
+        /// </summary>
+        [JsonPropertyOrder(12)]
+        public string? Result { get; set; }
+
+        /// <summary>
+        /// Optional error message (set when status reaches Failed).
+        /// </summary>
+        [JsonPropertyOrder(13)]
+        public string? Error { get; set; }
+
+        /// <summary>
+        /// Conversation history accumulated by the agent loop. Append-only.
+        /// Used by future multi-turn endpoints to continue this session.
+        /// </summary>
+        [JsonPropertyOrder(14)]
+        public List<SessionMessage> Messages { get; set; } = new();
+
+        /// <summary>
+        /// Per-session working directory for built-in tools (bash / read_file /
+        /// write_file). Reserved hook so future sandbox can swap underlying
+        /// storage without changing tool callsites. May be null until
+        /// built-in tools are introduced.
+        /// </summary>
+        [JsonPropertyOrder(15)]
+        public string? WorkingDirectory { get; set; }
+
+        /// <summary>
+        /// Id of the parent session that spawned this one (subagent /
+        /// invoke-agent pattern). Null for top-level sessions.
+        /// </summary>
+        [JsonPropertyOrder(16)]
+        public string? ParentSessionId { get; set; }
+
+        [JsonPropertyOrder(30)]
+        public required string CreatedBy { get; set; }
+
+        [JsonPropertyOrder(31)]
+        public DateTimeOffset CreatedAt { get; set; }
+
+        [JsonPropertyOrder(32)]
+        public DateTimeOffset LastUpdatedAt { get; set; }
+
+        public static SessionResource Create(SessionData data, AgentResource agentSnapshot, string createdBy, DateTimeOffset createdAt) =>
+            new()
+            {
+                Id = $"sess-{Guid.NewGuid():N}",
+                AgentName = data.AgentName,
+                Input = data.Input,
+                Title = string.IsNullOrWhiteSpace(data.Title) ? data.AgentName : data.Title,
+                RequiredRoles = data.RequiredRoles?.ToList() ?? [],
+                AgentSnapshot = agentSnapshot,
+                Status = SessionStatus.Pending,
+                Messages = new List<SessionMessage>(),
+                CreatedBy = createdBy,
+                CreatedAt = createdAt,
+                LastUpdatedAt = DateTimeOffset.UtcNow,
+            };
+
+        public SessionResource() { }
+    }
+}

--- a/dotnet/Microsoft.McpGateway.Management/src/Contracts/SessionStatus.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Contracts/SessionStatus.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.McpGateway.Management.Contracts
+{
+    /// <summary>
+    /// Lifecycle state of a session.
+    /// </summary>
+    public enum SessionStatus
+    {
+        Pending = 0,
+        Running = 1,
+        /// <summary>Reserved: agent paused waiting for human / external input. Not yet emitted.</summary>
+        Idle = 2,
+        Completed = 3,
+        Failed = 4,
+        Terminated = 5,
+        /// <summary>Caller cancelled the run before it completed. Reserved; not yet emitted.</summary>
+        Cancelled = 6,
+        /// <summary>Run is paused waiting on a tool/user response. Reserved; not yet emitted.</summary>
+        AwaitingInput = 7,
+    }
+}

--- a/dotnet/Microsoft.McpGateway.Management/src/Foundry/AgentRunner.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Foundry/AgentRunner.cs
@@ -1,0 +1,378 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.McpGateway.Management.Contracts;
+using OpenAI.Chat;
+
+namespace Microsoft.McpGateway.Management.Foundry
+{
+    /// <summary>
+    /// Runs an agent loop: send messages → if assistant requests tool calls,
+    /// execute them and append results, then loop. Stops when the assistant
+    /// returns a plain text response or when <see cref="MaxIterations"/> is hit.
+    /// </summary>
+    public class AgentRunner
+    {
+        public const int MaxIterations = 10;
+
+        private readonly IFoundryChatClient _chat;
+        private readonly AgentToolRegistry _toolRegistry;
+        private readonly ILogger<AgentRunner> _logger;
+
+        public AgentRunner(
+            IFoundryChatClient chat,
+            AgentToolRegistry toolRegistry,
+            ILogger<AgentRunner> logger)
+        {
+            _chat = chat ?? throw new ArgumentNullException(nameof(chat));
+            _toolRegistry = toolRegistry ?? throw new ArgumentNullException(nameof(toolRegistry));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        /// <summary>
+        /// Run the agent loop and return only the assistant's final text response.
+        /// Used by callers that don't care about intermediate events.
+        /// </summary>
+        public async Task<string> RunAsync(AgentResource agent, string userInput, CancellationToken cancellationToken)
+        {
+            string answer = string.Empty;
+            await foreach (var evt in RunStreamingAsync(agent, userInput, sessionId: string.Empty, parentSessionId: null, history: null, workingDirectory: null, cancellationToken).ConfigureAwait(false))
+            {
+                if (evt.Type == SessionEventType.Completed)
+                {
+                    answer = evt.Answer ?? string.Empty;
+                }
+                else if (evt.Type == SessionEventType.Failed)
+                {
+                    throw new InvalidOperationException(evt.Error ?? "Agent run failed.");
+                }
+            }
+            return answer;
+        }
+
+        /// <summary>
+        /// Run the agent loop and yield each step as a <see cref="SessionEvent"/>.
+        /// The sequence is always: Started → (ToolCallStarted, ToolCallCompleted)* → (Completed | Failed).
+        /// </summary>
+        /// <param name="history">
+        /// Optional caller-owned message log. When supplied, the runner appends
+        /// the user input, intermediate assistant/tool messages, and the final
+        /// assistant reply so the caller can persist them for multi-turn
+        /// continuation. When null, no history is recorded.
+        /// </param>
+        /// <param name="priorHistory">
+        /// Optional prior history to seed the conversation when continuing an
+        /// existing session. Only User and Assistant messages are replayed
+        /// verbatim; Tool messages are dropped because OpenAI requires each
+        /// Tool message be paired with the originating Assistant tool_call,
+        /// which is not part of our provider-agnostic <see cref="SessionMessage"/>.
+        /// </param>
+        public async IAsyncEnumerable<SessionEvent> RunStreamingAsync(
+            AgentResource agent,
+            string userInput,
+            string sessionId,
+            string? parentSessionId,
+            IList<SessionMessage>? history,
+            string? workingDirectory,
+            [EnumeratorCancellation] CancellationToken cancellationToken,
+            IReadOnlyList<SessionMessage>? priorHistory = null)
+        {
+            ArgumentNullException.ThrowIfNull(agent);
+
+            yield return new SessionEvent { Type = SessionEventType.Started, SessionId = sessionId, ParentSessionId = parentSessionId };
+
+            IReadOnlyList<ResolvedTool> resolvedTools;
+            List<ChatTool> chatTools;
+            List<ChatMessage> messages;
+            string? prepError = null;
+            try
+            {
+                resolvedTools = await _toolRegistry.ResolveAsync(agent.Tools, cancellationToken).ConfigureAwait(false);
+                chatTools = AgentToolRegistry.BuildChatTools(resolvedTools);
+                messages = new List<ChatMessage> { new SystemChatMessage(agent.System) };
+                if (priorHistory != null)
+                {
+                    foreach (var prev in priorHistory)
+                    {
+                        switch (prev.Role)
+                        {
+                            case SessionMessageRole.User:
+                                messages.Add(new UserChatMessage(prev.Content));
+                                break;
+                            case SessionMessageRole.Assistant:
+                                if (!string.IsNullOrEmpty(prev.Content))
+                                {
+                                    messages.Add(new AssistantChatMessage(prev.Content));
+                                }
+                                break;
+                            // Tool / System messages are intentionally skipped on replay.
+                        }
+                    }
+                }
+                messages.Add(new UserChatMessage(userInput));
+                history?.Add(new SessionMessage { Role = SessionMessageRole.User, Content = userInput });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to prepare agent run for session {sid}.", sessionId);
+                prepError = ex.Message;
+                resolvedTools = Array.Empty<ResolvedTool>();
+                chatTools = new List<ChatTool>();
+                messages = new List<ChatMessage>();
+            }
+
+            if (prepError != null)
+            {
+                yield return new SessionEvent { Type = SessionEventType.Failed, SessionId = sessionId, ParentSessionId = parentSessionId, Error = prepError };
+                yield break;
+            }
+
+            for (var iteration = 0; iteration < MaxIterations; iteration++)
+            {
+                // Streaming accumulation: collect content text + reassemble
+                // tool-call fragments. The OpenAI streaming API yields content
+                // tokens and tool-call argument fragments interleaved; we
+                // surface content as TokenDelta events live and dispatch any
+                // tool calls only after the stream finishes.
+                var contentBuffer = new System.Text.StringBuilder();
+                var toolCallAcc = new SortedDictionary<int, AccumulatedToolCall>();
+                OpenAI.Chat.ChatFinishReason? finishReason = null;
+                string? completionError = null;
+
+                IAsyncEnumerator<StreamingChatCompletionUpdate>? enumerator = null;
+                try
+                {
+                    enumerator = _chat.CompleteStreamingAsync(messages, chatTools, agent.Model, cancellationToken).GetAsyncEnumerator(cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to start chat stream at iteration {iter} for session {sid}.", iteration, sessionId);
+                    completionError = ex.Message;
+                }
+
+                if (enumerator != null)
+                {
+                    try
+                    {
+                        while (true)
+                        {
+                            bool hasNext;
+                            StreamingChatCompletionUpdate? update = null;
+                            try
+                            {
+                                hasNext = await enumerator.MoveNextAsync().ConfigureAwait(false);
+                                if (hasNext) update = enumerator.Current;
+                            }
+                            catch (Exception ex)
+                            {
+                                _logger.LogError(ex, "Chat stream error at iteration {iter} for session {sid}.", iteration, sessionId);
+                                completionError = ex.Message;
+                                break;
+                            }
+                            if (!hasNext || update == null) break;
+
+                            // Collect deltas from this update outside try so the yield works
+                            // below; defensively guard accessor exceptions on each property.
+                            string? deltaThisUpdate = null;
+                            try
+                            {
+                                if (update.ContentUpdate != null && update.ContentUpdate.Count > 0)
+                                {
+                                    var sb = new System.Text.StringBuilder();
+                                    foreach (var part in update.ContentUpdate)
+                                    {
+                                        var t = part?.Text;
+                                        if (!string.IsNullOrEmpty(t)) sb.Append(t);
+                                    }
+                                    if (sb.Length > 0)
+                                    {
+                                        deltaThisUpdate = sb.ToString();
+                                        contentBuffer.Append(deltaThisUpdate);
+                                    }
+                                }
+                                if (update.ToolCallUpdates != null && update.ToolCallUpdates.Count > 0)
+                                {
+                                    foreach (var tu in update.ToolCallUpdates)
+                                    {
+                                        if (!toolCallAcc.TryGetValue(tu.Index, out var acc))
+                                        {
+                                            acc = new AccumulatedToolCall();
+                                            toolCallAcc[tu.Index] = acc;
+                                        }
+                                        if (!string.IsNullOrEmpty(tu.ToolCallId)) acc.Id = tu.ToolCallId;
+                                        if (!string.IsNullOrEmpty(tu.FunctionName)) acc.Name = tu.FunctionName;
+                                        if (tu.FunctionArgumentsUpdate != null && tu.FunctionArgumentsUpdate.ToMemory().Length > 0)
+                                        {
+                                            var frag = tu.FunctionArgumentsUpdate.ToString();
+                                            if (!string.IsNullOrEmpty(frag)) acc.Arguments.Append(frag);
+                                        }
+                                    }
+                                }
+                                if (update.FinishReason.HasValue) finishReason = update.FinishReason;
+                            }
+                            catch (Exception ex)
+                            {
+                                _logger.LogError(ex, "Failed processing stream update at iteration {iter} for session {sid}.", iteration, sessionId);
+                                completionError = ex.Message;
+                                break;
+                            }
+
+                            if (deltaThisUpdate != null)
+                            {
+                                yield return new SessionEvent
+                                {
+                                    Type = SessionEventType.TokenDelta,
+                                    SessionId = sessionId,
+                                    ParentSessionId = parentSessionId,
+                                    Iteration = iteration,
+                                    DeltaText = deltaThisUpdate,
+                                };
+                            }
+                        }
+                    }
+                    finally
+                    {
+                        await enumerator.DisposeAsync().ConfigureAwait(false);
+                    }
+                }
+
+                if (completionError != null)
+                {
+                    yield return new SessionEvent { Type = SessionEventType.Failed, SessionId = sessionId, ParentSessionId = parentSessionId, Iteration = iteration, Error = completionError };
+                    yield break;
+                }
+
+                _logger.LogInformation("Iteration {iter}: finishReason={reason} toolCalls={count} contentChars={chars}",
+                    iteration, finishReason, toolCallAcc.Count, contentBuffer.Length);
+
+                if (toolCallAcc.Count > 0)
+                {
+                    // Build tool-call list first; OpenAI SDK requires the
+                    // assistant message to be constructed with at least one
+                    // tool call (or non-empty content) so we cannot start with
+                    // an empty list and append later.
+                    var toolCalls = new List<ChatToolCall>();
+                    foreach (var kv in toolCallAcc)
+                    {
+                        var acc = kv.Value;
+                        if (string.IsNullOrEmpty(acc.Id) || string.IsNullOrEmpty(acc.Name))
+                        {
+                            _logger.LogWarning("Discarding malformed tool call at index {idx} (id='{id}' name='{name}').", kv.Key, acc.Id, acc.Name);
+                            continue;
+                        }
+                        toolCalls.Add(ChatToolCall.CreateFunctionToolCall(acc.Id, acc.Name, BinaryData.FromString(acc.Arguments.Length == 0 ? "{}" : acc.Arguments.ToString())));
+                    }
+                    if (toolCalls.Count == 0)
+                    {
+                        // Streaming reported tool-call updates but none had a complete
+                        // id+name pair. Treat as malformed completion and retry.
+                        _logger.LogWarning("All streamed tool calls were malformed; retrying iteration {iter}.", iteration);
+                        continue;
+                    }
+                    var assistantMsg = new AssistantChatMessage(toolCalls);
+                    var contentText = contentBuffer.ToString();
+                    if (!string.IsNullOrEmpty(contentText))
+                    {
+                        assistantMsg.Content.Add(ChatMessageContentPart.CreateTextPart(contentText));
+                    }
+                    messages.Add(assistantMsg);
+
+                    foreach (var call in assistantMsg.ToolCalls)
+                    {
+                        var arguments = call.FunctionArguments?.ToString() ?? "{}";
+                        yield return new SessionEvent
+                        {
+                            Type = SessionEventType.ToolCallStarted,
+                            SessionId = sessionId,
+                            ParentSessionId = parentSessionId,
+                            Iteration = iteration,
+                            ToolCallId = call.Id,
+                            ToolName = call.FunctionName,
+                            Arguments = arguments,
+                        };
+
+                        var resolved = resolvedTools.FirstOrDefault(t => string.Equals(t.Name, call.FunctionName, StringComparison.Ordinal));
+                        ToolResult toolResult;
+                        if (resolved == null)
+                        {
+                            toolResult = new ToolResult(
+                                JsonSerializer.Serialize(new { error = $"Unknown tool '{call.FunctionName}'." }),
+                                IsError: true);
+                        }
+                        else
+                        {
+                            try
+                            {
+                                toolResult = await _toolRegistry.ExecuteAsync(resolved, arguments, sessionId, workingDirectory, cancellationToken).ConfigureAwait(false);
+                            }
+                            catch (Exception ex)
+                            {
+                                _logger.LogError(ex, "Tool {tool} threw during execution.", call.FunctionName);
+                                toolResult = new ToolResult(
+                                    JsonSerializer.Serialize(new { error = ex.Message }),
+                                    IsError: true);
+                            }
+                        }
+                        messages.Add(new ToolChatMessage(call.Id, toolResult.Content));
+                        history?.Add(new SessionMessage
+                        {
+                            Role = SessionMessageRole.Tool,
+                            Content = toolResult.Content,
+                            ToolCallId = call.Id,
+                            ToolName = call.FunctionName,
+                        });
+
+                        yield return new SessionEvent
+                        {
+                            Type = SessionEventType.ToolCallCompleted,
+                            SessionId = sessionId,
+                            ParentSessionId = parentSessionId,
+                            Iteration = iteration,
+                            ToolCallId = call.Id,
+                            ToolName = call.FunctionName,
+                            Result = toolResult.Content,
+                            Error = toolResult.IsError ? toolResult.Content : null,
+                        };
+                    }
+                    continue;
+                }
+
+                var text = contentBuffer.ToString();
+                history?.Add(new SessionMessage
+                {
+                    Role = SessionMessageRole.Assistant,
+                    Content = text,
+                });
+                yield return new SessionEvent
+                {
+                    Type = SessionEventType.Completed,
+                    SessionId = sessionId,
+                    ParentSessionId = parentSessionId,
+                    Iteration = iteration,
+                    Answer = text,
+                };
+                yield break;
+            }
+
+            _logger.LogWarning("Agent loop hit MaxIterations={max} for session {sid}.", MaxIterations, sessionId);
+            yield return new SessionEvent
+            {
+                Type = SessionEventType.Failed,
+                SessionId = sessionId,
+                ParentSessionId = parentSessionId,
+                Error = $"Agent stopped after {MaxIterations} iterations without producing a final answer.",
+            };
+        }
+
+        // Per-iteration accumulator for streaming tool-call fragments.
+        private sealed class AccumulatedToolCall
+        {
+            public string? Id { get; set; }
+            public string? Name { get; set; }
+            public System.Text.StringBuilder Arguments { get; } = new();
+        }
+    }
+}

--- a/dotnet/Microsoft.McpGateway.Management/src/Foundry/AgentToolRegistry.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Foundry/AgentToolRegistry.cs
@@ -19,7 +19,8 @@ namespace Microsoft.McpGateway.Management.Foundry
         // Tool names in AgentData are namespaced by prefix:
         //   "mcp:<name>"     → routed to an MCP tool pod
         //   "agent:<name>"   → spawn a child session against a peer agent (subagent / Task pattern)
-        //   "builtin:<name>" → reserved for in-process built-ins (bash/read/write); not yet implemented
+        //   "builtin:<name>" → in-process built-ins implemented by BuiltinToolExecutor
+        //                      (currently bash / read_file / write_file)
         // Unknown / unprefixed names are skipped with a log entry.
         private const string McpPrefix = "mcp:";
         private const string AgentPrefix = "agent:";

--- a/dotnet/Microsoft.McpGateway.Management/src/Foundry/AgentToolRegistry.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Foundry/AgentToolRegistry.cs
@@ -1,0 +1,290 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.McpGateway.Management.Contracts;
+using Microsoft.McpGateway.Management.Store;
+
+namespace Microsoft.McpGateway.Management.Foundry
+{
+    /// <summary>
+    /// Resolves an agent's declared tool list against the resource stores
+    /// (MCP tools, peer agents) and executes invocations either by HTTP
+    /// (MCP) or by spawning a child session (subagent).
+    /// </summary>
+    public class AgentToolRegistry
+    {
+        // Tool names in AgentData are namespaced by prefix:
+        //   "mcp:<name>"     → routed to an MCP tool pod
+        //   "agent:<name>"   → spawn a child session against a peer agent (subagent / Task pattern)
+        //   "builtin:<name>" → reserved for in-process built-ins (bash/read/write); not yet implemented
+        // Unknown / unprefixed names are skipped with a log entry.
+        private const string McpPrefix = "mcp:";
+        private const string AgentPrefix = "agent:";
+        private const string BuiltinPrefix = "builtin:";
+
+        // OpenAI function names cannot contain ':' so we munge "agent:foo" →
+        // "agent_foo" for the LLM-facing schema. Keep the prefix obvious so
+        // the model knows it's invoking another agent, not a regular tool.
+        private const string SubAgentFunctionPrefix = "agent_";
+
+        private readonly IToolResourceStore _toolStore;
+        private readonly IAgentResourceStore _agentStore;
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly SubAgentInvoker? _subAgentInvoker;
+        private readonly BuiltinToolExecutor? _builtinExecutor;
+        private readonly ILogger<AgentToolRegistry> _logger;
+
+        public AgentToolRegistry(
+            IToolResourceStore toolStore,
+            IAgentResourceStore agentStore,
+            IHttpClientFactory httpClientFactory,
+            ILogger<AgentToolRegistry> logger,
+            SubAgentInvoker? subAgentInvoker = null,
+            BuiltinToolExecutor? builtinExecutor = null)
+        {
+            _toolStore = toolStore ?? throw new ArgumentNullException(nameof(toolStore));
+            _agentStore = agentStore ?? throw new ArgumentNullException(nameof(agentStore));
+            _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _subAgentInvoker = subAgentInvoker;
+            _builtinExecutor = builtinExecutor;
+        }
+
+        /// <summary>
+        /// Resolve the agent's declared tool list. Returns successfully resolved
+        /// tools; logs and skips any that are missing or use an unsupported prefix.
+        /// </summary>
+        public async Task<IReadOnlyList<ResolvedTool>> ResolveAsync(IEnumerable<string> toolNames, CancellationToken cancellationToken)
+        {
+            var resolved = new List<ResolvedTool>();
+            foreach (var raw in toolNames ?? Enumerable.Empty<string>())
+            {
+                if (string.IsNullOrWhiteSpace(raw))
+                {
+                    continue;
+                }
+                if (raw.StartsWith(McpPrefix, StringComparison.OrdinalIgnoreCase))
+                {
+                    var toolName = raw[McpPrefix.Length..];
+                    var resource = await _toolStore.TryGetAsync(toolName, cancellationToken).ConfigureAwait(false);
+                    if (resource?.ToolDefinition?.Tool == null)
+                    {
+                        _logger.LogWarning("MCP tool '{tool}' declared by agent but not found in store; skipping.", toolName);
+                        continue;
+                    }
+                    resolved.Add(new McpResolvedTool(toolName, resource));
+                    continue;
+                }
+                if (raw.StartsWith(AgentPrefix, StringComparison.OrdinalIgnoreCase))
+                {
+                    if (_subAgentInvoker == null)
+                    {
+                        _logger.LogWarning("Tool '{tool}' requires SubAgentInvoker but none is registered; skipping.", raw);
+                        continue;
+                    }
+                    var agentName = raw[AgentPrefix.Length..];
+                    var agent = await _agentStore.TryGetAsync(agentName, cancellationToken).ConfigureAwait(false);
+                    if (agent == null)
+                    {
+                        _logger.LogWarning("Subagent '{agent}' declared by parent but not found in store; skipping.", agentName);
+                        continue;
+                    }
+                    resolved.Add(new SubAgentResolvedTool(SubAgentFunctionPrefix + Sanitize(agentName), agent));
+                    continue;
+                }
+                if (raw.StartsWith(BuiltinPrefix, StringComparison.OrdinalIgnoreCase))
+                {
+                    if (_builtinExecutor == null)
+                    {
+                        _logger.LogWarning("Tool '{tool}' requires BuiltinToolExecutor but none is registered; skipping.", raw);
+                        continue;
+                    }
+                    var name = raw[BuiltinPrefix.Length..];
+                    var fn = "builtin_" + name;
+                    if (!BuiltinToolExecutor.SupportedKinds.Contains(fn, StringComparer.Ordinal))
+                    {
+                        _logger.LogWarning("Unknown builtin tool '{tool}'; supported: {kinds}.", raw, string.Join(",", BuiltinToolExecutor.SupportedKinds));
+                        continue;
+                    }
+                    resolved.Add(new BuiltinResolvedTool(fn));
+                    continue;
+                }
+                _logger.LogInformation("Skipping unprefixed tool '{tool}' (expected one of mcp:/agent:/builtin:).", raw);
+            }
+            return resolved;
+        }
+
+        /// <summary>
+        /// Execute a tool call. Always returns a <see cref="ToolResult"/>
+        /// (never throws for HTTP/agent failures) so the agent loop can feed
+        /// errors back to the model for self-correction.
+        /// </summary>
+        /// <param name="parentSessionId">
+        /// Session id of the agent making the call. Used to set
+        /// <c>ParentSessionId</c> on any spawned subagent session and to
+        /// inherit auth context for the child run.
+        /// </param>
+        public async Task<ToolResult> ExecuteAsync(ResolvedTool tool, string argumentsJson, string parentSessionId, string? workingDirectory, CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(tool);
+            return tool switch
+            {
+                McpResolvedTool mcp => await ExecuteMcpAsync(mcp, argumentsJson, cancellationToken).ConfigureAwait(false),
+                SubAgentResolvedTool sub => await ExecuteSubAgentAsync(sub, argumentsJson, parentSessionId, cancellationToken).ConfigureAwait(false),
+                BuiltinResolvedTool builtin => await ExecuteBuiltinAsync(builtin, argumentsJson, workingDirectory, cancellationToken).ConfigureAwait(false),
+                _ => new ToolResult(JsonSerializer.Serialize(new { error = $"Unsupported tool kind '{tool.GetType().Name}'." }), IsError: true),
+            };
+        }
+
+        private Task<ToolResult> ExecuteBuiltinAsync(BuiltinResolvedTool tool, string argumentsJson, string? workingDirectory, CancellationToken cancellationToken)
+        {
+            if (_builtinExecutor == null)
+            {
+                return Task.FromResult(new ToolResult("{\"error\":\"BuiltinToolExecutor is not registered.\"}", IsError: true));
+            }
+            if (string.IsNullOrWhiteSpace(workingDirectory))
+            {
+                return Task.FromResult(new ToolResult("{\"error\":\"Built-in tools require a session WorkingDirectory.\"}", IsError: true));
+            }
+            return _builtinExecutor.ExecuteAsync(tool.Name, argumentsJson, workingDirectory, cancellationToken);
+        }
+
+        private async Task<ToolResult> ExecuteMcpAsync(McpResolvedTool tool, string argumentsJson, CancellationToken cancellationToken)
+        {
+            var def = tool.Resource.ToolDefinition;
+            // Same convention as HttpToolExecutor: the tool's pod is reachable
+            // via cluster DNS in the "adapter" namespace.
+            var endpoint = $"http://{tool.Name}-service.adapter.svc.cluster.local:{def.Port}{def.Path}";
+
+            _logger.LogInformation("Calling MCP tool {tool} at {endpoint} (args {len} bytes)", tool.Name, endpoint, argumentsJson?.Length ?? 0);
+
+            using var client = _httpClientFactory.CreateClient();
+            client.Timeout = TimeSpan.FromSeconds(60);
+            using var content = new StringContent(argumentsJson ?? "{}", Encoding.UTF8, "application/json");
+            using var response = await client.PostAsync(endpoint, content, cancellationToken).ConfigureAwait(false);
+            var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("MCP tool {tool} returned {code}: {body}", tool.Name, (int)response.StatusCode, body);
+                return new ToolResult(
+                    JsonSerializer.Serialize(new { error = $"HTTP {(int)response.StatusCode}", detail = body }),
+                    IsError: true);
+            }
+            return new ToolResult(body, IsError: false);
+        }
+
+        private async Task<ToolResult> ExecuteSubAgentAsync(SubAgentResolvedTool tool, string argumentsJson, string parentSessionId, CancellationToken cancellationToken)
+        {
+            if (_subAgentInvoker == null)
+            {
+                return new ToolResult("{\"error\":\"SubAgentInvoker is not registered.\"}", IsError: true);
+            }
+            string input;
+            try
+            {
+                using var doc = JsonDocument.Parse(string.IsNullOrWhiteSpace(argumentsJson) ? "{}" : argumentsJson);
+                if (!doc.RootElement.TryGetProperty("input", out var inputProp) || inputProp.ValueKind != JsonValueKind.String)
+                {
+                    return new ToolResult(
+                        JsonSerializer.Serialize(new { error = "Subagent call requires an 'input' string argument." }),
+                        IsError: true);
+                }
+                input = inputProp.GetString() ?? string.Empty;
+            }
+            catch (JsonException ex)
+            {
+                return new ToolResult(
+                    JsonSerializer.Serialize(new { error = $"Invalid JSON arguments: {ex.Message}" }),
+                    IsError: true);
+            }
+
+            _logger.LogInformation("Invoking subagent {agent} from parent session {parent} (input {len} chars)",
+                tool.Agent.Name, parentSessionId, input.Length);
+            return await _subAgentInvoker.InvokeAsync(tool.Agent, input, parentSessionId, cancellationToken).ConfigureAwait(false);
+        }
+
+        private static string Sanitize(string agentName)
+        {
+            // Function names allowed by OpenAI: ^[a-zA-Z0-9_-]{1,64}$
+            // Agent names already match ^[a-z0-9-]+$, so just pass through.
+            return agentName;
+        }
+
+        /// <summary>
+        /// Build OpenAI function-tool descriptors for all resolved tools so the
+        /// model can invoke them.
+        /// </summary>
+        public static List<global::OpenAI.Chat.ChatTool> BuildChatTools(IReadOnlyList<ResolvedTool> resolved)
+        {
+            var list = new List<global::OpenAI.Chat.ChatTool>();
+            foreach (var tool in resolved)
+            {
+                switch (tool)
+                {
+                    case McpResolvedTool mcp:
+                        {
+                            var def = mcp.Resource.ToolDefinition.Tool;
+                            BinaryData schema;
+                            try
+                            {
+                                schema = BinaryData.FromString(JsonSerializer.Serialize(def.InputSchema));
+                            }
+                            catch
+                            {
+                                schema = BinaryData.FromString("{\"type\":\"object\",\"properties\":{}}");
+                            }
+                            list.Add(global::OpenAI.Chat.ChatTool.CreateFunctionTool(
+                                functionName: mcp.Name,
+                                functionDescription: def.Description ?? string.Empty,
+                                functionParameters: schema));
+                            break;
+                        }
+                    case SubAgentResolvedTool sub:
+                        {
+                            var description = string.IsNullOrWhiteSpace(sub.Agent.Description)
+                                ? $"Delegate a task to the '{sub.Agent.Name}' agent."
+                                : sub.Agent.Description;
+                            var schema = BinaryData.FromString("{\"type\":\"object\",\"properties\":{\"input\":{\"type\":\"string\",\"description\":\"Task or question to delegate.\"}},\"required\":[\"input\"]}");
+                            list.Add(global::OpenAI.Chat.ChatTool.CreateFunctionTool(
+                                functionName: sub.Name,
+                                functionDescription: description,
+                                functionParameters: schema));
+                            break;
+                        }
+                    case BuiltinResolvedTool builtin:
+                        {
+                            list.Add(BuiltinToolExecutor.BuildChatTool(builtin.Name));
+                            break;
+                        }
+                }
+            }
+            return list;
+        }
+    }
+
+    /// <summary>
+    /// Discriminated base for any tool the agent loop can call.
+    /// <see cref="Name"/> is the LLM-facing function name.
+    /// </summary>
+    public abstract record ResolvedTool(string Name);
+
+    public sealed record McpResolvedTool(string Name, ToolResource Resource) : ResolvedTool(Name);
+
+    public sealed record SubAgentResolvedTool(string Name, AgentResource Agent) : ResolvedTool(Name);
+
+    /// <summary>
+    /// In-process built-in tool (bash / read_file / write_file). <see cref="Name"/>
+    /// matches one of <see cref="BuiltinToolExecutor.SupportedKinds"/>.
+    /// </summary>
+    public sealed record BuiltinResolvedTool(string Name) : ResolvedTool(Name);
+
+    /// <summary>
+    /// Outcome of a single tool invocation. <see cref="Content"/> is fed back
+    /// to the model verbatim; <see cref="IsError"/> lets the agent loop and
+    /// observers distinguish success from failure without parsing the body.
+    /// </summary>
+    public record ToolResult(string Content, bool IsError);
+}

--- a/dotnet/Microsoft.McpGateway.Management/src/Foundry/BuiltinToolExecutor.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Foundry/BuiltinToolExecutor.cs
@@ -1,0 +1,338 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.McpGateway.Management.Foundry
+{
+    /// <summary>
+    /// Built-in agent tools that run in-process inside the gateway pod.
+    /// All file operations are confined to a per-session
+    /// <c>workingDirectory</c>; bash commands inherit that as cwd.
+    /// P2 will add command allowlist + cgroup-style isolation.
+    /// </summary>
+    public class BuiltinToolExecutor
+    {
+        public const string Bash = "builtin_bash";
+        public const string ReadFile = "builtin_read_file";
+        public const string WriteFile = "builtin_write_file";
+
+        public static readonly IReadOnlyList<string> SupportedKinds = new[] { Bash, ReadFile, WriteFile };
+
+        private const int DefaultBashTimeoutSeconds = 30;
+        private const int MaxBashTimeoutSeconds = 120;
+        private const int MaxOutputBytes = 16 * 1024; // 16 KiB per stream
+        private const int MaxFileBytes = 256 * 1024;  // 256 KiB read/write cap
+        private const long DefaultSessionDiskQuotaBytes = 4 * 1024 * 1024; // 4 MiB total writes per session
+
+        // Bash command denylist. Matched against the raw command string
+        // case-insensitively as whole words. Intentionally narrow (block clear
+        // foot-guns / lateral-movement) rather than allowlist (which would
+        // make the tool useless for legitimate dev work).
+        // P3+ should replace this with a real sandbox (gVisor / firejail /
+        // pod-per-session) and demote this to defense-in-depth.
+        private static readonly Regex DenyPattern = new(
+            pattern: @"\b(?:sudo|su|mount|umount|kill|pkill|killall|reboot|shutdown|halt|poweroff|init|systemctl|service|iptables|nft|nftables|ip6tables|ufw|firewall-cmd|chroot|insmod|rmmod|modprobe|sysctl|dd|mkfs(?:\.\w+)?|fdisk|parted|crontab|at|chage|useradd|userdel|usermod|groupadd|passwd|visudo|setcap|setfacl|chown|chmod\s+[0-7]*[2367]?7+|nc|ncat|netcat|socat|nmap|ssh|scp|sftp|rsync|telnet|ftp|tftp|curl|wget|aria2c|http(?:ie)?)\b|/etc/(?:passwd|shadow|sudoers|hosts)|/proc/(?:sys|kcore|self/mem)|/sys/(?:kernel|class)|\$\(.*?(?:curl|wget|nc|sh|bash|eval|exec).*?\)|`.*?(?:curl|wget|nc|sh|bash|eval|exec).*?`|>\s*/dev/(?!null|stdout|stderr)|rm\s+-[a-zA-Z]*r[a-zA-Z]*f?\s+/(?!tmp)",
+            options: RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        // Tracks bytes written per session for soft disk-quota enforcement.
+        // In-process (not durable across restarts); fine for single-replica
+        // gateway and as best-effort backstop in front of pod ephemeral disk.
+        private readonly ConcurrentDictionary<string, long> _sessionBytesWritten = new();
+
+        private readonly ILogger<BuiltinToolExecutor> _logger;
+
+        public BuiltinToolExecutor(ILogger<BuiltinToolExecutor> logger)
+        {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public Task<ToolResult> ExecuteAsync(string kind, string argumentsJson, string workingDirectory, CancellationToken cancellationToken)
+        {
+            EnsureWorkingDirectory(workingDirectory);
+            using var doc = ParseArgs(argumentsJson, out var parseError);
+            if (parseError != null)
+            {
+                return Task.FromResult(Error(parseError));
+            }
+            var root = doc!.RootElement;
+            return kind switch
+            {
+                Bash => RunBashAsync(root, workingDirectory, cancellationToken),
+                ReadFile => Task.FromResult(RunReadFile(root, workingDirectory)),
+                WriteFile => Task.FromResult(RunWriteFile(root, workingDirectory)),
+                _ => Task.FromResult(Error($"Unknown builtin kind '{kind}'.")),
+            };
+        }
+
+        public static global::OpenAI.Chat.ChatTool BuildChatTool(string kind)
+        {
+            return kind switch
+            {
+                Bash => global::OpenAI.Chat.ChatTool.CreateFunctionTool(
+                    functionName: Bash,
+                    functionDescription: "Run a shell command in the session's working directory. Output is captured (stdout, stderr, exit code).",
+                    functionParameters: BinaryData.FromString("""
+                        {"type":"object","properties":{
+                          "command":{"type":"string","description":"Shell command to execute via /bin/bash -c."},
+                          "timeout_seconds":{"type":"integer","description":"Optional timeout (1-120, default 30)."}
+                        },"required":["command"]}
+                        """)),
+                ReadFile => global::OpenAI.Chat.ChatTool.CreateFunctionTool(
+                    functionName: ReadFile,
+                    functionDescription: "Read a UTF-8 text file relative to the session's working directory.",
+                    functionParameters: BinaryData.FromString("""
+                        {"type":"object","properties":{
+                          "path":{"type":"string","description":"Path relative to the session working directory. Absolute paths and '..' segments are rejected."}
+                        },"required":["path"]}
+                        """)),
+                WriteFile => global::OpenAI.Chat.ChatTool.CreateFunctionTool(
+                    functionName: WriteFile,
+                    functionDescription: "Write (or overwrite) a UTF-8 text file relative to the session's working directory.",
+                    functionParameters: BinaryData.FromString("""
+                        {"type":"object","properties":{
+                          "path":{"type":"string","description":"Path relative to the session working directory."},
+                          "content":{"type":"string","description":"File content (UTF-8)."}
+                        },"required":["path","content"]}
+                        """)),
+                _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, "Unknown builtin tool kind."),
+            };
+        }
+
+        private async Task<ToolResult> RunBashAsync(JsonElement args, string cwd, CancellationToken cancellationToken)
+        {
+            if (!args.TryGetProperty("command", out var cmdProp) || cmdProp.ValueKind != JsonValueKind.String)
+            {
+                return Error("'command' string argument is required.");
+            }
+            var command = cmdProp.GetString() ?? string.Empty;
+            if (string.IsNullOrWhiteSpace(command))
+            {
+                return Error("'command' must be non-empty.");
+            }
+            if (DenyPattern.IsMatch(command))
+            {
+                _logger.LogWarning("Rejected bash command (matched denylist): {cmd}", command.Length > 200 ? command[..200] + "..." : command);
+                return Error("Command rejected by sandbox policy (matched denylist for privileged / network / lateral-movement operations). Stick to local file and computation tasks within the session working directory.");
+            }
+            var timeoutSec = DefaultBashTimeoutSeconds;
+            if (args.TryGetProperty("timeout_seconds", out var toProp) && toProp.ValueKind == JsonValueKind.Number && toProp.TryGetInt32(out var t))
+            {
+                timeoutSec = Math.Clamp(t, 1, MaxBashTimeoutSeconds);
+            }
+
+            var psi = new ProcessStartInfo
+            {
+                FileName = "/bin/bash",
+                ArgumentList = { "-c", command },
+                WorkingDirectory = cwd,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+
+            using var proc = new Process { StartInfo = psi, EnableRaisingEvents = true };
+            var stdoutBuf = new StringBuilder();
+            var stderrBuf = new StringBuilder();
+            proc.OutputDataReceived += (_, e) => Append(stdoutBuf, e.Data);
+            proc.ErrorDataReceived += (_, e) => Append(stderrBuf, e.Data);
+
+            try
+            {
+                proc.Start();
+                proc.BeginOutputReadLine();
+                proc.BeginErrorReadLine();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to start bash process.");
+                return Error($"Failed to start bash: {ex.Message}");
+            }
+
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeoutCts.CancelAfter(TimeSpan.FromSeconds(timeoutSec));
+            bool timedOut = false;
+            try
+            {
+                await proc.WaitForExitAsync(timeoutCts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+                timedOut = true;
+                try { proc.Kill(entireProcessTree: true); } catch { /* best effort */ }
+                try { await proc.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false); } catch { /* ignore */ }
+            }
+
+            var payload = new
+            {
+                exitCode = timedOut ? -1 : proc.ExitCode,
+                timedOut,
+                stdout = stdoutBuf.ToString(),
+                stderr = stderrBuf.ToString(),
+            };
+            var body = JsonSerializer.Serialize(payload);
+            var isError = timedOut || payload.exitCode != 0;
+            _logger.LogInformation("bash exit={code} timedOut={to} stdout={out}B stderr={err}B",
+                payload.exitCode, timedOut, stdoutBuf.Length, stderrBuf.Length);
+            return new ToolResult(body, isError);
+        }
+
+        private ToolResult RunReadFile(JsonElement args, string cwd)
+        {
+            if (!args.TryGetProperty("path", out var pathProp) || pathProp.ValueKind != JsonValueKind.String)
+            {
+                return Error("'path' string argument is required.");
+            }
+            var (full, pathError) = ResolvePath(cwd, pathProp.GetString() ?? string.Empty);
+            if (pathError != null)
+            {
+                return Error(pathError);
+            }
+            if (!File.Exists(full))
+            {
+                return Error($"File not found: {Path.GetRelativePath(cwd, full)}");
+            }
+            try
+            {
+                var info = new FileInfo(full);
+                if (info.Length > MaxFileBytes)
+                {
+                    return Error($"File too large to read ({info.Length} bytes; max {MaxFileBytes}).");
+                }
+                var content = File.ReadAllText(full, Encoding.UTF8);
+                return new ToolResult(JsonSerializer.Serialize(new { path = Path.GetRelativePath(cwd, full), content }), IsError: false);
+            }
+            catch (Exception ex)
+            {
+                return Error($"Read failed: {ex.Message}");
+            }
+        }
+
+        private ToolResult RunWriteFile(JsonElement args, string cwd)
+        {
+            if (!args.TryGetProperty("path", out var pathProp) || pathProp.ValueKind != JsonValueKind.String)
+            {
+                return Error("'path' string argument is required.");
+            }
+            if (!args.TryGetProperty("content", out var contentProp) || contentProp.ValueKind != JsonValueKind.String)
+            {
+                return Error("'content' string argument is required.");
+            }
+            var content = contentProp.GetString() ?? string.Empty;
+            var byteCount = Encoding.UTF8.GetByteCount(content);
+            if (byteCount > MaxFileBytes)
+            {
+                return Error($"Content too large ({byteCount} bytes; max {MaxFileBytes}).");
+            }
+            // Soft disk quota: track total bytes written per session.
+            var quotaKey = cwd;
+            var newTotal = _sessionBytesWritten.AddOrUpdate(quotaKey, byteCount, (_, prev) => prev + byteCount);
+            if (newTotal > DefaultSessionDiskQuotaBytes)
+            {
+                // Roll back the count so a smaller subsequent write can still succeed.
+                _sessionBytesWritten.AddOrUpdate(quotaKey, 0, (_, prev) => Math.Max(0, prev - byteCount));
+                return Error($"Session disk quota exceeded ({newTotal} bytes; max {DefaultSessionDiskQuotaBytes}).");
+            }
+            var (full, pathError) = ResolvePath(cwd, pathProp.GetString() ?? string.Empty);
+            if (pathError != null)
+            {
+                return Error(pathError);
+            }
+            try
+            {
+                var dir = Path.GetDirectoryName(full);
+                if (!string.IsNullOrEmpty(dir))
+                {
+                    Directory.CreateDirectory(dir);
+                }
+                File.WriteAllText(full, content, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+                var info = new FileInfo(full);
+                return new ToolResult(JsonSerializer.Serialize(new { path = Path.GetRelativePath(cwd, full), bytesWritten = info.Length }), IsError: false);
+            }
+            catch (Exception ex)
+            {
+                return Error($"Write failed: {ex.Message}");
+            }
+        }
+
+        private static (string fullPath, string? error) ResolvePath(string cwd, string relative)
+        {
+            if (string.IsNullOrWhiteSpace(relative))
+            {
+                return (string.Empty, "'path' must be non-empty.");
+            }
+            if (Path.IsPathRooted(relative))
+            {
+                return (string.Empty, "Absolute paths are not allowed.");
+            }
+            if (relative.Split('/', '\\').Any(seg => seg == ".."))
+            {
+                return (string.Empty, "Path traversal ('..') is not allowed.");
+            }
+            var combined = Path.GetFullPath(Path.Combine(cwd, relative));
+            var cwdFull = Path.GetFullPath(cwd);
+            if (!combined.StartsWith(cwdFull, StringComparison.Ordinal))
+            {
+                return (string.Empty, "Path escapes the session working directory.");
+            }
+            return (combined, null);
+        }
+
+        private void Append(StringBuilder buf, string? data)
+        {
+            if (data == null) return;
+            lock (buf)
+            {
+                if (buf.Length >= MaxOutputBytes) return;
+                var remaining = MaxOutputBytes - buf.Length;
+                if (data.Length + 1 > remaining)
+                {
+                    buf.Append(data, 0, Math.Min(data.Length, remaining));
+                    if (buf.Length < MaxOutputBytes)
+                    {
+                        buf.Append('\n');
+                    }
+                }
+                else
+                {
+                    buf.AppendLine(data);
+                }
+            }
+        }
+
+        private static void EnsureWorkingDirectory(string workingDirectory)
+        {
+            if (string.IsNullOrWhiteSpace(workingDirectory))
+            {
+                throw new InvalidOperationException("Built-in tools require a session WorkingDirectory.");
+            }
+            if (!Directory.Exists(workingDirectory))
+            {
+                Directory.CreateDirectory(workingDirectory);
+            }
+        }
+
+        private static JsonDocument? ParseArgs(string argumentsJson, out string? error)
+        {
+            error = null;
+            try
+            {
+                return JsonDocument.Parse(string.IsNullOrWhiteSpace(argumentsJson) ? "{}" : argumentsJson);
+            }
+            catch (JsonException ex)
+            {
+                error = $"Invalid JSON arguments: {ex.Message}";
+                return null;
+            }
+        }
+
+        private static ToolResult Error(string message) =>
+            new(JsonSerializer.Serialize(new { error = message }), IsError: true);
+    }
+}

--- a/dotnet/Microsoft.McpGateway.Management/src/Foundry/BuiltinToolExecutor.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Foundry/BuiltinToolExecutor.cs
@@ -230,6 +230,13 @@ namespace Microsoft.McpGateway.Management.Foundry
             {
                 return Error($"Content too large ({byteCount} bytes; max {MaxFileBytes}).");
             }
+            // Validate the path BEFORE charging the quota so a malformed/unsafe
+            // path can't push the running total up and starve subsequent writes.
+            var (full, pathError) = ResolvePath(cwd, pathProp.GetString() ?? string.Empty);
+            if (pathError != null)
+            {
+                return Error(pathError);
+            }
             // Soft disk quota: track total bytes written per session.
             var quotaKey = cwd;
             var newTotal = _sessionBytesWritten.AddOrUpdate(quotaKey, byteCount, (_, prev) => prev + byteCount);
@@ -239,11 +246,7 @@ namespace Microsoft.McpGateway.Management.Foundry
                 _sessionBytesWritten.AddOrUpdate(quotaKey, 0, (_, prev) => Math.Max(0, prev - byteCount));
                 return Error($"Session disk quota exceeded ({newTotal} bytes; max {DefaultSessionDiskQuotaBytes}).");
             }
-            var (full, pathError) = ResolvePath(cwd, pathProp.GetString() ?? string.Empty);
-            if (pathError != null)
-            {
-                return Error(pathError);
-            }
+            bool committed = false;
             try
             {
                 var dir = Path.GetDirectoryName(full);
@@ -252,6 +255,7 @@ namespace Microsoft.McpGateway.Management.Foundry
                     Directory.CreateDirectory(dir);
                 }
                 File.WriteAllText(full, content, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+                committed = true;
                 var info = new FileInfo(full);
                 return new ToolResult(JsonSerializer.Serialize(new { path = Path.GetRelativePath(cwd, full), bytesWritten = info.Length }), IsError: false);
             }
@@ -259,6 +263,30 @@ namespace Microsoft.McpGateway.Management.Foundry
             {
                 return Error($"Write failed: {ex.Message}");
             }
+            finally
+            {
+                // If the write threw before completing, refund the quota so the
+                // failure doesn't permanently consume the session's budget.
+                if (!committed)
+                {
+                    _sessionBytesWritten.AddOrUpdate(quotaKey, 0, (_, prev) => Math.Max(0, prev - byteCount));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Drop any per-session bookkeeping (currently the disk-quota counter)
+        /// for the given working directory. Should be called when the owning
+        /// session is deleted so long-running pods don't accumulate orphaned
+        /// quota entries. Idempotent.
+        /// </summary>
+        public void ReleaseSession(string workingDirectory)
+        {
+            if (string.IsNullOrEmpty(workingDirectory))
+            {
+                return;
+            }
+            _sessionBytesWritten.TryRemove(workingDirectory, out _);
         }
 
         private static (string fullPath, string? error) ResolvePath(string cwd, string relative)

--- a/dotnet/Microsoft.McpGateway.Management/src/Foundry/FoundryChatClient.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Foundry/FoundryChatClient.cs
@@ -1,0 +1,105 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.AI.OpenAI;
+using Azure.Core;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using OpenAI.Chat;
+
+namespace Microsoft.McpGateway.Management.Foundry
+{
+    /// <summary>
+    /// <see cref="IFoundryChatClient"/> implementation using the Azure.AI.OpenAI
+    /// SDK against an AIServices resource. Authentication uses the supplied
+    /// <see cref="TokenCredential"/> (typically <c>DefaultAzureCredential</c> →
+    /// workload identity in cluster).
+    /// </summary>
+    public class FoundryChatClient : IFoundryChatClient
+    {
+        private readonly AzureOpenAIClient _client;
+        private readonly FoundrySettings _settings;
+        private readonly ILogger<FoundryChatClient> _logger;
+
+        public FoundryChatClient(
+            IOptions<FoundrySettings> settings,
+            TokenCredential credential,
+            ILogger<FoundryChatClient> logger)
+        {
+            ArgumentNullException.ThrowIfNull(settings);
+            ArgumentNullException.ThrowIfNull(credential);
+            ArgumentNullException.ThrowIfNull(logger);
+
+            _settings = settings.Value;
+            if (string.IsNullOrWhiteSpace(_settings.Endpoint))
+            {
+                throw new InvalidOperationException("FoundrySettings:Endpoint is not configured.");
+            }
+            if (string.IsNullOrWhiteSpace(_settings.DeploymentName))
+            {
+                throw new InvalidOperationException("FoundrySettings:DeploymentName is not configured.");
+            }
+
+            _client = new AzureOpenAIClient(new Uri(_settings.Endpoint), credential);
+            _logger = logger;
+        }
+
+        public async Task<ChatCompletion> CompleteAsync(
+            IList<ChatMessage> messages,
+            IEnumerable<ChatTool> tools,
+            string? deploymentNameOverride,
+            CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(messages);
+
+            var deployment = string.IsNullOrWhiteSpace(deploymentNameOverride)
+                ? _settings.DeploymentName
+                : deploymentNameOverride;
+
+            var chat = _client.GetChatClient(deployment);
+            var options = new ChatCompletionOptions();
+            if (tools != null)
+            {
+                foreach (var tool in tools)
+                {
+                    options.Tools.Add(tool);
+                }
+            }
+
+            _logger.LogInformation("Foundry chat completion: deployment={deployment} messages={count} tools={tools}", deployment, messages.Count, options.Tools.Count);
+
+            var response = await chat.CompleteChatAsync(messages, options, cancellationToken).ConfigureAwait(false);
+            return response.Value;
+        }
+
+        public async IAsyncEnumerable<StreamingChatCompletionUpdate> CompleteStreamingAsync(
+            IList<ChatMessage> messages,
+            IEnumerable<ChatTool> tools,
+            string? deploymentNameOverride,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(messages);
+
+            var deployment = string.IsNullOrWhiteSpace(deploymentNameOverride)
+                ? _settings.DeploymentName
+                : deploymentNameOverride;
+
+            var chat = _client.GetChatClient(deployment);
+            var options = new ChatCompletionOptions();
+            if (tools != null)
+            {
+                foreach (var tool in tools)
+                {
+                    options.Tools.Add(tool);
+                }
+            }
+
+            _logger.LogInformation("Foundry chat streaming: deployment={deployment} messages={count} tools={tools}", deployment, messages.Count, options.Tools.Count);
+
+            await foreach (var update in chat.CompleteChatStreamingAsync(messages, options, cancellationToken).ConfigureAwait(false))
+            {
+                yield return update;
+            }
+        }
+    }
+}

--- a/dotnet/Microsoft.McpGateway.Management/src/Foundry/FoundrySettings.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Foundry/FoundrySettings.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.McpGateway.Management.Foundry
+{
+    /// <summary>
+    /// Configuration for the Foundry / Azure OpenAI chat client.
+    /// Bound from the "FoundrySettings" section.
+    /// </summary>
+    public class FoundrySettings
+    {
+        /// <summary>
+        /// OpenAI-compatible endpoint of the AIServices resource.
+        /// </summary>
+        public string Endpoint { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Default deployment name to call when an agent does not specify one
+        /// recognized by Foundry. Example: "gpt-5-chat".
+        /// </summary>
+        public string DeploymentName { get; set; } = string.Empty;
+    }
+}

--- a/dotnet/Microsoft.McpGateway.Management/src/Foundry/IFoundryChatClient.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Foundry/IFoundryChatClient.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using OpenAI.Chat;
+
+namespace Microsoft.McpGateway.Management.Foundry
+{
+    /// <summary>
+    /// Thin wrapper around an Azure OpenAI chat deployment used by the agent
+    /// runner. The runner owns message history + the tool loop; this client
+    /// just executes a single completion call (with tools attached).
+    /// </summary>
+    public interface IFoundryChatClient
+    {
+        /// <summary>
+        /// Send the supplied message history (including any prior assistant /
+        /// tool messages) and return the next assistant message. The caller is
+        /// responsible for handling tool calls and re-invoking.
+        /// </summary>
+        Task<ChatCompletion> CompleteAsync(
+            IList<ChatMessage> messages,
+            IEnumerable<ChatTool> tools,
+            string? deploymentNameOverride,
+            CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Streaming variant: yield each <see cref="StreamingChatCompletionUpdate"/>
+        /// from the model as it arrives. Used by the agent loop to surface
+        /// token-level deltas to clients while still accumulating tool-call
+        /// fragments for dispatch when the stream completes.
+        /// </summary>
+        IAsyncEnumerable<StreamingChatCompletionUpdate> CompleteStreamingAsync(
+            IList<ChatMessage> messages,
+            IEnumerable<ChatTool> tools,
+            string? deploymentNameOverride,
+            CancellationToken cancellationToken);
+    }
+}

--- a/dotnet/Microsoft.McpGateway.Management/src/Foundry/SessionEvent.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Foundry/SessionEvent.cs
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.McpGateway.Management.Foundry
+{
+    /// <summary>
+    /// Discriminator for <see cref="SessionEvent"/>. Serialized as the SSE
+    /// <c>event:</c> field and as the <c>type</c> property in the JSON payload.
+    /// </summary>
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public enum SessionEventType
+    {
+        /// <summary>The agent run has begun. Emitted exactly once.</summary>
+        Started,
+        /// <summary>The model issued a tool invocation. Carries tool name + arguments.</summary>
+        ToolCallStarted,
+        /// <summary>A previously started tool call returned. Carries result text.</summary>
+        ToolCallCompleted,
+        /// <summary>The agent produced a final assistant message. Emitted at most once.</summary>
+        Completed,
+        /// <summary>The run terminated with an error. Emitted at most once.</summary>
+        Failed,
+        /// <summary>
+        /// Incremental assistant text token(s). Emitted zero or more times
+        /// before <see cref="Completed"/>; the concatenation of all
+        /// <see cref="SessionEvent.DeltaText"/> values for an iteration
+        /// equals the <see cref="SessionEvent.Answer"/> in <see cref="Completed"/>.
+        /// </summary>
+        TokenDelta,
+    }
+
+    /// <summary>
+    /// One event emitted by <see cref="AgentRunner.RunStreamingAsync"/>.
+    /// Designed to be written as an SSE message: <c>event: {Type}\ndata: {JSON}\n\n</c>.
+    /// </summary>
+    public class SessionEvent
+    {
+        [JsonPropertyName("type")]
+        public required SessionEventType Type { get; set; }
+
+        [JsonPropertyName("sessionId")]
+        public required string SessionId { get; set; }
+
+        /// <summary>
+        /// Id of the parent session that spawned this run (subagent /
+        /// invoke-agent pattern). Null for top-level runs. Reserved hook so
+        /// clients can already begin to render call-trees.
+        /// </summary>
+        [JsonPropertyName("parentSessionId")]
+        public string? ParentSessionId { get; set; }
+
+        /// <summary>Iteration index (0-based) when the event was produced.</summary>
+        [JsonPropertyName("iteration")]
+        public int Iteration { get; set; }
+
+        /// <summary>For ToolCallStarted/ToolCallCompleted.</summary>
+        [JsonPropertyName("toolCallId")]
+        public string? ToolCallId { get; set; }
+
+        /// <summary>For ToolCallStarted/ToolCallCompleted.</summary>
+        [JsonPropertyName("toolName")]
+        public string? ToolName { get; set; }
+
+        /// <summary>For ToolCallStarted: JSON arguments the model passed.</summary>
+        [JsonPropertyName("arguments")]
+        public string? Arguments { get; set; }
+
+        /// <summary>For ToolCallCompleted: tool response body (typically JSON).</summary>
+        [JsonPropertyName("result")]
+        public string? Result { get; set; }
+
+        /// <summary>For Completed: the assistant's final text answer.</summary>
+        [JsonPropertyName("answer")]
+        public string? Answer { get; set; }
+
+        /// <summary>For Failed: human-readable error.</summary>
+        [JsonPropertyName("error")]
+        public string? Error { get; set; }
+
+        /// <summary>
+        /// For TokenDelta: the chunk of assistant text just produced by the
+        /// model. Concatenate all deltas in an iteration to reconstruct the
+        /// final answer.
+        /// </summary>
+        [JsonPropertyName("deltaText")]
+        public string? DeltaText { get; set; }
+    }
+}

--- a/dotnet/Microsoft.McpGateway.Management/src/Foundry/SubAgentInvoker.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Foundry/SubAgentInvoker.cs
@@ -1,0 +1,143 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.McpGateway.Management.Contracts;
+using Microsoft.McpGateway.Management.Store;
+
+namespace Microsoft.McpGateway.Management.Foundry
+{
+    /// <summary>
+    /// Spawns a child session against a peer agent and returns its final answer.
+    /// Used to implement the <c>agent:</c> tool prefix: when a parent agent
+    /// invokes a subagent function, this service drives the child through
+    /// <see cref="AgentRunner"/> and persists it as a normal session with
+    /// <c>ParentSessionId</c> set, so observers can navigate the call tree.
+    /// </summary>
+    public class SubAgentInvoker
+    {
+        // Hard cap on subagent recursion depth to avoid runaway loops where
+        // one agent calls another that calls back. Counted via ParentSessionId
+        // chain length at invocation time.
+        private const int MaxDepth = 3;
+
+        private readonly ISessionResourceStore _sessionStore;
+        private readonly Func<AgentRunner> _runnerFactory;
+        private readonly ILogger<SubAgentInvoker> _logger;
+
+        public SubAgentInvoker(
+            ISessionResourceStore sessionStore,
+            Func<AgentRunner> runnerFactory,
+            ILogger<SubAgentInvoker> logger)
+        {
+            _sessionStore = sessionStore ?? throw new ArgumentNullException(nameof(sessionStore));
+            _runnerFactory = runnerFactory ?? throw new ArgumentNullException(nameof(runnerFactory));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        /// <summary>
+        /// Run <paramref name="childAgent"/> as a fresh session whose
+        /// <c>ParentSessionId</c> points back to <paramref name="parentSessionId"/>.
+        /// Returns a <see cref="ToolResult"/> whose content is the child's
+        /// final answer (or a JSON error blob if the run failed).
+        /// </summary>
+        public async Task<ToolResult> InvokeAsync(
+            AgentResource childAgent,
+            string input,
+            string parentSessionId,
+            CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(childAgent);
+            ArgumentException.ThrowIfNullOrEmpty(input);
+            ArgumentException.ThrowIfNullOrEmpty(parentSessionId);
+
+            // Walk up the parent chain to enforce depth limit.
+            var depth = await ComputeDepthAsync(parentSessionId, cancellationToken).ConfigureAwait(false);
+            if (depth >= MaxDepth)
+            {
+                _logger.LogWarning("Refusing to spawn subagent {agent}: depth {depth} >= {max} from parent {parent}.",
+                    childAgent.Name, depth, MaxDepth, parentSessionId);
+                return new ToolResult(
+                    JsonSerializer.Serialize(new { error = $"Subagent depth limit ({MaxDepth}) reached." }),
+                    IsError: true);
+            }
+
+            // Inherit auth context from the parent so downstream permission
+            // checks (when added) see the same caller.
+            var parent = await _sessionStore.TryGetAsync(parentSessionId, cancellationToken).ConfigureAwait(false);
+            var createdBy = parent?.CreatedBy ?? "subagent";
+
+            var data = new SessionData
+            {
+                AgentName = childAgent.Name,
+                Input = input,
+                Title = $"subagent({childAgent.Name})",
+            };
+            var child = SessionResource.Create(data, childAgent, createdBy, DateTimeOffset.UtcNow);
+            child.ParentSessionId = parentSessionId;
+            child.Status = SessionStatus.Running;
+            // Each subagent gets its own working directory so its file ops are
+            // isolated from the parent's. P2 will tighten with a real sandbox.
+            child.WorkingDirectory = Path.Combine(Path.GetTempPath(), "agent-sessions", child.Id);
+            Directory.CreateDirectory(child.WorkingDirectory);
+            await _sessionStore.UpsertAsync(child, cancellationToken).ConfigureAwait(false);
+
+            _logger.LogInformation("Spawned subagent session {child} for parent {parent} (agent={agent}, depth={depth}).",
+                child.Id, parentSessionId, childAgent.Name, depth);
+
+            string answer = string.Empty;
+            string? error = null;
+            var runner = _runnerFactory();
+            await foreach (var evt in runner.RunStreamingAsync(
+                childAgent,
+                input,
+                child.Id,
+                parentSessionId: parentSessionId,
+                history: child.Messages,
+                workingDirectory: child.WorkingDirectory,
+                cancellationToken).ConfigureAwait(false))
+            {
+                if (evt.Type == SessionEventType.Completed)
+                {
+                    answer = evt.Answer ?? string.Empty;
+                    child.Status = SessionStatus.Completed;
+                    child.Result = answer;
+                }
+                else if (evt.Type == SessionEventType.Failed)
+                {
+                    error = evt.Error;
+                    child.Status = SessionStatus.Failed;
+                    child.Error = error;
+                }
+            }
+            child.LastUpdatedAt = DateTimeOffset.UtcNow;
+            await _sessionStore.UpsertAsync(child, CancellationToken.None).ConfigureAwait(false);
+
+            if (error != null)
+            {
+                return new ToolResult(
+                    JsonSerializer.Serialize(new { error, childSessionId = child.Id }),
+                    IsError: true);
+            }
+            return new ToolResult(answer, IsError: false);
+        }
+
+        private async Task<int> ComputeDepthAsync(string parentSessionId, CancellationToken cancellationToken)
+        {
+            var depth = 0;
+            var cursor = parentSessionId;
+            while (!string.IsNullOrEmpty(cursor) && depth < MaxDepth + 1)
+            {
+                var session = await _sessionStore.TryGetAsync(cursor, cancellationToken).ConfigureAwait(false);
+                if (session?.ParentSessionId == null)
+                {
+                    break;
+                }
+                depth++;
+                cursor = session.ParentSessionId;
+            }
+            return depth;
+        }
+    }
+}

--- a/dotnet/Microsoft.McpGateway.Management/src/Microsoft.McpGateway.Management.csproj
+++ b/dotnet/Microsoft.McpGateway.Management/src/Microsoft.McpGateway.Management.csproj
@@ -14,5 +14,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="ModelContextProtocol" />
     <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="Azure.AI.OpenAI" />
+    <PackageReference Include="Azure.Identity" />
+    <PackageReference Include="Microsoft.Extensions.Http" />
   </ItemGroup>
 </Project>

--- a/dotnet/Microsoft.McpGateway.Management/src/Service/AgentManagementService.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Service/AgentManagementService.cs
@@ -19,16 +19,28 @@ namespace Microsoft.McpGateway.Management.Service
     public class AgentManagementService : IAgentManagementService
     {
         private const string NamePattern = "^[a-z0-9-]+$";
+        // Mirrors Foundry.BuiltinToolExecutor.SupportedKinds ("builtin_<name>")
+        // but expressed as the public, prefixed AgentData.Tools form.
+        private static readonly HashSet<string> KnownBuiltins = new(StringComparer.Ordinal)
+        {
+            "builtin:bash",
+            "builtin:read_file",
+            "builtin:write_file",
+        };
+
         private readonly IAgentResourceStore _store;
+        private readonly IToolResourceStore _toolStore;
         private readonly IPermissionProvider _permissionProvider;
         private readonly ILogger _logger;
 
         public AgentManagementService(
             IAgentResourceStore store,
+            IToolResourceStore toolStore,
             IPermissionProvider permissionProvider,
             ILogger<AgentManagementService> logger)
         {
             _store = store ?? throw new ArgumentNullException(nameof(store));
+            _toolStore = toolStore ?? throw new ArgumentNullException(nameof(toolStore));
             _permissionProvider = permissionProvider ?? throw new ArgumentNullException(nameof(permissionProvider));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
@@ -47,6 +59,8 @@ namespace Microsoft.McpGateway.Management.Service
                 _logger.LogWarning("/agents/{name} already exists.", request.Name.Sanitize());
                 throw new ArgumentException("An agent with the same name already exists.");
             }
+
+            await ValidateToolReferencesAsync(accessContext, request, cancellationToken).ConfigureAwait(false);
 
             var agent = AgentResource.Create(request, accessContext.GetUserId()!, DateTimeOffset.UtcNow);
 
@@ -87,6 +101,8 @@ namespace Microsoft.McpGateway.Management.Service
             {
                 throw new ArgumentException("The agent does not allow change on the submitted field.");
             }
+
+            await ValidateToolReferencesAsync(accessContext, request, cancellationToken).ConfigureAwait(false);
 
             var updated = AgentResource.Create(request, existing.CreatedBy, existing.CreatedAt);
             await _store.UpsertAsync(updated, cancellationToken).ConfigureAwait(false);
@@ -142,6 +158,82 @@ namespace Microsoft.McpGateway.Management.Service
             var operationName = operation.ToString().ToLowerInvariant();
             _logger.LogWarning("User {userId} is denied {operation} access for agent {resourceId}.", accessContext.GetUserId(), operationName, resource.Name.Sanitize());
             throw new UnauthorizedAccessException("You do not have permission to perform the operation.");
+        }
+
+        /// <summary>
+        /// Validate every entry in <see cref="AgentData.Tools"/> at agent
+        /// create/update time so an agent can't be persisted with references
+        /// the caller cannot themselves invoke. Each entry must be one of:
+        /// <list type="bullet">
+        ///   <item><description><c>mcp:&lt;tool-name&gt;</c> — a tool registered via <c>/tools</c> that the caller has read access to.</description></item>
+        ///   <item><description><c>agent:&lt;agent-name&gt;</c> — a peer agent the caller has read access to.</description></item>
+        ///   <item><description><c>builtin:&lt;name&gt;</c> — one of the in-process built-ins (<c>bash</c>, <c>read_file</c>, <c>write_file</c>).</description></item>
+        /// </list>
+        /// Throws <see cref="ArgumentException"/> for unknown / unprefixed
+        /// names and missing references; throws
+        /// <see cref="UnauthorizedAccessException"/> when the caller lacks
+        /// read access on a referenced resource.
+        /// </summary>
+        private async Task ValidateToolReferencesAsync(ClaimsPrincipal accessContext, AgentData request, CancellationToken cancellationToken)
+        {
+            if (request.Tools == null || request.Tools.Count == 0)
+            {
+                return;
+            }
+
+            foreach (var entry in request.Tools)
+            {
+                if (string.IsNullOrWhiteSpace(entry))
+                {
+                    throw new ArgumentException("Tool entries must be non-empty strings.");
+                }
+
+                var colon = entry.IndexOf(':');
+                if (colon <= 0 || colon == entry.Length - 1)
+                {
+                    throw new ArgumentException($"Tool entry '{entry}' is missing a recognized prefix (expected 'mcp:', 'agent:', or 'builtin:').");
+                }
+
+                var prefix = entry.Substring(0, colon);
+                var name = entry.Substring(colon + 1);
+
+                switch (prefix)
+                {
+                    case "mcp":
+                        var tool = await _toolStore.TryGetAsync(name, cancellationToken).ConfigureAwait(false)
+                            ?? throw new ArgumentException($"MCP tool '{name}' referenced by agent does not exist.");
+                        if (!await _permissionProvider.CheckAccessAsync(accessContext, tool, Operation.Read).ConfigureAwait(false))
+                        {
+                            _logger.LogWarning("User {userId} denied read access on tool {tool} while saving agent {agent}.", accessContext.GetUserId(), name.Sanitize(), request.Name.Sanitize());
+                            throw new UnauthorizedAccessException($"You do not have permission to reference tool '{name}'.");
+                        }
+                        break;
+
+                    case "agent":
+                        if (string.Equals(name, request.Name, StringComparison.Ordinal))
+                        {
+                            throw new ArgumentException($"Agent '{request.Name}' cannot reference itself as a subagent.");
+                        }
+                        var peer = await _store.TryGetAsync(name, cancellationToken).ConfigureAwait(false)
+                            ?? throw new ArgumentException($"Peer agent '{name}' referenced by agent does not exist.");
+                        if (!await _permissionProvider.CheckAccessAsync(accessContext, peer, Operation.Read).ConfigureAwait(false))
+                        {
+                            _logger.LogWarning("User {userId} denied read access on peer agent {peer} while saving agent {agent}.", accessContext.GetUserId(), name.Sanitize(), request.Name.Sanitize());
+                            throw new UnauthorizedAccessException($"You do not have permission to reference agent '{name}'.");
+                        }
+                        break;
+
+                    case "builtin":
+                        if (!KnownBuiltins.Contains(entry))
+                        {
+                            throw new ArgumentException($"Unknown built-in tool '{entry}'. Supported: {string.Join(", ", KnownBuiltins)}.");
+                        }
+                        break;
+
+                    default:
+                        throw new ArgumentException($"Tool entry '{entry}' uses an unrecognized prefix '{prefix}:' (expected 'mcp:', 'agent:', or 'builtin:').");
+                }
+            }
         }
     }
 }

--- a/dotnet/Microsoft.McpGateway.Management/src/Service/AgentManagementService.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Service/AgentManagementService.cs
@@ -1,0 +1,147 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Linq;
+using System.Security.Claims;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
+using Microsoft.McpGateway.Management.Authorization;
+using Microsoft.McpGateway.Management.Contracts;
+using Microsoft.McpGateway.Management.Extensions;
+using Microsoft.McpGateway.Management.Store;
+
+namespace Microsoft.McpGateway.Management.Service
+{
+    /// <summary>
+    /// Service for managing agent definitions. Pure metadata CRUD; no
+    /// Kubernetes deployment side-effects.
+    /// </summary>
+    public class AgentManagementService : IAgentManagementService
+    {
+        private const string NamePattern = "^[a-z0-9-]+$";
+        private readonly IAgentResourceStore _store;
+        private readonly IPermissionProvider _permissionProvider;
+        private readonly ILogger _logger;
+
+        public AgentManagementService(
+            IAgentResourceStore store,
+            IPermissionProvider permissionProvider,
+            ILogger<AgentManagementService> logger)
+        {
+            _store = store ?? throw new ArgumentNullException(nameof(store));
+            _permissionProvider = permissionProvider ?? throw new ArgumentNullException(nameof(permissionProvider));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public async Task<AgentResource> CreateAsync(ClaimsPrincipal accessContext, AgentData request, CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(accessContext);
+            ArgumentNullException.ThrowIfNull(request);
+
+            if (!Regex.IsMatch(request.Name, NamePattern))
+                throw new ArgumentException("Name must contain only lowercase letters, numbers, and dashes.");
+
+            var existing = await _store.TryGetAsync(request.Name, cancellationToken).ConfigureAwait(false);
+            if (existing != null)
+            {
+                _logger.LogWarning("/agents/{name} already exists.", request.Name.Sanitize());
+                throw new ArgumentException("An agent with the same name already exists.");
+            }
+
+            var agent = AgentResource.Create(request, accessContext.GetUserId()!, DateTimeOffset.UtcNow);
+
+            _logger.LogInformation("Creating /agents/{name}.", request.Name.Sanitize());
+            await _store.UpsertAsync(agent, cancellationToken).ConfigureAwait(false);
+            return agent;
+        }
+
+        public async Task<AgentResource?> GetAsync(ClaimsPrincipal accessContext, string name, CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(accessContext);
+            ArgumentException.ThrowIfNullOrEmpty(name);
+
+            _logger.LogInformation("Getting /agents/{name}.", name.Sanitize());
+            var agent = await _store.TryGetAsync(name, cancellationToken).ConfigureAwait(false);
+            if (agent == null)
+            {
+                return null;
+            }
+
+            await EnsureAccessAsync(accessContext, agent, Operation.Read).ConfigureAwait(false);
+            return agent;
+        }
+
+        public async Task<AgentResource> UpdateAsync(ClaimsPrincipal accessContext, AgentData request, CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(accessContext);
+            ArgumentNullException.ThrowIfNull(request);
+
+            _logger.LogInformation("Updating /agents/{name}.", request.Name.Sanitize());
+
+            var existing = await _store.TryGetAsync(request.Name, cancellationToken).ConfigureAwait(false)
+                ?? throw new ArgumentException("The agent does not exist and cannot be updated.");
+
+            await EnsureAccessAsync(accessContext, existing, Operation.Write).ConfigureAwait(false);
+
+            if (existing.Name != request.Name)
+            {
+                throw new ArgumentException("The agent does not allow change on the submitted field.");
+            }
+
+            var updated = AgentResource.Create(request, existing.CreatedBy, existing.CreatedAt);
+            await _store.UpsertAsync(updated, cancellationToken).ConfigureAwait(false);
+            return updated;
+        }
+
+        public async Task DeleteAsync(ClaimsPrincipal accessContext, string name, CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(accessContext);
+            ArgumentException.ThrowIfNullOrEmpty(name);
+
+            _logger.LogInformation("Deleting /agents/{name}.", name.Sanitize());
+            var existing = await _store.TryGetAsync(name, cancellationToken).ConfigureAwait(false)
+                ?? throw new ArgumentException("The agent does not exist.");
+
+            await EnsureAccessAsync(accessContext, existing, Operation.Write).ConfigureAwait(false);
+
+            await _store.DeleteAsync(name, cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task<IEnumerable<AgentResource>> ListAsync(ClaimsPrincipal accessContext, CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(accessContext);
+
+            _logger.LogInformation("Listing /agents for user.");
+            var resources = (await _store.ListAsync(cancellationToken).ConfigureAwait(false)).ToList();
+            var allowed = await _permissionProvider.CheckAccessAsync(accessContext, resources, Operation.Read).ConfigureAwait(false);
+
+            var filteredCount = resources.Count - allowed.Length;
+            if (filteredCount > 0)
+            {
+                _logger.LogInformation("Filtered {count} agent resources due to authorization.", filteredCount);
+            }
+
+            return allowed;
+        }
+
+        private async Task EnsureAccessAsync(ClaimsPrincipal accessContext, AgentResource resource, Operation operation)
+        {
+            ArgumentNullException.ThrowIfNull(accessContext);
+            ArgumentNullException.ThrowIfNull(resource);
+
+            if (await _permissionProvider.CheckAccessAsync(accessContext, resource, operation).ConfigureAwait(false))
+            {
+                if (operation == Operation.Write)
+                {
+                    _logger.LogInformation("User {userId} is authorized for write operations on agent {resourceId}.", accessContext.GetUserId(), resource.Name.Sanitize());
+                }
+
+                return;
+            }
+
+            var operationName = operation.ToString().ToLowerInvariant();
+            _logger.LogWarning("User {userId} is denied {operation} access for agent {resourceId}.", accessContext.GetUserId(), operationName, resource.Name.Sanitize());
+            throw new UnauthorizedAccessException("You do not have permission to perform the operation.");
+        }
+    }
+}

--- a/dotnet/Microsoft.McpGateway.Management/src/Service/IAgentManagementService.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Service/IAgentManagementService.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Security.Claims;
+using Microsoft.McpGateway.Management.Contracts;
+
+namespace Microsoft.McpGateway.Management.Service
+{
+    /// <summary>
+    /// Interface for managing agent definitions. Agents are metadata-only;
+    /// no Kubernetes deployment is involved.
+    /// </summary>
+    public interface IAgentManagementService
+    {
+        /// <summary>
+        /// Create a new agent definition.
+        /// </summary>
+        Task<AgentResource> CreateAsync(ClaimsPrincipal accessContext, AgentData request, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Get an agent definition by name.
+        /// </summary>
+        Task<AgentResource?> GetAsync(ClaimsPrincipal accessContext, string name, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Update an existing agent definition.
+        /// </summary>
+        Task<AgentResource> UpdateAsync(ClaimsPrincipal accessContext, AgentData request, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Delete an agent definition.
+        /// </summary>
+        Task DeleteAsync(ClaimsPrincipal accessContext, string name, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// List all agent definitions accessible to the caller.
+        /// </summary>
+        Task<IEnumerable<AgentResource>> ListAsync(ClaimsPrincipal accessContext, CancellationToken cancellationToken);
+    }
+}

--- a/dotnet/Microsoft.McpGateway.Management/src/Service/ISessionManagementService.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Service/ISessionManagementService.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Security.Claims;
+using Microsoft.McpGateway.Management.Contracts;
+using Microsoft.McpGateway.Management.Foundry;
+
+namespace Microsoft.McpGateway.Management.Service
+{
+    /// <summary>
+    /// Interface for managing agent sessions (one execution of an agent definition).
+    /// </summary>
+    public interface ISessionManagementService
+    {
+        /// <summary>
+        /// Create a new session against an existing agent. Snapshots the agent definition.
+        /// The agent loop runs in the background; clients poll <see cref="GetAsync"/> for state.
+        /// </summary>
+        Task<SessionResource> CreateAsync(ClaimsPrincipal accessContext, SessionData request, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Create a session and synchronously stream agent events as they happen.
+        /// The session is persisted before the first event is yielded; the final
+        /// <see cref="SessionEventType.Completed"/> / <see cref="SessionEventType.Failed"/>
+        /// event is also persisted to the store before the enumerable completes.
+        /// </summary>
+        IAsyncEnumerable<SessionEvent> RunStreamingAsync(ClaimsPrincipal accessContext, SessionData request, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Continue an existing session by appending a new user message and
+        /// streaming the agent's response. Replays prior User/Assistant
+        /// messages as conversation context. The new turn's messages are
+        /// appended to the persisted history.
+        /// </summary>
+        IAsyncEnumerable<SessionEvent> ContinueStreamingAsync(ClaimsPrincipal accessContext, string sessionId, string userInput, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Get a session by id.
+        /// </summary>
+        Task<SessionResource?> GetAsync(ClaimsPrincipal accessContext, string id, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Delete a session by id.
+        /// </summary>
+        Task DeleteAsync(ClaimsPrincipal accessContext, string id, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// List all sessions accessible to the caller.
+        /// </summary>
+        Task<IEnumerable<SessionResource>> ListAsync(ClaimsPrincipal accessContext, CancellationToken cancellationToken);
+    }
+}

--- a/dotnet/Microsoft.McpGateway.Management/src/Service/SessionManagementService.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Service/SessionManagementService.cs
@@ -1,0 +1,317 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Security.Claims;
+using Microsoft.Extensions.Logging;
+using Microsoft.McpGateway.Management.Authorization;
+using Microsoft.McpGateway.Management.Contracts;
+using Microsoft.McpGateway.Management.Extensions;
+using Microsoft.McpGateway.Management.Foundry;
+using Microsoft.McpGateway.Management.Store;
+
+namespace Microsoft.McpGateway.Management.Service
+{
+    /// <summary>
+    /// Service for managing sessions. Phase 2: pure metadata + agent snapshot,
+    /// plus an in-process fire-and-forget LLM call that writes the result back
+    /// to the session record. No worker pod, no agent loop, no tools yet.
+    /// </summary>
+    public class SessionManagementService : ISessionManagementService
+    {
+        private readonly ISessionResourceStore _store;
+        private readonly IAgentResourceStore _agentStore;
+        private readonly IPermissionProvider _permissionProvider;
+        private readonly AgentRunner? _agentRunner;
+        private readonly ILogger _logger;
+
+        public SessionManagementService(
+            ISessionResourceStore store,
+            IAgentResourceStore agentStore,
+            IPermissionProvider permissionProvider,
+            ILogger<SessionManagementService> logger,
+            AgentRunner? agentRunner = null)
+        {
+            _store = store ?? throw new ArgumentNullException(nameof(store));
+            _agentStore = agentStore ?? throw new ArgumentNullException(nameof(agentStore));
+            _permissionProvider = permissionProvider ?? throw new ArgumentNullException(nameof(permissionProvider));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _agentRunner = agentRunner;
+        }
+
+        public async Task<SessionResource> CreateAsync(ClaimsPrincipal accessContext, SessionData request, CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(accessContext);
+            ArgumentNullException.ThrowIfNull(request);
+
+            var agent = await _agentStore.TryGetAsync(request.AgentName, cancellationToken).ConfigureAwait(false)
+                ?? throw new ArgumentException($"Agent '{request.AgentName}' does not exist.");
+
+            // Caller must be allowed to read the agent definition before invoking it.
+            if (!await _permissionProvider.CheckAccessAsync(accessContext, agent, Operation.Read).ConfigureAwait(false))
+            {
+                _logger.LogWarning("User {userId} denied read access on agent {agent} when creating a session.", accessContext.GetUserId(), agent.Name.Sanitize());
+                throw new UnauthorizedAccessException("You do not have permission to invoke this agent.");
+            }
+
+            var session = SessionResource.Create(request, agent, accessContext.GetUserId()!, DateTimeOffset.UtcNow);
+
+            _logger.LogInformation("Creating /sessions/{id} for agent {agent}.", session.Id, agent.Name.Sanitize());
+            await _store.UpsertAsync(session, cancellationToken).ConfigureAwait(false);
+
+            // Phase 3: kick off the agent loop (LLM + tool calls) in the
+            // background. Caller polls /sessions/{id} for completion.
+            if (_agentRunner != null)
+            {
+                _ = Task.Run(() => RunSessionAsync(session.Id), CancellationToken.None);
+            }
+            else
+            {
+                _logger.LogWarning("No AgentRunner registered; session {id} will stay in Pending state.", session.Id);
+            }
+
+            return session;
+        }
+
+        /// <summary>
+        /// Background worker for a single session. Runs the agent's system prompt
+        /// against the user's input as a one-shot chat completion. Updates the
+        /// stored session with Status=Completed/Failed and Result/Error.
+        /// </summary>
+        private async Task RunSessionAsync(string sessionId)
+        {
+            try
+            {
+                var session = await _store.TryGetAsync(sessionId, CancellationToken.None).ConfigureAwait(false);
+                if (session == null)
+                {
+                    _logger.LogWarning("Session {id} disappeared before background run could start.", sessionId);
+                    return;
+                }
+
+                session.Status = SessionStatus.Running;
+                session.LastUpdatedAt = DateTimeOffset.UtcNow;
+                await _store.UpsertAsync(session, CancellationToken.None).ConfigureAwait(false);
+
+                var result = await _agentRunner!.RunAsync(
+                    session.AgentSnapshot,
+                    session.Input,
+                    CancellationToken.None).ConfigureAwait(false);
+
+                session.Result = result;
+                session.Status = SessionStatus.Completed;
+                session.LastUpdatedAt = DateTimeOffset.UtcNow;
+                await _store.UpsertAsync(session, CancellationToken.None).ConfigureAwait(false);
+                _logger.LogInformation("Session {id} completed (result {len} chars).", sessionId, result.Length);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Session {id} failed during background run.", sessionId);
+                try
+                {
+                    var session = await _store.TryGetAsync(sessionId, CancellationToken.None).ConfigureAwait(false);
+                    if (session != null)
+                    {
+                        session.Status = SessionStatus.Failed;
+                        session.Error = ex.Message;
+                        session.LastUpdatedAt = DateTimeOffset.UtcNow;
+                        await _store.UpsertAsync(session, CancellationToken.None).ConfigureAwait(false);
+                    }
+                }
+                catch (Exception writeEx)
+                {
+                    _logger.LogError(writeEx, "Failed to persist Failed status for session {id}.", sessionId);
+                }
+            }
+        }
+
+        public async IAsyncEnumerable<SessionEvent> RunStreamingAsync(
+            ClaimsPrincipal accessContext,
+            SessionData request,
+            [EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(accessContext);
+            ArgumentNullException.ThrowIfNull(request);
+            if (_agentRunner == null)
+            {
+                throw new InvalidOperationException("Streaming runs require an AgentRunner. Configure FoundrySettings:Endpoint to enable it.");
+            }
+
+            // Same validation + persistence as CreateAsync, then drive the runner
+            // synchronously so the caller (controller) can stream each event over
+            // SSE. Final state is written back to the store before the enumerable
+            // completes so /sessions/{id} reflects the result for replay.
+            var agent = await _agentStore.TryGetAsync(request.AgentName, cancellationToken).ConfigureAwait(false)
+                ?? throw new ArgumentException($"Agent '{request.AgentName}' does not exist.");
+
+            if (!await _permissionProvider.CheckAccessAsync(accessContext, agent, Operation.Read).ConfigureAwait(false))
+            {
+                _logger.LogWarning("User {userId} denied read access on agent {agent} for streaming run.", accessContext.GetUserId(), agent.Name.Sanitize());
+                throw new UnauthorizedAccessException("You do not have permission to invoke this agent.");
+            }
+
+            var session = SessionResource.Create(request, agent, accessContext.GetUserId()!, DateTimeOffset.UtcNow);
+            session.Status = SessionStatus.Running;
+            session.WorkingDirectory = AllocateWorkingDirectory(session.Id);
+            _logger.LogInformation("Streaming run for /sessions/{id} on agent {agent}.", session.Id, agent.Name.Sanitize());
+            await _store.UpsertAsync(session, cancellationToken).ConfigureAwait(false);
+
+            await foreach (var evt in _agentRunner.RunStreamingAsync(
+                agent,
+                session.Input,
+                session.Id,
+                parentSessionId: session.ParentSessionId,
+                history: session.Messages,
+                workingDirectory: session.WorkingDirectory,
+                cancellationToken).ConfigureAwait(false))
+            {
+                if (evt.Type == SessionEventType.Completed)
+                {
+                    session.Status = SessionStatus.Completed;
+                    session.Result = evt.Answer;
+                    session.LastUpdatedAt = DateTimeOffset.UtcNow;
+                    await _store.UpsertAsync(session, CancellationToken.None).ConfigureAwait(false);
+                }
+                else if (evt.Type == SessionEventType.Failed)
+                {
+                    session.Status = SessionStatus.Failed;
+                    session.Error = evt.Error;
+                    session.LastUpdatedAt = DateTimeOffset.UtcNow;
+                    await _store.UpsertAsync(session, CancellationToken.None).ConfigureAwait(false);
+                }
+                yield return evt;
+            }
+        }
+
+        public async IAsyncEnumerable<SessionEvent> ContinueStreamingAsync(
+            ClaimsPrincipal accessContext,
+            string sessionId,
+            string userInput,
+            [EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(accessContext);
+            ArgumentException.ThrowIfNullOrEmpty(sessionId);
+            ArgumentException.ThrowIfNullOrEmpty(userInput);
+            if (_agentRunner == null)
+            {
+                throw new InvalidOperationException("Streaming runs require an AgentRunner. Configure FoundrySettings:Endpoint to enable it.");
+            }
+
+            var session = await _store.TryGetAsync(sessionId, cancellationToken).ConfigureAwait(false)
+                ?? throw new ArgumentException($"Session '{sessionId}' does not exist.");
+            await EnsureAccessAsync(accessContext, session, Operation.Write).ConfigureAwait(false);
+
+            // Snapshot prior messages BEFORE appending the new user turn so the
+            // runner replays only past history, not the live message it is about
+            // to process.
+            var priorHistory = session.Messages.ToList();
+            session.Status = SessionStatus.Running;
+            session.LastUpdatedAt = DateTimeOffset.UtcNow;
+            await _store.UpsertAsync(session, cancellationToken).ConfigureAwait(false);
+
+            _logger.LogInformation("Continuing /sessions/{id} with new user message ({len} chars, {prior} prior messages).",
+                session.Id, userInput.Length, priorHistory.Count);
+
+            await foreach (var evt in _agentRunner.RunStreamingAsync(
+                session.AgentSnapshot,
+                userInput,
+                session.Id,
+                parentSessionId: session.ParentSessionId,
+                history: session.Messages,
+                workingDirectory: session.WorkingDirectory,
+                cancellationToken,
+                priorHistory: priorHistory).ConfigureAwait(false))
+            {
+                if (evt.Type == SessionEventType.Completed)
+                {
+                    session.Status = SessionStatus.Completed;
+                    session.Result = evt.Answer;
+                    session.LastUpdatedAt = DateTimeOffset.UtcNow;
+                    await _store.UpsertAsync(session, CancellationToken.None).ConfigureAwait(false);
+                }
+                else if (evt.Type == SessionEventType.Failed)
+                {
+                    session.Status = SessionStatus.Failed;
+                    session.Error = evt.Error;
+                    session.LastUpdatedAt = DateTimeOffset.UtcNow;
+                    await _store.UpsertAsync(session, CancellationToken.None).ConfigureAwait(false);
+                }
+                yield return evt;
+            }
+        }
+
+        public async Task<SessionResource?> GetAsync(ClaimsPrincipal accessContext, string id, CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(accessContext);
+            ArgumentException.ThrowIfNullOrEmpty(id);
+
+            _logger.LogInformation("Getting /sessions/{id}.", id.Sanitize());
+            var session = await _store.TryGetAsync(id, cancellationToken).ConfigureAwait(false);
+            if (session == null)
+            {
+                return null;
+            }
+
+            await EnsureAccessAsync(accessContext, session, Operation.Read).ConfigureAwait(false);
+            return session;
+        }
+
+        public async Task DeleteAsync(ClaimsPrincipal accessContext, string id, CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(accessContext);
+            ArgumentException.ThrowIfNullOrEmpty(id);
+
+            _logger.LogInformation("Deleting /sessions/{id}.", id.Sanitize());
+            var existing = await _store.TryGetAsync(id, cancellationToken).ConfigureAwait(false)
+                ?? throw new ArgumentException("The session does not exist.");
+
+            await EnsureAccessAsync(accessContext, existing, Operation.Write).ConfigureAwait(false);
+            await _store.DeleteAsync(id, cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task<IEnumerable<SessionResource>> ListAsync(ClaimsPrincipal accessContext, CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(accessContext);
+
+            _logger.LogInformation("Listing /sessions for user.");
+            var resources = (await _store.ListAsync(cancellationToken).ConfigureAwait(false)).ToList();
+            var allowed = await _permissionProvider.CheckAccessAsync(accessContext, resources, Operation.Read).ConfigureAwait(false);
+
+            var filteredCount = resources.Count - allowed.Length;
+            if (filteredCount > 0)
+            {
+                _logger.LogInformation("Filtered {count} session resources due to authorization.", filteredCount);
+            }
+
+            return allowed;
+        }
+
+        private async Task EnsureAccessAsync(ClaimsPrincipal accessContext, SessionResource resource, Operation operation)
+        {
+            ArgumentNullException.ThrowIfNull(accessContext);
+            ArgumentNullException.ThrowIfNull(resource);
+
+            if (await _permissionProvider.CheckAccessAsync(accessContext, resource, operation).ConfigureAwait(false))
+            {
+                return;
+            }
+
+            var operationName = operation.ToString().ToLowerInvariant();
+            _logger.LogWarning("User {userId} is denied {operation} access for session {resourceId}.", accessContext.GetUserId(), operationName, resource.Id);
+            throw new UnauthorizedAccessException("You do not have permission to perform the operation.");
+        }
+
+        /// <summary>
+        /// Allocate a per-session working directory for built-in tools. Located
+        /// under the OS temp dir so the gateway pod can recycle on restart.
+        /// P2 will replace this with a sandboxed/quota'd path.
+        /// </summary>
+        private static string AllocateWorkingDirectory(string sessionId)
+        {
+            var path = Path.Combine(Path.GetTempPath(), "agent-sessions", sessionId);
+            Directory.CreateDirectory(path);
+            return path;
+        }
+    }
+}

--- a/dotnet/Microsoft.McpGateway.Management/src/Service/SessionManagementService.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Service/SessionManagementService.cs
@@ -14,9 +14,11 @@ using Microsoft.McpGateway.Management.Store;
 namespace Microsoft.McpGateway.Management.Service
 {
     /// <summary>
-    /// Service for managing sessions. Phase 2: pure metadata + agent snapshot,
-    /// plus an in-process fire-and-forget LLM call that writes the result back
-    /// to the session record. No worker pod, no agent loop, no tools yet.
+    /// Service for managing sessions. Drives an <see cref="AgentRunner"/>
+    /// (LLM + tool calls + SSE event stream) and persists per-session state
+    /// (status, messages, working directory) in the session store.
+    /// Streaming requires <see cref="AgentRunner"/> to be registered, which
+    /// happens only when <c>FoundrySettings:Endpoint</c> is configured.
     /// </summary>
     public class SessionManagementService : ISessionManagementService
     {
@@ -24,6 +26,7 @@ namespace Microsoft.McpGateway.Management.Service
         private readonly IAgentResourceStore _agentStore;
         private readonly IPermissionProvider _permissionProvider;
         private readonly AgentRunner? _agentRunner;
+        private readonly BuiltinToolExecutor? _builtinExecutor;
         private readonly ILogger _logger;
 
         public SessionManagementService(
@@ -31,13 +34,15 @@ namespace Microsoft.McpGateway.Management.Service
             IAgentResourceStore agentStore,
             IPermissionProvider permissionProvider,
             ILogger<SessionManagementService> logger,
-            AgentRunner? agentRunner = null)
+            AgentRunner? agentRunner = null,
+            BuiltinToolExecutor? builtinExecutor = null)
         {
             _store = store ?? throw new ArgumentNullException(nameof(store));
             _agentStore = agentStore ?? throw new ArgumentNullException(nameof(agentStore));
             _permissionProvider = permissionProvider ?? throw new ArgumentNullException(nameof(permissionProvider));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _agentRunner = agentRunner;
+            _builtinExecutor = builtinExecutor;
         }
 
         public async Task<SessionResource> CreateAsync(ClaimsPrincipal accessContext, SessionData request, CancellationToken cancellationToken)
@@ -157,30 +162,70 @@ namespace Microsoft.McpGateway.Management.Service
             _logger.LogInformation("Streaming run for /sessions/{id} on agent {agent}.", session.Id, agent.Name.Sanitize());
             await _store.UpsertAsync(session, cancellationToken).ConfigureAwait(false);
 
-            await foreach (var evt in _agentRunner.RunStreamingAsync(
+            var enumerator = _agentRunner.RunStreamingAsync(
                 agent,
                 session.Input,
                 session.Id,
                 parentSessionId: session.ParentSessionId,
                 history: session.Messages,
                 workingDirectory: session.WorkingDirectory,
-                cancellationToken).ConfigureAwait(false))
+                cancellationToken).GetAsyncEnumerator(cancellationToken);
+            try
             {
-                if (evt.Type == SessionEventType.Completed)
+                while (true)
                 {
-                    session.Status = SessionStatus.Completed;
-                    session.Result = evt.Answer;
-                    session.LastUpdatedAt = DateTimeOffset.UtcNow;
-                    await _store.UpsertAsync(session, CancellationToken.None).ConfigureAwait(false);
+                    SessionEvent evt;
+                    try
+                    {
+                        if (!await enumerator.MoveNextAsync().ConfigureAwait(false))
+                        {
+                            break;
+                        }
+                        evt = enumerator.Current;
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        // Client disconnected or cancellation token tripped before
+                        // the runner could emit Completed/Failed. Persist a terminal
+                        // status so the session record doesn't stay stuck on Running.
+                        await PersistTerminalStatusAsync(session, SessionStatus.Cancelled, error: "Run cancelled before completion.").ConfigureAwait(false);
+                        throw;
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Streaming run for session {id} faulted.", session.Id);
+                        await PersistTerminalStatusAsync(session, SessionStatus.Failed, error: ex.Message).ConfigureAwait(false);
+                        throw;
+                    }
+
+                    if (evt.Type == SessionEventType.Completed)
+                    {
+                        session.Status = SessionStatus.Completed;
+                        session.Result = evt.Answer;
+                        session.LastUpdatedAt = DateTimeOffset.UtcNow;
+                        await _store.UpsertAsync(session, CancellationToken.None).ConfigureAwait(false);
+                    }
+                    else if (evt.Type == SessionEventType.Failed)
+                    {
+                        session.Status = SessionStatus.Failed;
+                        session.Error = evt.Error;
+                        session.LastUpdatedAt = DateTimeOffset.UtcNow;
+                        await _store.UpsertAsync(session, CancellationToken.None).ConfigureAwait(false);
+                    }
+                    yield return evt;
                 }
-                else if (evt.Type == SessionEventType.Failed)
+
+                // If the runner completed without ever emitting a terminal
+                // event (defensive; AgentRunner contract says it always does),
+                // mark the session Completed so it doesn't stay Running.
+                if (session.Status == SessionStatus.Running)
                 {
-                    session.Status = SessionStatus.Failed;
-                    session.Error = evt.Error;
-                    session.LastUpdatedAt = DateTimeOffset.UtcNow;
-                    await _store.UpsertAsync(session, CancellationToken.None).ConfigureAwait(false);
+                    await PersistTerminalStatusAsync(session, SessionStatus.Completed, error: null).ConfigureAwait(false);
                 }
-                yield return evt;
+            }
+            finally
+            {
+                await enumerator.DisposeAsync().ConfigureAwait(false);
             }
         }
 
@@ -213,7 +258,7 @@ namespace Microsoft.McpGateway.Management.Service
             _logger.LogInformation("Continuing /sessions/{id} with new user message ({len} chars, {prior} prior messages).",
                 session.Id, userInput.Length, priorHistory.Count);
 
-            await foreach (var evt in _agentRunner.RunStreamingAsync(
+            var enumerator = _agentRunner.RunStreamingAsync(
                 session.AgentSnapshot,
                 userInput,
                 session.Id,
@@ -221,23 +266,79 @@ namespace Microsoft.McpGateway.Management.Service
                 history: session.Messages,
                 workingDirectory: session.WorkingDirectory,
                 cancellationToken,
-                priorHistory: priorHistory).ConfigureAwait(false))
+                priorHistory: priorHistory).GetAsyncEnumerator(cancellationToken);
+            try
             {
-                if (evt.Type == SessionEventType.Completed)
+                while (true)
                 {
-                    session.Status = SessionStatus.Completed;
-                    session.Result = evt.Answer;
-                    session.LastUpdatedAt = DateTimeOffset.UtcNow;
-                    await _store.UpsertAsync(session, CancellationToken.None).ConfigureAwait(false);
+                    SessionEvent evt;
+                    try
+                    {
+                        if (!await enumerator.MoveNextAsync().ConfigureAwait(false))
+                        {
+                            break;
+                        }
+                        evt = enumerator.Current;
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        await PersistTerminalStatusAsync(session, SessionStatus.Cancelled, error: "Run cancelled before completion.").ConfigureAwait(false);
+                        throw;
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Continuing session {id} faulted.", session.Id);
+                        await PersistTerminalStatusAsync(session, SessionStatus.Failed, error: ex.Message).ConfigureAwait(false);
+                        throw;
+                    }
+
+                    if (evt.Type == SessionEventType.Completed)
+                    {
+                        session.Status = SessionStatus.Completed;
+                        session.Result = evt.Answer;
+                        session.LastUpdatedAt = DateTimeOffset.UtcNow;
+                        await _store.UpsertAsync(session, CancellationToken.None).ConfigureAwait(false);
+                    }
+                    else if (evt.Type == SessionEventType.Failed)
+                    {
+                        session.Status = SessionStatus.Failed;
+                        session.Error = evt.Error;
+                        session.LastUpdatedAt = DateTimeOffset.UtcNow;
+                        await _store.UpsertAsync(session, CancellationToken.None).ConfigureAwait(false);
+                    }
+                    yield return evt;
                 }
-                else if (evt.Type == SessionEventType.Failed)
+
+                if (session.Status == SessionStatus.Running)
                 {
-                    session.Status = SessionStatus.Failed;
-                    session.Error = evt.Error;
-                    session.LastUpdatedAt = DateTimeOffset.UtcNow;
-                    await _store.UpsertAsync(session, CancellationToken.None).ConfigureAwait(false);
+                    await PersistTerminalStatusAsync(session, SessionStatus.Completed, error: null).ConfigureAwait(false);
                 }
-                yield return evt;
+            }
+            finally
+            {
+                await enumerator.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Best-effort persistence of a terminal session state. Swallows store
+        /// errors so the original cancellation / exception flow isn't masked.
+        /// </summary>
+        private async Task PersistTerminalStatusAsync(SessionResource session, SessionStatus status, string? error)
+        {
+            try
+            {
+                session.Status = status;
+                if (error != null)
+                {
+                    session.Error = error;
+                }
+                session.LastUpdatedAt = DateTimeOffset.UtcNow;
+                await _store.UpsertAsync(session, CancellationToken.None).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to persist terminal status {status} for session {id}.", status, session.Id);
             }
         }
 
@@ -268,6 +369,25 @@ namespace Microsoft.McpGateway.Management.Service
 
             await EnsureAccessAsync(accessContext, existing, Operation.Write).ConfigureAwait(false);
             await _store.DeleteAsync(id, cancellationToken).ConfigureAwait(false);
+
+            // Release per-session quota bookkeeping and best-effort scrub the
+            // session's working directory so long-lived pods don't accumulate
+            // orphaned counters or temp files.
+            if (!string.IsNullOrEmpty(existing.WorkingDirectory))
+            {
+                _builtinExecutor?.ReleaseSession(existing.WorkingDirectory);
+                try
+                {
+                    if (Directory.Exists(existing.WorkingDirectory))
+                    {
+                        Directory.Delete(existing.WorkingDirectory, recursive: true);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to delete working directory for session {id}.", id.Sanitize());
+                }
+            }
         }
 
         public async Task<IEnumerable<SessionResource>> ListAsync(ClaimsPrincipal accessContext, CancellationToken cancellationToken)

--- a/dotnet/Microsoft.McpGateway.Management/src/Store/CosmosAgentResourceStore.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Store/CosmosAgentResourceStore.cs
@@ -1,0 +1,108 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Net;
+using System.Text.Json;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Logging;
+using Microsoft.McpGateway.Management.Contracts;
+using Microsoft.McpGateway.Management.Extensions;
+
+namespace Microsoft.McpGateway.Management.Store
+{
+    /// <summary>
+    /// Cosmos DB implementation of the agent resource store.
+    /// </summary>
+    public class CosmosAgentResourceStore : IAgentResourceStore
+    {
+        private readonly Container _container;
+        private readonly ILogger _logger;
+        private readonly CosmosClient _client;
+        private readonly string _databaseId;
+        private readonly string _containerId;
+
+        public CosmosAgentResourceStore(CosmosClient client, string databaseId, string containerId, ILogger logger)
+        {
+            ArgumentNullException.ThrowIfNull(client);
+            ArgumentNullException.ThrowIfNull(logger);
+            ArgumentException.ThrowIfNullOrEmpty(databaseId);
+            ArgumentException.ThrowIfNullOrEmpty(containerId);
+
+            _databaseId = databaseId;
+            _containerId = containerId;
+            _client = client;
+            _container = client.GetContainer(databaseId, containerId);
+            _logger = logger;
+        }
+
+        public async Task InitializeAsync(CancellationToken cancellationToken)
+        {
+            var db = await _client.CreateDatabaseIfNotExistsAsync(_databaseId, cancellationToken: cancellationToken).ConfigureAwait(false);
+            await db.Database.CreateContainerIfNotExistsAsync(
+                new ContainerProperties
+                {
+                    Id = _containerId,
+                    PartitionKeyPath = "/id"
+                }, cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task<AgentResource?> TryGetAsync(string name, CancellationToken cancellationToken)
+        {
+            try
+            {
+                var response = await _container.ReadItemAsync<AgentResource>(
+                    id: name,
+                    partitionKey: new PartitionKey(name),
+                    cancellationToken: cancellationToken).ConfigureAwait(false);
+
+                return response.Resource;
+            }
+            catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+            {
+                _logger.LogInformation("Cannot find /agents/{name}, returning NULL", name.Sanitize());
+                return null;
+            }
+        }
+
+        public async Task UpsertAsync(AgentResource agent, CancellationToken cancellationToken)
+        {
+            using var stream = new MemoryStream();
+            await JsonSerializer.SerializeAsync(stream, agent, cancellationToken: cancellationToken).ConfigureAwait(false);
+            stream.Position = 0;
+            var response = await _container.UpsertItemStreamAsync(
+                stream,
+                partitionKey: new PartitionKey(agent.Id),
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+        }
+
+        public async Task DeleteAsync(string name, CancellationToken cancellationToken)
+        {
+            try
+            {
+                await _container.DeleteItemAsync<AgentResource>(
+                    id: name,
+                    partitionKey: new PartitionKey(name),
+                    cancellationToken: cancellationToken).ConfigureAwait(false);
+            }
+            catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+            {
+                _logger.LogWarning("Cannot find /agents/{name} for deleting, skip the following tasks", name.Sanitize());
+            }
+        }
+
+        public async Task<IEnumerable<AgentResource>> ListAsync(CancellationToken cancellationToken)
+        {
+            var query = _container.GetItemQueryIterator<AgentResource>();
+            var results = new List<AgentResource>();
+
+            while (query.HasMoreResults)
+            {
+                var response = await query.ReadNextAsync(cancellationToken).ConfigureAwait(false);
+                results.AddRange(response.Resource);
+            }
+
+            return results;
+        }
+    }
+}

--- a/dotnet/Microsoft.McpGateway.Management/src/Store/CosmosSessionResourceStore.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Store/CosmosSessionResourceStore.cs
@@ -1,0 +1,108 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Net;
+using System.Text.Json;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Logging;
+using Microsoft.McpGateway.Management.Contracts;
+using Microsoft.McpGateway.Management.Extensions;
+
+namespace Microsoft.McpGateway.Management.Store
+{
+    /// <summary>
+    /// Cosmos DB implementation of the session resource store.
+    /// </summary>
+    public class CosmosSessionResourceStore : ISessionResourceStore
+    {
+        private readonly Container _container;
+        private readonly ILogger _logger;
+        private readonly CosmosClient _client;
+        private readonly string _databaseId;
+        private readonly string _containerId;
+
+        public CosmosSessionResourceStore(CosmosClient client, string databaseId, string containerId, ILogger logger)
+        {
+            ArgumentNullException.ThrowIfNull(client);
+            ArgumentNullException.ThrowIfNull(logger);
+            ArgumentException.ThrowIfNullOrEmpty(databaseId);
+            ArgumentException.ThrowIfNullOrEmpty(containerId);
+
+            _databaseId = databaseId;
+            _containerId = containerId;
+            _client = client;
+            _container = client.GetContainer(databaseId, containerId);
+            _logger = logger;
+        }
+
+        public async Task InitializeAsync(CancellationToken cancellationToken)
+        {
+            var db = await _client.CreateDatabaseIfNotExistsAsync(_databaseId, cancellationToken: cancellationToken).ConfigureAwait(false);
+            await db.Database.CreateContainerIfNotExistsAsync(
+                new ContainerProperties
+                {
+                    Id = _containerId,
+                    PartitionKeyPath = "/id"
+                }, cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task<SessionResource?> TryGetAsync(string id, CancellationToken cancellationToken)
+        {
+            try
+            {
+                var response = await _container.ReadItemAsync<SessionResource>(
+                    id: id,
+                    partitionKey: new PartitionKey(id),
+                    cancellationToken: cancellationToken).ConfigureAwait(false);
+
+                return response.Resource;
+            }
+            catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+            {
+                _logger.LogInformation("Cannot find /sessions/{id}, returning NULL", id.Sanitize());
+                return null;
+            }
+        }
+
+        public async Task UpsertAsync(SessionResource session, CancellationToken cancellationToken)
+        {
+            using var stream = new MemoryStream();
+            await JsonSerializer.SerializeAsync(stream, session, cancellationToken: cancellationToken).ConfigureAwait(false);
+            stream.Position = 0;
+            var response = await _container.UpsertItemStreamAsync(
+                stream,
+                partitionKey: new PartitionKey(session.Id),
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+        }
+
+        public async Task DeleteAsync(string id, CancellationToken cancellationToken)
+        {
+            try
+            {
+                await _container.DeleteItemAsync<SessionResource>(
+                    id: id,
+                    partitionKey: new PartitionKey(id),
+                    cancellationToken: cancellationToken).ConfigureAwait(false);
+            }
+            catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+            {
+                _logger.LogWarning("Cannot find /sessions/{id} for deleting, skip the following tasks", id.Sanitize());
+            }
+        }
+
+        public async Task<IEnumerable<SessionResource>> ListAsync(CancellationToken cancellationToken)
+        {
+            var query = _container.GetItemQueryIterator<SessionResource>();
+            var results = new List<SessionResource>();
+
+            while (query.HasMoreResults)
+            {
+                var response = await query.ReadNextAsync(cancellationToken).ConfigureAwait(false);
+                results.AddRange(response.Resource);
+            }
+
+            return results;
+        }
+    }
+}

--- a/dotnet/Microsoft.McpGateway.Management/src/Store/IAgentResourceStore.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Store/IAgentResourceStore.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.McpGateway.Management.Contracts;
+
+namespace Microsoft.McpGateway.Management.Store
+{
+    /// <summary>
+    /// Interface for storing and retrieving agent resources.
+    /// </summary>
+    public interface IAgentResourceStore
+    {
+        /// <summary>
+        /// Try to get an agent resource by name.
+        /// </summary>
+        Task<AgentResource?> TryGetAsync(string name, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Upsert an agent resource.
+        /// </summary>
+        Task UpsertAsync(AgentResource agent, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Delete an agent resource by name.
+        /// </summary>
+        Task DeleteAsync(string name, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// List all agent resources.
+        /// </summary>
+        Task<IEnumerable<AgentResource>> ListAsync(CancellationToken cancellationToken);
+    }
+}

--- a/dotnet/Microsoft.McpGateway.Management/src/Store/ISessionResourceStore.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Store/ISessionResourceStore.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.McpGateway.Management.Contracts;
+
+namespace Microsoft.McpGateway.Management.Store
+{
+    /// <summary>
+    /// Interface for storing and retrieving session resources.
+    /// </summary>
+    public interface ISessionResourceStore
+    {
+        Task<SessionResource?> TryGetAsync(string id, CancellationToken cancellationToken);
+
+        Task UpsertAsync(SessionResource session, CancellationToken cancellationToken);
+
+        Task DeleteAsync(string id, CancellationToken cancellationToken);
+
+        Task<IEnumerable<SessionResource>> ListAsync(CancellationToken cancellationToken);
+    }
+}

--- a/dotnet/Microsoft.McpGateway.Management/src/Store/InMemoryAgentResourceStore.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Store/InMemoryAgentResourceStore.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Concurrent;
+using Microsoft.McpGateway.Management.Contracts;
+
+namespace Microsoft.McpGateway.Management.Store
+{
+    /// <summary>
+    /// In-memory implementation of the agent resource store for development.
+    /// </summary>
+    public class InMemoryAgentResourceStore : IAgentResourceStore
+    {
+        private readonly ConcurrentDictionary<string, AgentResource> _agents = new();
+
+        public Task<AgentResource?> TryGetAsync(string name, CancellationToken cancellationToken)
+        {
+            _agents.TryGetValue(name, out var agent);
+            return Task.FromResult(agent);
+        }
+
+        public Task UpsertAsync(AgentResource agent, CancellationToken cancellationToken)
+        {
+            _agents[agent.Name] = agent;
+            return Task.CompletedTask;
+        }
+
+        public Task DeleteAsync(string name, CancellationToken cancellationToken)
+        {
+            _agents.TryRemove(name, out _);
+            return Task.CompletedTask;
+        }
+
+        public Task<IEnumerable<AgentResource>> ListAsync(CancellationToken cancellationToken)
+        {
+            return Task.FromResult<IEnumerable<AgentResource>>([.. _agents.Values]);
+        }
+    }
+}

--- a/dotnet/Microsoft.McpGateway.Management/src/Store/InMemorySessionResourceStore.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Store/InMemorySessionResourceStore.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Concurrent;
+using Microsoft.McpGateway.Management.Contracts;
+
+namespace Microsoft.McpGateway.Management.Store
+{
+    /// <summary>
+    /// In-memory implementation of the session resource store for development.
+    /// </summary>
+    public class InMemorySessionResourceStore : ISessionResourceStore
+    {
+        private readonly ConcurrentDictionary<string, SessionResource> _sessions = new();
+
+        public Task<SessionResource?> TryGetAsync(string id, CancellationToken cancellationToken)
+        {
+            _sessions.TryGetValue(id, out var session);
+            return Task.FromResult(session);
+        }
+
+        public Task UpsertAsync(SessionResource session, CancellationToken cancellationToken)
+        {
+            _sessions[session.Id] = session;
+            return Task.CompletedTask;
+        }
+
+        public Task DeleteAsync(string id, CancellationToken cancellationToken)
+        {
+            _sessions.TryRemove(id, out _);
+            return Task.CompletedTask;
+        }
+
+        public Task<IEnumerable<SessionResource>> ListAsync(CancellationToken cancellationToken)
+        {
+            return Task.FromResult<IEnumerable<SessionResource>>([.. _sessions.Values]);
+        }
+    }
+}

--- a/dotnet/Microsoft.McpGateway.Management/test/AgentManagementServiceTests.cs
+++ b/dotnet/Microsoft.McpGateway.Management/test/AgentManagementServiceTests.cs
@@ -1,0 +1,276 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.McpGateway.Management.Authorization;
+using Microsoft.McpGateway.Management.Contracts;
+using Microsoft.McpGateway.Management.Service;
+using Microsoft.McpGateway.Management.Store;
+using ModelContextProtocol.Protocol;
+using Moq;
+
+namespace Microsoft.McpGateway.Management.Tests
+{
+    [TestClass]
+    public class AgentManagementServiceTests
+    {
+        private readonly Mock<IAgentResourceStore> _agentStoreMock;
+        private readonly Mock<IToolResourceStore> _toolStoreMock;
+        private readonly Mock<IPermissionProvider> _permissionProviderMock;
+        private readonly Mock<ILogger<AgentManagementService>> _loggerMock;
+        private readonly AgentManagementService _service;
+        private readonly ClaimsPrincipal _accessContext;
+
+        public AgentManagementServiceTests()
+        {
+            _agentStoreMock = new Mock<IAgentResourceStore>();
+            _toolStoreMock = new Mock<IToolResourceStore>();
+            _permissionProviderMock = new Mock<IPermissionProvider>();
+            _loggerMock = new Mock<ILogger<AgentManagementService>>();
+
+            _permissionProviderMock
+                .Setup(x => x.CheckAccessAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<IManagedResource>(), It.IsAny<Operation>()))
+                .ReturnsAsync(true);
+            _permissionProviderMock
+                .Setup(x => x.CheckAccessAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<IEnumerable<AgentResource>>(), Operation.Read))
+                .ReturnsAsync((ClaimsPrincipal _, IEnumerable<AgentResource> r, Operation _) => r.ToArray());
+
+            _service = new AgentManagementService(
+                _agentStoreMock.Object,
+                _toolStoreMock.Object,
+                _permissionProviderMock.Object,
+                _loggerMock.Object);
+
+            _accessContext = new ClaimsPrincipal(new ClaimsIdentity([new(ClaimTypes.NameIdentifier, "user1")]));
+        }
+
+        private static AgentData CreateAgentData(
+            string name = "demo-agent",
+            IList<string>? tools = null) =>
+            new()
+            {
+                Name = name,
+                Model = "gpt-4o",
+                System = "you are helpful.",
+                Tools = tools ?? new List<string>(),
+                Description = "test",
+            };
+
+        private static ToolResource CreateToolResource(string name)
+        {
+            var schemaJson = System.Text.Json.JsonSerializer.Serialize(new { type = "object", properties = new { } });
+            var schema = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(schemaJson);
+            var data = new ToolData
+            {
+                Name = name,
+                ImageName = "img",
+                ImageVersion = "v1",
+                ReplicaCount = 1,
+                EnvironmentVariables = [],
+                ToolDefinition = new ToolDefinition
+                {
+                    Tool = new Tool { Name = name, Description = "t", InputSchema = schema },
+                },
+            };
+            return ToolResource.Create(data, "user1", DateTimeOffset.UtcNow);
+        }
+
+        [TestMethod]
+        public async Task CreateAsync_ShouldSucceed_WithEmptyTools()
+        {
+            var request = CreateAgentData("agent-a");
+            _agentStoreMock.Setup(x => x.TryGetAsync("agent-a", It.IsAny<CancellationToken>())).ReturnsAsync((AgentResource?)null);
+
+            var result = await _service.CreateAsync(_accessContext, request, CancellationToken.None);
+
+            result.Name.Should().Be("agent-a");
+            _agentStoreMock.Verify(x => x.UpsertAsync(It.IsAny<AgentResource>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task CreateAsync_ShouldThrow_WhenNameInvalid()
+        {
+            var request = CreateAgentData("Bad_Name");
+
+            Func<Task> act = () => _service.CreateAsync(_accessContext, request, CancellationToken.None);
+
+            await act.Should().ThrowAsync<ArgumentException>()
+                .WithMessage("Name must contain only lowercase letters, numbers, and dashes.");
+        }
+
+        [TestMethod]
+        public async Task CreateAsync_ShouldThrow_WhenAgentAlreadyExists()
+        {
+            var request = CreateAgentData("dup");
+            var existing = AgentResource.Create(request, "user1", DateTimeOffset.UtcNow);
+            _agentStoreMock.Setup(x => x.TryGetAsync("dup", It.IsAny<CancellationToken>())).ReturnsAsync(existing);
+
+            Func<Task> act = () => _service.CreateAsync(_accessContext, request, CancellationToken.None);
+
+            await act.Should().ThrowAsync<ArgumentException>()
+                .WithMessage("An agent with the same name already exists.");
+        }
+
+        [TestMethod]
+        public async Task CreateAsync_ShouldAcceptKnownBuiltins()
+        {
+            var request = CreateAgentData("agent-b", new List<string>
+            {
+                "builtin:bash", "builtin:read_file", "builtin:write_file",
+            });
+            _agentStoreMock.Setup(x => x.TryGetAsync("agent-b", It.IsAny<CancellationToken>())).ReturnsAsync((AgentResource?)null);
+
+            var result = await _service.CreateAsync(_accessContext, request, CancellationToken.None);
+
+            result.Tools.Should().BeEquivalentTo(request.Tools);
+        }
+
+        [TestMethod]
+        public async Task CreateAsync_ShouldThrow_OnUnknownBuiltin()
+        {
+            var request = CreateAgentData("agent-c", new List<string> { "builtin:nope" });
+            _agentStoreMock.Setup(x => x.TryGetAsync("agent-c", It.IsAny<CancellationToken>())).ReturnsAsync((AgentResource?)null);
+
+            Func<Task> act = () => _service.CreateAsync(_accessContext, request, CancellationToken.None);
+
+            await act.Should().ThrowAsync<ArgumentException>().WithMessage("*builtin:nope*");
+        }
+
+        [TestMethod]
+        public async Task CreateAsync_ShouldThrow_OnUnprefixedTool()
+        {
+            var request = CreateAgentData("agent-d", new List<string> { "weather" });
+            _agentStoreMock.Setup(x => x.TryGetAsync("agent-d", It.IsAny<CancellationToken>())).ReturnsAsync((AgentResource?)null);
+
+            Func<Task> act = () => _service.CreateAsync(_accessContext, request, CancellationToken.None);
+
+            await act.Should().ThrowAsync<ArgumentException>().WithMessage("*missing a recognized prefix*");
+        }
+
+        [TestMethod]
+        public async Task CreateAsync_ShouldThrow_WhenMcpToolMissing()
+        {
+            var request = CreateAgentData("agent-e", new List<string> { "mcp:weather" });
+            _agentStoreMock.Setup(x => x.TryGetAsync("agent-e", It.IsAny<CancellationToken>())).ReturnsAsync((AgentResource?)null);
+            _toolStoreMock.Setup(x => x.TryGetAsync("weather", It.IsAny<CancellationToken>())).ReturnsAsync((ToolResource?)null);
+
+            Func<Task> act = () => _service.CreateAsync(_accessContext, request, CancellationToken.None);
+
+            await act.Should().ThrowAsync<ArgumentException>().WithMessage("*MCP tool 'weather'*does not exist*");
+        }
+
+        [TestMethod]
+        public async Task CreateAsync_ShouldThrow_WhenCallerLacksMcpToolAccess()
+        {
+            var request = CreateAgentData("agent-f", new List<string> { "mcp:weather" });
+            _agentStoreMock.Setup(x => x.TryGetAsync("agent-f", It.IsAny<CancellationToken>())).ReturnsAsync((AgentResource?)null);
+            var tool = CreateToolResource("weather");
+            _toolStoreMock.Setup(x => x.TryGetAsync("weather", It.IsAny<CancellationToken>())).ReturnsAsync(tool);
+            _permissionProviderMock
+                .Setup(x => x.CheckAccessAsync(It.IsAny<ClaimsPrincipal>(), It.Is<IManagedResource>(r => r is ToolResource), Operation.Read))
+                .ReturnsAsync(false);
+
+            Func<Task> act = () => _service.CreateAsync(_accessContext, request, CancellationToken.None);
+
+            await act.Should().ThrowAsync<UnauthorizedAccessException>().WithMessage("*permission to reference tool 'weather'*");
+        }
+
+        [TestMethod]
+        public async Task CreateAsync_ShouldThrow_WhenSubAgentMissing()
+        {
+            var request = CreateAgentData("agent-g", new List<string> { "agent:peer" });
+            _agentStoreMock.Setup(x => x.TryGetAsync("agent-g", It.IsAny<CancellationToken>())).ReturnsAsync((AgentResource?)null);
+            _agentStoreMock.Setup(x => x.TryGetAsync("peer", It.IsAny<CancellationToken>())).ReturnsAsync((AgentResource?)null);
+
+            Func<Task> act = () => _service.CreateAsync(_accessContext, request, CancellationToken.None);
+
+            await act.Should().ThrowAsync<ArgumentException>().WithMessage("*Peer agent 'peer'*");
+        }
+
+        [TestMethod]
+        public async Task CreateAsync_ShouldThrow_WhenAgentSelfReferences()
+        {
+            var request = CreateAgentData("agent-h", new List<string> { "agent:agent-h" });
+            _agentStoreMock.Setup(x => x.TryGetAsync("agent-h", It.IsAny<CancellationToken>())).ReturnsAsync((AgentResource?)null);
+
+            Func<Task> act = () => _service.CreateAsync(_accessContext, request, CancellationToken.None);
+
+            await act.Should().ThrowAsync<ArgumentException>().WithMessage("*cannot reference itself*");
+        }
+
+        [TestMethod]
+        public async Task UpdateAsync_ShouldRevalidateTools()
+        {
+            var existing = AgentResource.Create(CreateAgentData("agent-i"), "user1", DateTimeOffset.UtcNow);
+            _agentStoreMock.Setup(x => x.TryGetAsync("agent-i", It.IsAny<CancellationToken>())).ReturnsAsync(existing);
+
+            var update = CreateAgentData("agent-i", new List<string> { "mcp:missing" });
+            _toolStoreMock.Setup(x => x.TryGetAsync("missing", It.IsAny<CancellationToken>())).ReturnsAsync((ToolResource?)null);
+
+            Func<Task> act = () => _service.UpdateAsync(_accessContext, update, CancellationToken.None);
+
+            await act.Should().ThrowAsync<ArgumentException>().WithMessage("*MCP tool 'missing'*");
+        }
+
+        [TestMethod]
+        public async Task GetAsync_ShouldReturnNull_WhenAgentMissing()
+        {
+            _agentStoreMock.Setup(x => x.TryGetAsync("nope", It.IsAny<CancellationToken>())).ReturnsAsync((AgentResource?)null);
+
+            var result = await _service.GetAsync(_accessContext, "nope", CancellationToken.None);
+
+            result.Should().BeNull();
+        }
+
+        [TestMethod]
+        public async Task GetAsync_ShouldThrow_WhenCallerLacksReadAccess()
+        {
+            var existing = AgentResource.Create(CreateAgentData("agent-j"), "user1", DateTimeOffset.UtcNow);
+            _agentStoreMock.Setup(x => x.TryGetAsync("agent-j", It.IsAny<CancellationToken>())).ReturnsAsync(existing);
+            _permissionProviderMock
+                .Setup(x => x.CheckAccessAsync(It.IsAny<ClaimsPrincipal>(), It.Is<IManagedResource>(r => r is AgentResource), Operation.Read))
+                .ReturnsAsync(false);
+
+            Func<Task> act = () => _service.GetAsync(_accessContext, "agent-j", CancellationToken.None);
+
+            await act.Should().ThrowAsync<UnauthorizedAccessException>();
+        }
+
+        [TestMethod]
+        public async Task ListAsync_ShouldFilterByPermission()
+        {
+            var a1 = AgentResource.Create(CreateAgentData("a1"), "user1", DateTimeOffset.UtcNow);
+            var a2 = AgentResource.Create(CreateAgentData("a2"), "user2", DateTimeOffset.UtcNow);
+            _agentStoreMock.Setup(x => x.ListAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new[] { a1, a2 });
+            _permissionProviderMock
+                .Setup(x => x.CheckAccessAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<IEnumerable<AgentResource>>(), Operation.Read))
+                .ReturnsAsync((ClaimsPrincipal _, IEnumerable<AgentResource> rs, Operation _) => rs.Where(r => r.Name == "a1").ToArray());
+
+            var result = (await _service.ListAsync(_accessContext, CancellationToken.None)).ToList();
+
+            result.Should().HaveCount(1);
+            result[0].Name.Should().Be("a1");
+        }
+
+        [TestMethod]
+        public async Task DeleteAsync_ShouldRequireWrite()
+        {
+            var existing = AgentResource.Create(CreateAgentData("agent-k"), "user1", DateTimeOffset.UtcNow);
+            _agentStoreMock.Setup(x => x.TryGetAsync("agent-k", It.IsAny<CancellationToken>())).ReturnsAsync(existing);
+            _permissionProviderMock
+                .Setup(x => x.CheckAccessAsync(It.IsAny<ClaimsPrincipal>(), It.Is<IManagedResource>(r => r is AgentResource), Operation.Write))
+                .ReturnsAsync(false);
+
+            Func<Task> act = () => _service.DeleteAsync(_accessContext, "agent-k", CancellationToken.None);
+
+            await act.Should().ThrowAsync<UnauthorizedAccessException>();
+            _agentStoreMock.Verify(x => x.DeleteAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+    }
+}

--- a/dotnet/Microsoft.McpGateway.Service/src/Controllers/AgentManagementController.cs
+++ b/dotnet/Microsoft.McpGateway.Service/src/Controllers/AgentManagementController.cs
@@ -1,0 +1,103 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.McpGateway.Management.Contracts;
+using Microsoft.McpGateway.Management.Service;
+
+namespace Microsoft.McpGateway.Service.Controllers
+{
+    /// <summary>
+    /// Controller for managing agent definitions. Agents are metadata-only
+    /// (system prompt + model + tool list); they are not deployed as pods.
+    /// </summary>
+    [ApiController]
+    [Route("agents")]
+    [Authorize]
+    public class AgentManagementController(IAgentManagementService managementService) : ControllerBase
+    {
+        private readonly IAgentManagementService _managementService = managementService ?? throw new ArgumentNullException(nameof(managementService));
+
+        // POST /agents
+        [HttpPost]
+        public async Task<IActionResult> CreateAgent([FromBody] AgentData request, CancellationToken cancellationToken)
+        {
+            try
+            {
+                var result = await _managementService.CreateAsync(HttpContext.User, request, cancellationToken).ConfigureAwait(false);
+                return CreatedAtAction(nameof(GetAgent), new { name = result.Name }, result);
+            }
+            catch (ArgumentException ex)
+            {
+                return BadRequest(ex.Message);
+            }
+        }
+
+        // GET /agents/{name}
+        [HttpGet("{name}")]
+        public async Task<IActionResult> GetAgent(string name, CancellationToken cancellationToken)
+        {
+            try
+            {
+                var agent = await _managementService.GetAsync(HttpContext.User, name, cancellationToken).ConfigureAwait(false);
+                if (agent == null)
+                    return NotFound();
+                return Ok(agent);
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return Forbid();
+            }
+        }
+
+        // PUT /agents/{name}
+        [HttpPut("{name}")]
+        public async Task<IActionResult> UpdateAgent(string name, [FromBody] AgentData request, CancellationToken cancellationToken)
+        {
+            if (!string.Equals(name, request.Name, StringComparison.OrdinalIgnoreCase))
+                return BadRequest("Agent name in URL and body must match.");
+
+            try
+            {
+                var agent = await _managementService.UpdateAsync(HttpContext.User, request, cancellationToken).ConfigureAwait(false);
+                return Ok(agent);
+            }
+            catch (ArgumentException ex)
+            {
+                return BadRequest(ex.Message);
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return Forbid();
+            }
+        }
+
+        // DELETE /agents/{name}
+        [HttpDelete("{name}")]
+        public async Task<IActionResult> DeleteAgent(string name, CancellationToken cancellationToken)
+        {
+            try
+            {
+                await _managementService.DeleteAsync(HttpContext.User, name, cancellationToken).ConfigureAwait(false);
+                return NoContent();
+            }
+            catch (ArgumentException ex)
+            {
+                return BadRequest(ex.Message);
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return Forbid();
+            }
+        }
+
+        // GET /agents
+        [HttpGet]
+        public async Task<IActionResult> ListAgents(CancellationToken cancellationToken)
+        {
+            var agents = await _managementService.ListAsync(HttpContext.User, cancellationToken).ConfigureAwait(false);
+            return Ok(agents);
+        }
+    }
+}

--- a/dotnet/Microsoft.McpGateway.Service/src/Controllers/SessionManagementController.cs
+++ b/dotnet/Microsoft.McpGateway.Service/src/Controllers/SessionManagementController.cs
@@ -1,0 +1,188 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.McpGateway.Management.Contracts;
+using Microsoft.McpGateway.Management.Foundry;
+using Microsoft.McpGateway.Management.Service;
+
+namespace Microsoft.McpGateway.Service.Controllers
+{
+    /// <summary>
+    /// Controller for managing sessions (one execution of an agent definition).
+    /// </summary>
+    [ApiController]
+    [Route("sessions")]
+    [Authorize]
+    public class SessionManagementController(ISessionManagementService managementService) : ControllerBase
+    {
+        private static readonly JsonSerializerOptions SseJsonOptions = new(JsonSerializerDefaults.Web);
+
+        private readonly ISessionManagementService _managementService = managementService ?? throw new ArgumentNullException(nameof(managementService));
+
+        // POST /sessions
+        [HttpPost]
+        public async Task<IActionResult> CreateSession([FromBody] SessionData request, CancellationToken cancellationToken)
+        {
+            try
+            {
+                var result = await _managementService.CreateAsync(HttpContext.User, request, cancellationToken).ConfigureAwait(false);
+                return CreatedAtAction(nameof(GetSession), new { id = result.Id }, result);
+            }
+            catch (ArgumentException ex)
+            {
+                return BadRequest(ex.Message);
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return Forbid();
+            }
+        }
+
+        // POST /sessions/run — synchronous, server-sent-events stream.
+        // Each event is written as `event: <type>\ndata: <json>\n\n` so a
+        // browser EventSource (or any line-buffered SSE reader) can consume it.
+        [HttpPost("run")]
+        public async Task RunSessionStream([FromBody] SessionData request, CancellationToken cancellationToken)
+        {
+            Response.StatusCode = 200;
+            Response.ContentType = "text/event-stream";
+            Response.Headers["Cache-Control"] = "no-cache";
+            Response.Headers["X-Accel-Buffering"] = "no";
+
+            try
+            {
+                await foreach (var evt in _managementService.RunStreamingAsync(HttpContext.User, request, cancellationToken).ConfigureAwait(false))
+                {
+                    var json = JsonSerializer.Serialize(evt, SseJsonOptions);
+                    var payload = $"event: {evt.Type}\ndata: {json}\n\n";
+                    var bytes = Encoding.UTF8.GetBytes(payload);
+                    await Response.Body.WriteAsync(bytes, cancellationToken).ConfigureAwait(false);
+                    await Response.Body.FlushAsync(cancellationToken).ConfigureAwait(false);
+                }
+            }
+            catch (ArgumentException ex)
+            {
+                await WriteSseErrorAsync("error", ex.Message, cancellationToken).ConfigureAwait(false);
+            }
+            catch (UnauthorizedAccessException)
+            {
+                await WriteSseErrorAsync("forbidden", "You do not have permission to invoke this agent.", cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                await WriteSseErrorAsync("error", ex.Message, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        private async Task WriteSseErrorAsync(string eventName, string message, CancellationToken cancellationToken)
+        {
+            var payload = $"event: {eventName}\ndata: {JsonSerializer.Serialize(new { error = message }, SseJsonOptions)}\n\n";
+            var bytes = Encoding.UTF8.GetBytes(payload);
+            try
+            {
+                await Response.Body.WriteAsync(bytes, cancellationToken).ConfigureAwait(false);
+                await Response.Body.FlushAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch
+            {
+                // Client likely disconnected; nothing more to do.
+            }
+        }
+
+        // POST /sessions/{id}/messages — append a user message to an existing
+        // session and stream the agent's reply over SSE. The session must
+        // already exist; prior User/Assistant messages are replayed as context.
+        public sealed class ContinueSessionBody
+        {
+            public string? Input { get; set; }
+        }
+
+        [HttpPost("{id}/messages")]
+        public async Task ContinueSession(string id, [FromBody] ContinueSessionBody request, CancellationToken cancellationToken)
+        {
+            Response.StatusCode = 200;
+            Response.ContentType = "text/event-stream";
+            Response.Headers["Cache-Control"] = "no-cache";
+            Response.Headers["X-Accel-Buffering"] = "no";
+
+            var input = request?.Input?.Trim();
+            if (string.IsNullOrEmpty(input))
+            {
+                await WriteSseErrorAsync("error", "Request body must include a non-empty 'input' field.", cancellationToken).ConfigureAwait(false);
+                return;
+            }
+
+            try
+            {
+                await foreach (var evt in _managementService.ContinueStreamingAsync(HttpContext.User, id, input, cancellationToken).ConfigureAwait(false))
+                {
+                    var json = JsonSerializer.Serialize(evt, SseJsonOptions);
+                    var payload = $"event: {evt.Type}\ndata: {json}\n\n";
+                    var bytes = Encoding.UTF8.GetBytes(payload);
+                    await Response.Body.WriteAsync(bytes, cancellationToken).ConfigureAwait(false);
+                    await Response.Body.FlushAsync(cancellationToken).ConfigureAwait(false);
+                }
+            }
+            catch (ArgumentException ex)
+            {
+                await WriteSseErrorAsync("error", ex.Message, cancellationToken).ConfigureAwait(false);
+            }
+            catch (UnauthorizedAccessException)
+            {
+                await WriteSseErrorAsync("forbidden", "You do not have permission to continue this session.", cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                await WriteSseErrorAsync("error", ex.Message, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        // GET /sessions/{id}
+        [HttpGet("{id}")]
+        public async Task<IActionResult> GetSession(string id, CancellationToken cancellationToken)
+        {
+            try
+            {
+                var session = await _managementService.GetAsync(HttpContext.User, id, cancellationToken).ConfigureAwait(false);
+                if (session == null)
+                    return NotFound();
+                return Ok(session);
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return Forbid();
+            }
+        }
+
+        // DELETE /sessions/{id}
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> DeleteSession(string id, CancellationToken cancellationToken)
+        {
+            try
+            {
+                await _managementService.DeleteAsync(HttpContext.User, id, cancellationToken).ConfigureAwait(false);
+                return NoContent();
+            }
+            catch (ArgumentException ex)
+            {
+                return BadRequest(ex.Message);
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return Forbid();
+            }
+        }
+
+        // GET /sessions
+        [HttpGet]
+        public async Task<IActionResult> ListSessions(CancellationToken cancellationToken)
+        {
+            var sessions = await _managementService.ListAsync(HttpContext.User, cancellationToken).ConfigureAwait(false);
+            return Ok(sessions);
+        }
+    }
+}

--- a/dotnet/Microsoft.McpGateway.Service/src/Program.cs
+++ b/dotnet/Microsoft.McpGateway.Service/src/Program.cs
@@ -9,6 +9,7 @@ using Microsoft.Azure.Cosmos.Fluent;
 using Microsoft.Identity.Web;
 using Microsoft.McpGateway.Management.Authorization;
 using Microsoft.McpGateway.Management.Deployment;
+using Microsoft.McpGateway.Management.Foundry;
 using Microsoft.McpGateway.Management.Service;
 using Microsoft.McpGateway.Management.Store;
 using Microsoft.McpGateway.Service.Authentication;
@@ -44,6 +45,8 @@ if (builder.Environment.IsDevelopment())
 
     builder.Services.AddSingleton<IAdapterResourceStore, RedisAdapterResourceStore>();
     builder.Services.AddSingleton<IToolResourceStore, RedisToolResourceStore>();
+    builder.Services.AddSingleton<IAgentResourceStore, InMemoryAgentResourceStore>();
+    builder.Services.AddSingleton<ISessionResourceStore, InMemorySessionResourceStore>();
 
     builder.Logging.AddConsole();
     builder.Logging.SetMinimumLevel(LogLevel.Debug);
@@ -94,6 +97,18 @@ else
         var logger = sp.GetRequiredService<ILogger<CosmosToolResourceStore>>();
         return new CosmosToolResourceStore(cosmosClient, cosmosConfig["DatabaseName"]!, "ToolContainer", logger);
     });
+
+    builder.Services.AddSingleton<IAgentResourceStore>(sp =>
+    {
+        var logger = sp.GetRequiredService<ILogger<CosmosAgentResourceStore>>();
+        return new CosmosAgentResourceStore(cosmosClient, cosmosConfig["DatabaseName"]!, "AgentContainer", logger);
+    });
+
+    builder.Services.AddSingleton<ISessionResourceStore>(sp =>
+    {
+        var logger = sp.GetRequiredService<ILogger<CosmosSessionResourceStore>>();
+        return new CosmosSessionResourceStore(cosmosClient, cosmosConfig["DatabaseName"]!, "SessionContainer", logger);
+    });
     
     builder.Services.AddCosmosCache(options =>
     {
@@ -117,7 +132,25 @@ builder.Services.AddSingleton<IAdapterDeploymentManager>(c =>
 });
 builder.Services.AddSingleton<IAdapterManagementService, AdapterManagementService>();
 builder.Services.AddSingleton<IToolManagementService, ToolManagementService>();
+builder.Services.AddSingleton<IAgentManagementService, AgentManagementService>();
+builder.Services.AddSingleton<ISessionManagementService, SessionManagementService>();
 builder.Services.AddSingleton<IAdapterRichResultProvider, AdapterRichResultProvider>();
+
+// Foundry chat client. Only registered when an endpoint is configured so that
+// dev / unit-test environments can run without it; SessionManagementService
+// gracefully leaves sessions in Pending when no client is wired up.
+var foundrySection = builder.Configuration.GetSection("FoundrySettings");
+if (!string.IsNullOrWhiteSpace(foundrySection["Endpoint"]))
+{
+    builder.Services.Configure<FoundrySettings>(foundrySection);
+    builder.Services.AddSingleton<Azure.Core.TokenCredential>(credential);
+    builder.Services.AddSingleton<IFoundryChatClient, FoundryChatClient>();
+    builder.Services.AddSingleton<BuiltinToolExecutor>();
+    builder.Services.AddSingleton<AgentToolRegistry>();
+    builder.Services.AddSingleton<AgentRunner>();
+    builder.Services.AddSingleton<Func<AgentRunner>>(sp => () => sp.GetRequiredService<AgentRunner>());
+    builder.Services.AddSingleton<SubAgentInvoker>();
+}
 
 builder.Services.AddAuthorization();
 builder.Services.AddControllers();


### PR DESCRIPTION
## Summary
Adds an opt-in agent/session subsystem on top of the existing MCP gateway:
- New `/agents` and `/sessions` REST endpoints for defining LLM agents and running them.
- Foundry-backed `AgentRunner` with MCP tool loop, multi-turn continuation, and sub-agent invocation (`agent:` prefix).
- SSE event stream (`Started`, `ToolCallRequested`, `ToolCallCompleted`, `TokenDelta`, `Completed`) for `POST /sessions/run` and `POST /sessions/{id}/messages`.
- Built-in tools (`bash`, `read_file`, `write_file`) with regex denylist, per-stream output cap, max file size, and a per-session disk quota.
- Cosmos and in-memory stores for `AgentResource` / `SessionResource`.

The feature is **disabled by default** — `IFoundryChatClient` is only registered when `FoundrySettings:Endpoint` is configured, so existing users see no behavior change.

## Preview / single-replica scope
README marks this as preview. Built-in tools run in-process; per-session state (working dir, quota counters) is pod-local. Multi-replica / multi-tenant production use needs an out-of-process sandbox and shared storage — flagged in `BuiltinToolExecutor.cs` and the README.

## Validation
- `dotnet build` clean (Release, 0 warnings).
- `dotnet test` all green (127/127: Service 9, Tools 27, Management 91).
- New deps: `Azure.AI.OpenAI 2.1.0`, `Azure.Identity 1.13.1`, `Microsoft.Extensions.Http 9.0.10`.

## Docs
README has a new "Agents and Sessions (Preview)" section covering enablement, sample requests, SSE event types, and security limits.