### PR TITLE
Fix MSRC-112281: SSRF

### DIFF
--- a/dotnet/Microsoft.McpGateway.Management/src/Service/ToolManagementService.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Service/ToolManagementService.cs
@@ -20,6 +20,13 @@ namespace Microsoft.McpGateway.Management.Service
     public class ToolManagementService : IToolManagementService
     {
         private const string NamePattern = "^[a-z0-9-]+$";
+
+        // Path may only contain a leading '/' followed by alphanumeric characters, slashes,
+        // dashes, underscores, and dots. This intentionally excludes characters that could be
+        // used to inject URI authority or query/fragment components (e.g. '@', '?', '#', ':',
+        // '\\', whitespace) when the path is later concatenated into a URL.
+        private static readonly Regex PathPattern = new(@"^/[a-zA-Z0-9/_\-\.]*$", RegexOptions.Compiled);
+
         private readonly IAdapterDeploymentManager _deploymentManager;
         private readonly IToolResourceStore _store;
         private readonly IPermissionProvider _permissionProvider;
@@ -44,6 +51,8 @@ namespace Microsoft.McpGateway.Management.Service
 
             if (!Regex.IsMatch(request.Name, NamePattern))
                 throw new ArgumentException("Name must contain only lowercase letters, numbers, and dashes.");
+
+            ValidateToolDefinition(request.ToolDefinition);
 
             var existing = await _store.TryGetAsync(request.Name, cancellationToken).ConfigureAwait(false);
             if (existing != null)
@@ -89,6 +98,8 @@ namespace Microsoft.McpGateway.Management.Service
             ArgumentNullException.ThrowIfNull(request);
 
             _logger.LogInformation("Start updating /tools/{name}.", request.Name.Sanitize());
+
+            ValidateToolDefinition(request.ToolDefinition);
 
             var existing = await _store.TryGetAsync(request.Name, cancellationToken).ConfigureAwait(false)
                 ?? throw new ArgumentException("The tool does not exist and cannot be updated.");
@@ -151,6 +162,23 @@ namespace Microsoft.McpGateway.Management.Service
             }
 
             return allowedResources;
+        }
+
+        /// <summary>
+        /// Validates the supplied <see cref="ToolDefinition"/> to ensure the port and path values
+        /// cannot be abused to perform Server-Side Request Forgery (SSRF) against cluster-internal
+        /// services. The path is constrained to a strict allowlist to prevent URI authority
+        /// injection (e.g. paths containing '@' that would otherwise reinterpret the host).
+        /// </summary>
+        private static void ValidateToolDefinition(ToolDefinition toolDefinition)
+        {
+            ArgumentNullException.ThrowIfNull(toolDefinition);
+
+            if (toolDefinition.Port < 1 || toolDefinition.Port > 65535)
+                throw new ArgumentException("Port must be between 1 and 65535.");
+
+            if (string.IsNullOrEmpty(toolDefinition.Path) || !PathPattern.IsMatch(toolDefinition.Path))
+                throw new ArgumentException("Path must start with '/' and contain only alphanumeric characters, slashes, dashes, underscores, and dots.");
         }
 
         private async Task EnsureAccessAsync(ClaimsPrincipal accessContext, ToolResource resource, Operation operation)

--- a/dotnet/Microsoft.McpGateway.Management/test/ToolManagementServiceTests.cs
+++ b/dotnet/Microsoft.McpGateway.Management/test/ToolManagementServiceTests.cs
@@ -104,6 +104,58 @@ namespace Microsoft.McpGateway.Management.Tests
                 .WithMessage("The tool with the same name already exists.");
         }
 
+        [DataTestMethod]
+        [DataRow(0)]
+        [DataRow(-1)]
+        [DataRow(65536)]
+        [DataRow(int.MaxValue)]
+        public async Task CreateAsync_ShouldThrowArgumentException_WhenPortIsOutOfRange(int port)
+        {
+            var request = CreateToolData("port-tool", "image", "v1");
+            request.ToolDefinition.Port = port;
+
+            Func<Task> act = () => _service.CreateAsync(_accessContext, request, CancellationToken.None);
+
+            await act.Should().ThrowAsync<ArgumentException>()
+                .WithMessage("Port must be between 1 and 65535.");
+            _deploymentManagerMock.Verify(x => x.CreateDeploymentAsync(It.IsAny<AdapterData>(), It.IsAny<ResourceType>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [DataTestMethod]
+        [DataRow("")]
+        [DataRow("score")]                                  // missing leading '/'
+        [DataRow("/@169.254.169.254/metadata")]             // URI authority injection attempt
+        [DataRow("/path with space")]
+        [DataRow("/path?query=1")]
+        [DataRow("/path#fragment")]
+        [DataRow("/path:8080/x")]                           // ':' could shift port interpretation
+        public async Task CreateAsync_ShouldThrowArgumentException_WhenPathIsInvalid(string path)
+        {
+            var request = CreateToolData("path-tool", "image", "v1");
+            request.ToolDefinition.Path = path;
+
+            Func<Task> act = () => _service.CreateAsync(_accessContext, request, CancellationToken.None);
+
+            await act.Should().ThrowAsync<ArgumentException>()
+                .WithMessage("Path must start with '/' and contain only alphanumeric characters, slashes, dashes, underscores, and dots.");
+            _deploymentManagerMock.Verify(x => x.CreateDeploymentAsync(It.IsAny<AdapterData>(), It.IsAny<ResourceType>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [TestMethod]
+        public async Task UpdateAsync_ShouldThrowArgumentException_WhenPathIsInvalid()
+        {
+            var existing = ToolResource.Create(CreateToolData("tool1", "image", "v1"), "user1", DateTimeOffset.UtcNow);
+            var request = CreateToolData("tool1", "image", "v1");
+            request.ToolDefinition.Path = "/@evil.example.com/";
+            _storeMock.Setup(x => x.TryGetAsync("tool1", It.IsAny<CancellationToken>())).ReturnsAsync(existing);
+
+            Func<Task> act = () => _service.UpdateAsync(_accessContext, request, CancellationToken.None);
+
+            await act.Should().ThrowAsync<ArgumentException>()
+                .WithMessage("Path must start with '/' and contain only alphanumeric characters, slashes, dashes, underscores, and dots.");
+            _deploymentManagerMock.Verify(x => x.UpdateDeploymentAsync(It.IsAny<AdapterData>(), It.IsAny<ResourceType>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
         [TestMethod]
         public async Task CreateAsync_ShouldThrowArgumentNullException_WhenAccessContextIsNull()
         {

--- a/dotnet/Microsoft.McpGateway.Service/src/Controllers/AdapterReverseProxyController.cs
+++ b/dotnet/Microsoft.McpGateway.Service/src/Controllers/AdapterReverseProxyController.cs
@@ -60,7 +60,28 @@ namespace Microsoft.McpGateway.Service.Controllers
             {
                 sessionId = AdapterSessionRoutingHandler.GetSessionId(response);
                 if (!string.IsNullOrEmpty(sessionId))
-                    await sessionStore.SetAsync(sessionId, targetAddress, cancellationToken).ConfigureAwait(false);
+                {
+                    // The session id is supplied by the downstream adapter, which is not fully
+                    // trusted. Validate its shape before persisting; a malicious adapter could
+                    // otherwise return a crafted value that pollutes another user's scoped key
+                    // or breaks routing semantics.
+                    if (!AdapterSessionRoutingHandler.IsValidSessionId(sessionId))
+                    {
+                        logger.LogWarning("Downstream adapter returned an invalid session id for adapter {adapterName}.", (name ?? ToolGateway).Sanitize());
+
+                        // Drop the invalid value from the proxied response so clients cannot
+                        // cache or replay it — there is no scoped-key entry it could ever
+                        // resolve to, and forwarding it would create a confusing handle.
+                        response.Headers.Remove("mcp-session-id");
+                    }
+                    else
+                    {
+                        // Bind the session to the authenticated user so subsequent lookups
+                        // require both the session id and the same user identity.
+                        var scopedKey = AdapterSessionRoutingHandler.BuildScopedSessionKey(HttpContext, sessionId);
+                        await sessionStore.SetAsync(scopedKey, targetAddress, cancellationToken).ConfigureAwait(false);
+                    }
+                }
             }
 
             await HttpProxy.CopyProxiedHttpResponseAsync(HttpContext, response, cancellationToken).ConfigureAwait(false);

--- a/dotnet/Microsoft.McpGateway.Service/src/Session/AdapterSessionRoutingHandler.cs
+++ b/dotnet/Microsoft.McpGateway.Service/src/Session/AdapterSessionRoutingHandler.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Text.RegularExpressions;
 using Microsoft.McpGateway.Management.Extensions;
 using Microsoft.McpGateway.Service.Routing;
 
@@ -8,6 +9,12 @@ namespace Microsoft.McpGateway.Service.Session
 {
     public class AdapterSessionRoutingHandler(IServiceNodeInfoProvider serviceNodeInfoProvider, IAdapterSessionStore sessionStore, ILogger<AdapterSessionRoutingHandler> logger) : ISessionRoutingHandler
     {
+        // Session IDs are issued by downstream adapter pods (untrusted). Constrain to a
+        // conservative character set/length to keep them safe to use as cache keys and to log,
+        // and to prevent a malicious adapter from injecting separators that would let it forge
+        // a different user's scoped session key.
+        private static readonly Regex SessionIdPattern = new(@"^[a-zA-Z0-9\-]{1,128}$", RegexOptions.Compiled);
+
         private readonly IServiceNodeInfoProvider _serviceNodeInfoProvider = serviceNodeInfoProvider ?? throw new ArgumentNullException(nameof(serviceNodeInfoProvider));
         private readonly IAdapterSessionStore _sessionStore = sessionStore ?? throw new ArgumentNullException(nameof(sessionStore));
         private readonly ILogger<AdapterSessionRoutingHandler> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -31,7 +38,20 @@ namespace Microsoft.McpGateway.Service.Session
                 throw new ArgumentException("Session id not found in the request.");
             }
 
-            var (targetAddress, exists) = await _sessionStore.TryGetAsync(sessionId, cancellationToken).ConfigureAwait(false);
+            // Reject ids that fall outside the allowlist before touching the session store.
+            // Only adapter-issued ids that previously passed IsValidSessionId on the way in
+            // can possibly match an entry, so a malformed inbound id is a fast-fail.
+            if (!IsValidSessionId(sessionId))
+            {
+                _logger.LogWarning("Rejecting malformed session id for request {path}", httpContext.Request.Path.Sanitize());
+                throw new ArgumentException("Session id is not valid, or has expired.");
+            }
+
+            // Scope the lookup to the authenticated user so a client cannot route into another
+            // user's session by supplying that user's session id.
+            var scopedKey = BuildScopedSessionKey(httpContext, sessionId);
+
+            var (targetAddress, exists) = await _sessionStore.TryGetAsync(scopedKey, cancellationToken).ConfigureAwait(false);
             if (!exists || targetAddress == null)
             {
                 _logger.LogWarning("Cannot find session id for request {path}", httpContext.Request.Path.Sanitize());
@@ -58,6 +78,38 @@ namespace Microsoft.McpGateway.Service.Session
                 return sessionId;
             }
             return string.Empty;
+        }
+
+        /// <summary>
+        /// Validates that a session id supplied by a downstream adapter has a safe shape before
+        /// it is persisted in the session store. Rejects values that contain separators or
+        /// otherwise look like an attempt to break out of the scoped key namespace.
+        /// </summary>
+        public static bool IsValidSessionId(string? sessionId) =>
+            !string.IsNullOrEmpty(sessionId) && SessionIdPattern.IsMatch(sessionId);
+
+        /// <summary>
+        /// Computes the session store key used for a given (user, session id) pair. Binding the
+        /// session id to the authenticated user's id prevents cross-tenant session hijacking
+        /// even when an attacker can observe or guess another user's raw session id.
+        /// </summary>
+        /// <exception cref="UnauthorizedAccessException">
+        /// Thrown when the request has no authenticated user id. Endpoints that use the session
+        /// store are expected to be guarded by <c>[Authorize]</c>; missing identity here means
+        /// the request must be rejected rather than silently routed.
+        /// </exception>
+        public static string BuildScopedSessionKey(HttpContext httpContext, string sessionId)
+        {
+            ArgumentNullException.ThrowIfNull(httpContext);
+            ArgumentException.ThrowIfNullOrEmpty(sessionId);
+
+            var userId = httpContext.User?.GetUserId();
+            if (string.IsNullOrWhiteSpace(userId))
+            {
+                throw new UnauthorizedAccessException("Authenticated user is required to access a session.");
+            }
+
+            return $"{userId}:{sessionId}";
         }
     }
 }

--- a/dotnet/Microsoft.McpGateway.Service/test/AdapterSessionRoutingHandlerTests.cs
+++ b/dotnet/Microsoft.McpGateway.Service/test/AdapterSessionRoutingHandlerTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Security.Claims;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -13,6 +14,8 @@ namespace Microsoft.McpGateway.Service.Tests
     [TestClass]
     public class AdapterSessionRoutingHandlerTests
     {
+        private const string TestUserId = "user-1";
+
         private readonly Mock<IServiceNodeInfoProvider> _serviceNodeInfoProviderMock;
         private readonly Mock<IAdapterSessionStore> _sessionStoreMock;
         private readonly AdapterSessionRoutingHandler _handler;
@@ -24,11 +27,22 @@ namespace Microsoft.McpGateway.Service.Tests
             _handler = new AdapterSessionRoutingHandler(_serviceNodeInfoProviderMock.Object, _sessionStoreMock.Object, NullLogger<AdapterSessionRoutingHandler>.Instance);
         }
 
+        private static DefaultHttpContext CreateAuthenticatedContext(string userId = TestUserId)
+        {
+            var context = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(new ClaimsIdentity(
+                    [new Claim(ClaimTypes.NameIdentifier, userId)],
+                    authenticationType: "Test"))
+            };
+            return context;
+        }
+
         [TestMethod]
         public async Task GetNewSessionTargetAsync_ReturnsTargetAddress()
         {
             var adapterName = "adapter";
-            var httpContext = new DefaultHttpContext();
+            var httpContext = CreateAuthenticatedContext();
             var cancellationToken = CancellationToken.None;
             var nodeAddresses = new Dictionary<string, string>
             {
@@ -48,13 +62,14 @@ namespace Microsoft.McpGateway.Service.Tests
         [TestMethod]
         public async Task GetExistingSessionTargetAsync_WithValidSessionId_ReturnsTargetAddress()
         {
-            var httpContext = new DefaultHttpContext();
+            var httpContext = CreateAuthenticatedContext();
             var sessionId = "abc123";
+            var scopedKey = $"{TestUserId}:{sessionId}";
             var cancellationToken = CancellationToken.None;
             httpContext.Request.QueryString = new QueryString("?session_id=" + sessionId);
 
             _sessionStoreMock
-                .Setup(x => x.TryGetAsync(sessionId, cancellationToken))
+                .Setup(x => x.TryGetAsync(scopedKey, cancellationToken))
                 .ReturnsAsync(("http://target", true));
 
             var result = await _handler.GetExistingSessionTargetAsync(httpContext, cancellationToken);
@@ -65,7 +80,7 @@ namespace Microsoft.McpGateway.Service.Tests
         [TestMethod]
         public async Task GetExistingSessionTargetAsync_WithMissingSessionId_ThrowsArgumentException()
         {
-            var httpContext = new DefaultHttpContext();
+            var httpContext = CreateAuthenticatedContext();
             var cancellationToken = CancellationToken.None;
 
             Func<Task> act = () => _handler.GetExistingSessionTargetAsync(httpContext, cancellationToken);
@@ -75,21 +90,137 @@ namespace Microsoft.McpGateway.Service.Tests
         }
 
         [TestMethod]
-        public async Task GetExistingSessionTargetAsync_WithInvalidSessionId_ThrowsArgumentException()
+        public async Task GetExistingSessionTargetAsync_WithUnknownSessionId_ThrowsArgumentException()
         {
-            var httpContext = new DefaultHttpContext();
-            var sessionId = "invalid";
+            // "unknown" passes IsValidSessionId; the failure is a cache miss on the scoped key,
+            // which represents an expired or never-issued session.
+            var httpContext = CreateAuthenticatedContext();
+            var sessionId = "unknown";
+            var scopedKey = $"{TestUserId}:{sessionId}";
             var cancellationToken = CancellationToken.None;
             httpContext.Request.QueryString = new QueryString("?session_id=" + sessionId);
 
             _sessionStoreMock
-                .Setup(x => x.TryGetAsync(sessionId, cancellationToken))
+                .Setup(x => x.TryGetAsync(scopedKey, cancellationToken))
                 .ReturnsAsync((null, false));
 
             Func<Task> act = () => _handler.GetExistingSessionTargetAsync(httpContext, cancellationToken);
 
             await act.Should().ThrowAsync<ArgumentException>()
                 .WithMessage("Session id is not valid, or has expired.");
+        }
+
+        [DataTestMethod]
+        [DataRow("bad:id")]
+        [DataRow("bad/id")]
+        [DataRow("..")]
+        [DataRow("evil@host")]
+        [DataRow("has space")]
+        public async Task GetExistingSessionTargetAsync_WithMalformedSessionId_FastFailsWithoutCacheLookup(string sessionId)
+        {
+            var httpContext = CreateAuthenticatedContext();
+            var cancellationToken = CancellationToken.None;
+            httpContext.Request.Headers["mcp-session-id"] = sessionId;
+
+            Func<Task> act = () => _handler.GetExistingSessionTargetAsync(httpContext, cancellationToken);
+
+            await act.Should().ThrowAsync<ArgumentException>()
+                .WithMessage("Session id is not valid, or has expired.");
+
+            _sessionStoreMock.Verify(
+                x => x.TryGetAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        [TestMethod]
+        public async Task GetExistingSessionTargetAsync_DoesNotLookUpUnscopedKey()
+        {
+            // A request from User B carrying User A's raw session id must NOT resolve to User A's
+            // routing target — the lookup is performed under User B's scoped key.
+            var httpContext = CreateAuthenticatedContext("user-B");
+            var victimSessionId = "victim-session-id";
+            var cancellationToken = CancellationToken.None;
+            httpContext.Request.Headers["mcp-session-id"] = victimSessionId;
+
+            // Simulate the victim's mapping still being present under the victim's scoped key.
+            _sessionStoreMock
+                .Setup(x => x.TryGetAsync($"user-A:{victimSessionId}", cancellationToken))
+                .ReturnsAsync(("http://victim-pod", true));
+            _sessionStoreMock
+                .Setup(x => x.TryGetAsync($"user-B:{victimSessionId}", cancellationToken))
+                .ReturnsAsync((null, false));
+
+            Func<Task> act = () => _handler.GetExistingSessionTargetAsync(httpContext, cancellationToken);
+
+            await act.Should().ThrowAsync<ArgumentException>()
+                .WithMessage("Session id is not valid, or has expired.");
+            _sessionStoreMock.Verify(x => x.TryGetAsync(victimSessionId, cancellationToken), Times.Never);
+        }
+
+        [TestMethod]
+        public async Task GetExistingSessionTargetAsync_WithoutAuthenticatedUser_ThrowsUnauthorized()
+        {
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.Headers["mcp-session-id"] = "abc123";
+
+            Func<Task> act = () => _handler.GetExistingSessionTargetAsync(httpContext, CancellationToken.None);
+
+            await act.Should().ThrowAsync<UnauthorizedAccessException>();
+        }
+
+        [TestMethod]
+        public void BuildScopedSessionKey_ProducesUserScopedKey()
+        {
+            var httpContext = CreateAuthenticatedContext("alice");
+
+            var key = AdapterSessionRoutingHandler.BuildScopedSessionKey(httpContext, "sess-1");
+
+            key.Should().Be("alice:sess-1");
+        }
+
+        [TestMethod]
+        public void BuildScopedSessionKey_WithoutUserId_Throws()
+        {
+            var httpContext = new DefaultHttpContext();
+
+            Action act = () => AdapterSessionRoutingHandler.BuildScopedSessionKey(httpContext, "sess-1");
+
+            act.Should().Throw<UnauthorizedAccessException>();
+        }
+
+        [DataTestMethod]
+        [DataRow("abc123")]
+        [DataRow("550e8400-e29b-41d4-a716-446655440000")]
+        [DataRow("A-B-C-1-2-3")]
+        public void IsValidSessionId_AcceptsWellFormedValues(string sessionId)
+        {
+            AdapterSessionRoutingHandler.IsValidSessionId(sessionId).Should().BeTrue();
+        }
+
+        [DataTestMethod]
+        [DataRow("")]
+        [DataRow("contains space")]
+        [DataRow("with:colon")]
+        [DataRow("with/slash")]
+        [DataRow("with..dot")]
+        [DataRow("with@at")]
+        public void IsValidSessionId_RejectsUnsafeValues(string sessionId)
+        {
+            AdapterSessionRoutingHandler.IsValidSessionId(sessionId).Should().BeFalse();
+        }
+
+        [TestMethod]
+        public void IsValidSessionId_RejectsNull()
+        {
+            AdapterSessionRoutingHandler.IsValidSessionId(null).Should().BeFalse();
+        }
+
+        [TestMethod]
+        public void IsValidSessionId_RejectsOverlyLongValues()
+        {
+            var tooLong = new string('a', 129);
+
+            AdapterSessionRoutingHandler.IsValidSessionId(tooLong).Should().BeFalse();
         }
     }
 }

--- a/dotnet/Microsoft.McpGateway.Tools/src/Services/HttpToolExecutor.cs
+++ b/dotnet/Microsoft.McpGateway.Tools/src/Services/HttpToolExecutor.cs
@@ -85,9 +85,18 @@ namespace Microsoft.McpGateway.Tools.Services
                 // Refresh provider cache for subsequent list requests
                 _ = await this.toolDefinitionProvider.GetToolDefinitionAsync(toolName, cancellationToken).ConfigureAwait(false);
 
-                // Compose the execution endpoint URL
-                // Format: http://{toolName}-service.adapter.svc.cluster.local:{port}{path}
-                var executionEndpoint = $"http://{toolName}-service.adapter.svc.cluster.local:{toolDefinition.Port}{toolDefinition.Path}";
+                // Compose the execution endpoint URL using UriBuilder. Building the URI from
+                // discrete components (rather than string-interpolating the configured path)
+                // prevents URI authority injection — e.g. a path beginning with "@" cannot be
+                // reinterpreted as user-info that overrides the cluster-internal host. The path
+                // is additionally validated at registration time in ToolManagementService.
+                var host = $"{toolName}-service.adapter.svc.cluster.local";
+                var uriBuilder = new UriBuilder(
+                    Uri.UriSchemeHttp,
+                    host,
+                    toolDefinition.Port,
+                    toolDefinition.Path ?? "/");
+                var executionEndpoint = uriBuilder.Uri;
 
                 this.logger.LogInformation(
                     "Forwarding tool {ToolName} to endpoint: {Endpoint}",


### PR DESCRIPTION
* Tool registration (POST/PUT /tools): validate ToolDefinition.Port (1-65535) and ToolDefinition.Path against a strict allowlist (^/[a-zA-Z0-9/_\-\.]*$), preventing URI authority/query/fragment injection.
* Tool execution (HttpToolExecutor): build the downstream endpoint URL with UriBuilder from discrete host/port/path components instead of string interpolation. The cluster-internal host stays pinned even if a malicious record were to bypass the registration validator.
* Adapter session routing: scope every session-store key with the authenticated user id (BuildScopedSessionKey -> "userId:sessionId") and reject untrusted adapter-supplied session ids that fall outside ^[a-zA-Z0-9\-]{1,128}$ (IsValidSessionId). A second user replaying another user's mcp-session-id now misses the scoped key instead of being routed into the original user's pod.

Adds new unit tests for each guard (port range, path allowlist on Create and Update, scoped-key lookup, IsValidSessionId/BuildScopedSessionKey edge cases) and a runtime validation script + evidence report under docs/security/ that reproduces the fixes against the local kind cluster.