### PR TITLE
React management UX

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -31,6 +31,11 @@ jobs:
       with:
         dotnet-version: '8.x'
 
+    - name: Setup Node.js (for the management portal)
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+
     - name: Restore dependencies
       run: dotnet restore dotnet/Microsoft.McpGateway.sln --runtime linux-x64
 

--- a/.gitignore
+++ b/.gitignore
@@ -398,3 +398,9 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+
+# MCP Gateway portal (built SPA assets)
+dotnet/Microsoft.McpGateway.Service/src/wwwroot/portal/
+portal/dist/
+portal/node_modules/
+portal/*.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -172,6 +172,13 @@ For step-by-step guidance on configuring Azure Entra ID (creating `mcp.admin` an
 - Support for **Proxying Local & Remote MCP Servers**. See [examples and usage](sample-servers/mcp-proxy/README.md).
 - Stateless reverse proxy with a distributed session store (production mode).
 - Kubernetes-native deployment using StatefulSets and headless services.
+- **Management portal** (React SPA) served by the gateway itself at
+  [`/portal/`](portal/README.md) — list / create / edit / delete adapters and
+  tools, inspect status and pod logs, and exercise each MCP server with an
+  in-browser JSON-RPC test console. Authentication mirrors the API: anonymous
+  in dev mode (with an optional dev-identity switcher) and MSAL / Entra ID in
+  cloud mode, so every list call already filters down to the resources the
+  signed-in user is allowed to see.
 
 ### Tool Registration and Dynamic Routing
 

--- a/dotnet/Microsoft.McpGateway.Service/src/Controllers/ManagementController.cs
+++ b/dotnet/Microsoft.McpGateway.Service/src/Controllers/ManagementController.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using k8s.Autorest;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.McpGateway.Management.Contracts;
@@ -82,6 +83,14 @@ namespace Microsoft.McpGateway.Service.Controllers
             catch (UnauthorizedAccessException)
             {
                 return Forbid();
+            }
+            // The k8s API returns 400 BadRequest while the pod is still ContainerCreating
+            // or before the container has produced any output. Surface that as a 200 with
+            // a placeholder string so the portal log panel can render gracefully instead
+            // of bubbling a 500 up to the user immediately after creating an adapter.
+            catch (HttpOperationException ex) when (ex.Response?.StatusCode == System.Net.HttpStatusCode.BadRequest)
+            {
+                return Ok($"Logs are not yet available for instance {instance} (pod is starting). Try again in a few seconds.");
             }
         }
 

--- a/dotnet/Microsoft.McpGateway.Service/src/Controllers/PortalConfigController.cs
+++ b/dotnet/Microsoft.McpGateway.Service/src/Controllers/PortalConfigController.cs
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.McpGateway.Service.Controllers
+{
+    /// <summary>
+    /// Serves the runtime configuration consumed by the management portal SPA.
+    /// The portal calls this endpoint once on startup to decide whether to
+    /// initialize MSAL (cloud mode) or fall back to the local development
+    /// authentication handler.
+    ///
+    /// The endpoint is intentionally anonymous and only returns information
+    /// that is also required to authenticate to the gateway (tenant id, client
+    /// id, public origin). It never exposes secrets.
+    /// </summary>
+    [ApiController]
+    [Route("portal/config")]
+    [AllowAnonymous]
+    public sealed class PortalConfigController(
+        IWebHostEnvironment environment,
+        IConfiguration configuration,
+        ILogger<PortalConfigController> logger) : ControllerBase
+    {
+        private readonly IWebHostEnvironment _environment = environment;
+        private readonly IConfiguration _configuration = configuration;
+        private readonly ILogger<PortalConfigController> _logger = logger;
+
+        // GET /portal/config
+        [HttpGet]
+        public IActionResult GetConfig()
+        {
+            try
+            {
+                // Treat the env-driven bypass the same as the Development
+                // environment: the SPA skips MSAL and sends X-Dev-* headers
+                // that the server's DevelopmentAuthenticationHandler reads.
+                var bypassEntra = _configuration.GetValue<bool>("Authentication:BypassEntra");
+                var isDevelopment = _environment.IsDevelopment() || bypassEntra;
+
+                var azureAdSection = _configuration.GetSection("AzureAd");
+                var tenantId = azureAdSection["TenantId"];
+                var clientId = azureAdSection["ClientId"];
+                var hasAzureAd = !isDevelopment
+                    && !string.IsNullOrWhiteSpace(tenantId)
+                    && !string.IsNullOrWhiteSpace(clientId)
+                    // Don't leak the placeholder values shipped in appsettings.json.
+                    && !string.Equals(tenantId, "YOUR_TENANT_ID", StringComparison.Ordinal)
+                    && !string.Equals(clientId, "YOUR_API_CLIENT_ID", StringComparison.Ordinal);
+
+                var publicOrigin = _configuration.GetValue<string>("PublicOrigin");
+                if (string.IsNullOrWhiteSpace(publicOrigin))
+                {
+                    // Fall back to the host/scheme observed on this request so
+                    // the SPA can still build redirect URIs in dev or in any
+                    // setup that forgot to set PublicOrigin.
+                    publicOrigin = $"{Request.Scheme}://{Request.Host.Value}";
+                }
+
+                var agentsEnabled = !string.IsNullOrWhiteSpace(_configuration["FoundrySettings:Endpoint"]);
+
+                PortalAzureAd? azureAd = null;
+                if (hasAzureAd)
+                {
+                    azureAd = new PortalAzureAd(
+                        tenantId!,
+                        clientId!,
+                        new[] { $"api://{clientId}/.default" });
+                }
+
+                var payload = new PortalConfigResponse(
+                    isDevelopment,
+                    publicOrigin,
+                    agentsEnabled,
+                    azureAd);
+
+                return Ok(payload);
+            }
+            catch (Exception ex)
+            {
+                // Surface the real reason in the body so an operator looking
+                // at "Failed to load portal config (500 ...)" in the SPA gets
+                // an actionable hint instead of a blank wall.
+                _logger.LogError(ex, "Failed to build portal runtime config.");
+                return Problem(
+                    detail: ex.Message,
+                    title: "Portal configuration failed",
+                    statusCode: StatusCodes.Status500InternalServerError);
+            }
+        }
+
+        private sealed record PortalConfigResponse(
+            bool IsDevelopment,
+            string PublicOrigin,
+            bool AgentsEnabled,
+            PortalAzureAd? AzureAd);
+
+        private sealed record PortalAzureAd(
+            string TenantId,
+            string ClientId,
+            IReadOnlyList<string> Scopes);
+    }
+}

--- a/dotnet/Microsoft.McpGateway.Service/src/Microsoft.McpGateway.Service.csproj
+++ b/dotnet/Microsoft.McpGateway.Service/src/Microsoft.McpGateway.Service.csproj
@@ -32,13 +32,27 @@
     part of `dotnet publish` so the container image always contains the
     latest assets. `dotnet build` skips the npm step to keep developer
     inner-loops fast; set `/p:BuildPortal=true` to force a rebuild there.
+
+    The Vite output lands under wwwroot/portal *after* the SDK's default
+    `Content` glob has already been evaluated, so on a clean checkout those
+    files would not otherwise be part of the publish/container output. We
+    therefore add the generated assets to `ResolvedFileToPublish` explicitly
+    and run before `ComputeFilesToPublish` so the manifest picks them up.
   -->
   <Target Name="BuildManagementPortal"
-          BeforeTargets="PrepareForPublish"
+          BeforeTargets="ComputeFilesToPublish"
           Condition="'$(BuildPortal)' == 'true' AND Exists('$(PortalSourceDir)package.json')">
     <Message Importance="high" Text="Building MCP Gateway portal from $(PortalSourceDir)" />
     <Exec Command="npm ci --prefer-offline --no-audit --no-fund" WorkingDirectory="$(PortalSourceDir)" />
     <Exec Command="npm run build" WorkingDirectory="$(PortalSourceDir)" />
+
+    <ItemGroup>
+      <_PortalPublishFiles Include="$(PortalOutputDir)**\*" />
+      <ResolvedFileToPublish Include="@(_PortalPublishFiles)">
+        <RelativePath>wwwroot\portal\%(RecursiveDir)%(Filename)%(Extension)</RelativePath>
+        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+      </ResolvedFileToPublish>
+    </ItemGroup>
   </Target>
 
 </Project>

--- a/dotnet/Microsoft.McpGateway.Service/src/Microsoft.McpGateway.Service.csproj
+++ b/dotnet/Microsoft.McpGateway.Service/src/Microsoft.McpGateway.Service.csproj
@@ -5,6 +5,13 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <Platforms>x64</Platforms>
+    <!--
+      Set BuildPortal=false to skip the npm build (useful for incremental
+      backend-only dev loops). The container image build always includes it.
+    -->
+    <BuildPortal Condition="'$(BuildPortal)' == ''">true</BuildPortal>
+    <PortalSourceDir>$(MSBuildThisFileDirectory)..\..\..\portal\</PortalSourceDir>
+    <PortalOutputDir>$(MSBuildThisFileDirectory)wwwroot\portal\</PortalOutputDir>
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,4 +27,19 @@
     <ProjectReference Include="..\..\Microsoft.McpGateway.Management\src\Microsoft.McpGateway.Management.csproj" />
   </ItemGroup>
 
+  <!--
+    The portal SPA is built (npm ci + npm run build) into wwwroot/portal as
+    part of `dotnet publish` so the container image always contains the
+    latest assets. `dotnet build` skips the npm step to keep developer
+    inner-loops fast; set `/p:BuildPortal=true` to force a rebuild there.
+  -->
+  <Target Name="BuildManagementPortal"
+          BeforeTargets="PrepareForPublish"
+          Condition="'$(BuildPortal)' == 'true' AND Exists('$(PortalSourceDir)package.json')">
+    <Message Importance="high" Text="Building MCP Gateway portal from $(PortalSourceDir)" />
+    <Exec Command="npm ci --prefer-offline --no-audit --no-fund" WorkingDirectory="$(PortalSourceDir)" />
+    <Exec Command="npm run build" WorkingDirectory="$(PortalSourceDir)" />
+  </Target>
+
 </Project>
+

--- a/dotnet/Microsoft.McpGateway.Service/src/Program.cs
+++ b/dotnet/Microsoft.McpGateway.Service/src/Program.cs
@@ -30,21 +30,62 @@ builder.Services.AddSingleton<IAdapterSessionStore, DistributedMemorySessionStor
 builder.Services.AddSingleton<IServiceNodeInfoProvider, AdapterKubernetesNodeInfoProvider>();
 builder.Services.AddSingleton<ISessionRoutingHandler, AdapterSessionRoutingHandler>();
 
-if (builder.Environment.IsDevelopment())
+// Operators can opt out of Entra ID and run the gateway with the dev auth
+// handler (X-Dev-* headers) by setting `Authentication__BypassEntra=true`
+// in the pod's environment. This is intended for restricted demo / e2e
+// clusters that aren't reachable from the public internet. Always-on in
+// Development as before.
+var bypassEntra = builder.Configuration.GetValue<bool>("Authentication:BypassEntra");
+var useDevAuth = builder.Environment.IsDevelopment() || bypassEntra;
+
+if (useDevAuth)
 {
+    if (bypassEntra && !builder.Environment.IsDevelopment())
+    {
+        Console.WriteLine("[auth] Authentication:BypassEntra=true; using Development auth scheme (X-Dev-* headers). Do NOT enable this on internet-facing deployments.");
+    }
+
     builder.Services
         .AddAuthentication(DevelopmentAuthenticationHandler.SchemeName)
         .AddScheme<AuthenticationSchemeOptions, DevelopmentAuthenticationHandler>(DevelopmentAuthenticationHandler.SchemeName, null);
+}
 
+if (builder.Environment.IsDevelopment())
+{
+
+    // The shipped appsettings.Development.json points Redis at the in-cluster
+    // `redis-service` hostname so the same image works inside the local
+    // kind/k3s deployment, but a vanilla `dotnet run` on a laptop has no
+    // Redis. Probe the configured endpoint with a short timeout: if it's
+    // reachable, use the Redis-backed stores; otherwise transparently fall
+    // back to in-memory so the gateway and management portal still work.
+    //
+    // The probe only runs in Development; production / cloud always uses
+    // Cosmos and never goes through this branch.
     var redisConnection = builder.Configuration.GetValue<string>("Redis:ConnectionString") ?? "localhost:6379";
-    builder.Services.AddStackExchangeRedisCache(options =>
-    {
-        options.Configuration = redisConnection;
-        options.InstanceName = "mcpgateway:";
-    });
+    var useInMemoryStoresSetting = builder.Configuration.GetValue<bool?>("Storage:UseInMemoryStores");
+    var useInMemoryStores = useInMemoryStoresSetting ?? !TryProbeRedis(redisConnection);
 
-    builder.Services.AddSingleton<IAdapterResourceStore, RedisAdapterResourceStore>();
-    builder.Services.AddSingleton<IToolResourceStore, RedisToolResourceStore>();
+    if (useInMemoryStores)
+    {
+        Console.WriteLine($"[dev] Redis at '{redisConnection}' unavailable or disabled; using in-memory stores.");
+        builder.Services.AddDistributedMemoryCache();
+        builder.Services.AddSingleton<IAdapterResourceStore, InMemoryAdapterResourceStore>();
+        builder.Services.AddSingleton<IToolResourceStore, InMemoryToolResourceStore>();
+    }
+    else
+    {
+        Console.WriteLine($"[dev] Using Redis at '{redisConnection}' for adapter/tool stores.");
+        builder.Services.AddStackExchangeRedisCache(options =>
+        {
+            options.Configuration = redisConnection;
+            options.InstanceName = "mcpgateway:";
+        });
+
+        builder.Services.AddSingleton<IAdapterResourceStore, RedisAdapterResourceStore>();
+        builder.Services.AddSingleton<IToolResourceStore, RedisToolResourceStore>();
+    }
+
     builder.Services.AddSingleton<IAgentResourceStore, InMemoryAgentResourceStore>();
     builder.Services.AddSingleton<ISessionResourceStore, InMemorySessionResourceStore>();
 
@@ -53,25 +94,28 @@ if (builder.Environment.IsDevelopment())
 }
 else
 {
-    var azureAdConfig = builder.Configuration.GetSection("AzureAd");
-    builder.Services.AddAuthentication(options =>
+    if (!useDevAuth)
     {
-        options.DefaultChallengeScheme = McpAuthenticationDefaults.AuthenticationScheme;
-        options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
-    })
-    .AddScheme<McpAuthenticationOptions, McpSubPathAwareAuthenticationHandler>(
-        McpAuthenticationDefaults.AuthenticationScheme,
-        McpAuthenticationDefaults.DisplayName,
-    options =>
-    {
-        options.ResourceMetadata = new()
+        var azureAdConfig = builder.Configuration.GetSection("AzureAd");
+        builder.Services.AddAuthentication(options =>
         {
-            Resource = new Uri(builder.Configuration.GetValue<string>("PublicOrigin")!),
-            AuthorizationServers = { new Uri($"https://login.microsoftonline.com/{azureAdConfig["TenantId"]}/v2.0") },
-            ScopesSupported = [$"api://{azureAdConfig["ClientId"]}/.default"]
-        };
-    })
-    .AddMicrosoftIdentityWebApi(azureAdConfig);
+            options.DefaultChallengeScheme = McpAuthenticationDefaults.AuthenticationScheme;
+            options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+        })
+        .AddScheme<McpAuthenticationOptions, McpSubPathAwareAuthenticationHandler>(
+            McpAuthenticationDefaults.AuthenticationScheme,
+            McpAuthenticationDefaults.DisplayName,
+        options =>
+        {
+            options.ResourceMetadata = new()
+            {
+                Resource = new Uri(builder.Configuration.GetValue<string>("PublicOrigin")!),
+                AuthorizationServers = { new Uri($"https://login.microsoftonline.com/{azureAdConfig["TenantId"]}/v2.0") },
+                ScopesSupported = [$"api://{azureAdConfig["ClientId"]}/.default"]
+            };
+        })
+        .AddMicrosoftIdentityWebApi(azureAdConfig);
+    }
 
     // Create CosmosClient with credential-based authentication
     var cosmosConfig = builder.Configuration.GetSection("CosmosSettings");
@@ -163,8 +207,52 @@ builder.WebHost.ConfigureKestrel(options =>
 
 var app = builder.Build();
 
+// Serve the management portal SPA out of wwwroot/portal. Static files are
+// mapped before authentication so the HTML shell, JS bundle and runtime
+// config endpoint are reachable anonymously; the SPA acquires its own
+// access token via MSAL once it loads.
+app.UseStaticFiles();
+
 // Configure the HTTP request pipeline.
 app.UseAuthentication();
 app.UseAuthorization();
+
+// Land users on the portal when they visit the gateway in a browser. The
+// redirect is attributed AllowAnonymous so the unauthenticated case still
+// reaches the SPA shell instead of the 401 challenge handler.
+app.MapGet("/", () => Results.Redirect("/portal/", permanent: false))
+    .AllowAnonymous();
+
 app.MapControllers();
+
+// Any /portal/* path that didn't match a physical file or controller route
+// is treated as a SPA route and served the portal shell. The `nonfile`
+// constraint keeps requests for hashed asset bundles flowing through the
+// static-file middleware instead. Constrained to /portal/* so requests like
+// `GET /adapters/foo` continue to hit the API controllers untouched.
+app.MapFallbackToFile("/portal", "portal/index.html").AllowAnonymous();
+app.MapFallbackToFile("/portal/{*path:nonfile}", "portal/index.html")
+    .AllowAnonymous();
 await app.RunAsync();
+
+// Best-effort check that a configured Redis is reachable. Only used by the
+// Development-mode store registration above so a developer running
+// `dotnet run` on a laptop transparently falls back to in-memory stores
+// instead of failing every /adapters and /tools call with a Redis timeout.
+static bool TryProbeRedis(string connectionString)
+{
+    try
+    {
+        var options = StackExchange.Redis.ConfigurationOptions.Parse(connectionString);
+        options.AbortOnConnectFail = false;
+        options.ConnectTimeout = 2000;
+        options.SyncTimeout = 2000;
+        options.ConnectRetry = 1;
+        using var muxer = StackExchange.Redis.ConnectionMultiplexer.Connect(options);
+        return muxer.IsConnected;
+    }
+    catch
+    {
+        return false;
+    }
+}

--- a/portal/README.md
+++ b/portal/README.md
@@ -1,0 +1,91 @@
+# MCP Gateway Portal
+
+A React + TypeScript single-page application that lets operators manage the
+lifecycle of MCP servers (adapters and tools) registered with the MCP Gateway,
+inspect their status and logs, and test their connections directly from the
+browser.
+
+## Architecture
+
+- The portal is a standard Vite + React SPA written in TypeScript and styled
+  with Fluent UI v9.
+- In production the bundle is built into
+  `dotnet/Microsoft.McpGateway.Service/src/wwwroot/` and served by the gateway
+  itself, so the SPA and the API share a single origin and no CORS rules are
+  needed.
+- At startup the portal loads `GET /portal/config` (anonymous) to learn whether
+  the gateway is running in development or cloud mode and, in cloud mode, which
+  Entra ID tenant and audience to authenticate against. The same endpoint
+  returns its self-identifying `publicOrigin` so the SPA can construct MCP
+  endpoint URLs that work from anywhere it's hosted.
+
+## Authentication
+
+- **Local / dev mode** — the gateway runs the `DevelopmentAuthenticationHandler`
+  which mints a `dev` principal for unauthenticated requests. The portal
+  detects `isDevelopment: true` from `/portal/config` and skips MSAL; the user
+  can optionally pick a synthetic identity (user id, display name, roles) that
+  is forwarded via `X-Dev-UserId`, `X-Dev-Name`, and `X-Dev-Roles` headers so
+  RBAC paths can be exercised end to end.
+- **Cloud / production mode** — the portal initializes
+  [`@azure/msal-browser`](https://www.npmjs.com/package/@azure/msal-browser)
+  with the tenant/client id from `/portal/config`, signs the user in via the
+  redirect flow, and acquires an access token with the
+  `api://<clientId>/.default` scope. Every API call attaches that token as a
+  `Bearer` header. Server-side filtering already limits responses to resources
+  the principal is allowed to see, so no client-side filtering is required.
+
+## Running locally
+
+```bash
+# from the repo root, after deploying the gateway to localhost:8000
+cd portal
+npm install
+npm run dev
+```
+
+Then open <http://localhost:5173>. Vite proxies `/adapters`, `/tools`,
+`/agents`, `/sessions`, `/mcp`, `/portal/config`, and `/ping` to
+`http://localhost:8000` so the SPA shares an origin with the gateway. Override
+the target with `VITE_GATEWAY_URL=http://example:8000 npm run dev`.
+
+### Gateway storage in dev mode
+
+When `ASPNETCORE_ENVIRONMENT=Development` the gateway probes the configured
+Redis at startup (default `redis-service:6379` from
+`appsettings.Development.json`, which only resolves inside the k8s deployment).
+If the connection succeeds the Redis-backed adapter and tool stores are used
+exactly as in the k8s local deployment; if it fails — for example a vanilla
+`dotnet run` on a laptop — the gateway transparently falls back to in-memory
+stores so the management portal works without any external dependencies. Force
+either path by setting `Storage:UseInMemoryStores=true|false` (env var or
+appsettings override).
+
+## Building for production
+
+```bash
+cd portal
+npm install
+npm run build
+```
+
+The output lands in `dotnet/Microsoft.McpGateway.Service/src/wwwroot/`. The
+service's csproj invokes the same commands automatically during
+`dotnet publish`, so the container image produced by the existing GitHub
+Actions workflow already includes the portal.
+
+## Layout
+
+| Path                                  | Purpose                                                   |
+| ------------------------------------- | --------------------------------------------------------- |
+| `src/main.tsx`                        | App entrypoint, Fluent UI provider, MSAL bootstrap        |
+| `src/auth/`                           | Runtime config loader + MSAL helpers + dev identity store |
+| `src/api/`                            | Typed fetch client mirroring the gateway contracts        |
+| `src/pages/AdaptersPage.tsx`          | List / search MCP adapters                                |
+| `src/pages/AdapterDetailPage.tsx`     | View metadata, status, logs; embeds the MCP test panel    |
+| `src/pages/AdapterCreatePage.tsx`     | Form for creating or editing adapters                     |
+| `src/pages/ToolsPage.tsx`             | List / search registered tools                            |
+| `src/pages/ToolDetailPage.tsx`        | View metadata, status, logs, tool definition              |
+| `src/pages/ToolCreatePage.tsx`        | Form for creating or editing tools                        |
+| `src/components/McpTestPanel.tsx`     | JSON-RPC test console (`initialize`, `tools/list`, …)     |
+| `src/components/Layout.tsx`           | Top bar, sign-in state, dev-identity switcher             |

--- a/portal/README.md
+++ b/portal/README.md
@@ -44,8 +44,9 @@ npm install
 npm run dev
 ```
 
-Then open <http://localhost:5173>. Vite proxies `/adapters`, `/tools`,
-`/agents`, `/sessions`, `/mcp`, `/portal/config`, and `/ping` to
+Then open <http://localhost:5173/portal/> (the app uses a `/portal` router
+basename, so the root path renders a blank page). Vite proxies `/adapters`,
+`/tools`, `/agents`, `/sessions`, `/mcp`, `/portal/config`, and `/ping` to
 `http://localhost:8000` so the SPA shares an origin with the gateway. Override
 the target with `VITE_GATEWAY_URL=http://example:8000 npm run dev`.
 

--- a/portal/index.html
+++ b/portal/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex" />
+    <title>MCP Gateway Portal</title>
+    <link rel="icon" href="data:," />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/portal/package-lock.json
+++ b/portal/package-lock.json
@@ -1,0 +1,3592 @@
+{
+  "name": "mcp-gateway-portal",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mcp-gateway-portal",
+      "version": "0.1.0",
+      "dependencies": {
+        "@azure/msal-browser": "^3.27.0",
+        "@azure/msal-react": "^2.2.0",
+        "@fluentui/react-components": "^9.55.1",
+        "@fluentui/react-icons": "^2.0.260",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^6.28.0"
+      },
+      "devDependencies": {
+        "@types/node": "^20.19.41",
+        "@types/react": "^18.3.12",
+        "@types/react-dom": "^18.3.1",
+        "@vitejs/plugin-react": "^4.3.3",
+        "typescript": "^5.6.3",
+        "vite": "^5.4.10"
+      }
+    },
+    "node_modules/@azure/msal-browser": {
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-3.30.0.tgz",
+      "integrity": "sha512-I0XlIGVdM4E9kYP5eTjgW8fgATdzwxJvQ6bm2PNiHaZhEuUz47NYw1xHthC9R+lXz4i9zbShS0VdLyxd7n0GGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "14.16.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-common": {
+      "version": "14.16.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.16.1.tgz",
+      "integrity": "sha512-nyxsA6NA4SVKh5YyRpbSXiMr7oQbwark7JU9LMeg6tJYTSPyAGkdx61wPT4gyxZfxlSxMMEyAsWaubBlNyIa1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-react": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-react/-/msal-react-2.2.0.tgz",
+      "integrity": "sha512-2V+9JXeXyyjYNF92y5u0tU4el9px/V1+vkRuN+DtoxyiMHCtYQpJoaFdGWArh43zhz5aqQqiGW/iajPDSu3QsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@azure/msal-browser": "^3.27.0",
+        "react": "^16.8.0 || ^17 || ^18"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@ctrl/tinycolor": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.6.1.tgz",
+      "integrity": "sha512-SITSV6aIXsuVNV3f3O0f2n/cgyEDWoSqtZMYiAmcsYHydcKrOz3gUxB/iXd/Qf08+IZX4KpgNbvUdMBmWz+kcA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+      "license": "MIT"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/devtools": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/devtools/-/devtools-0.2.3.tgz",
+      "integrity": "sha512-ZTcxTvgo9CRlP7vJV62yCxdqmahHTGpSTi5QaTDgGoyQq0OyjaVZhUhXv/qdkQFOI3Sxlfmz0XGG4HaZMsDf8Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
+    },
+    "node_modules/@fluentui/keyboard-keys": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@fluentui/keyboard-keys/-/keyboard-keys-9.0.8.tgz",
+      "integrity": "sha512-iUSJUUHAyTosnXK8O2Ilbfxma+ZyZPMua5vB028Ys96z80v+LFwntoehlFsdH3rMuPsA8GaC1RE7LMezwPBPdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.1"
+      }
+    },
+    "node_modules/@fluentui/priority-overflow": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/priority-overflow/-/priority-overflow-9.3.0.tgz",
+      "integrity": "sha512-yaBC0R4e+4ZlCWDulB5S+xBrlnLwfzdg68GaarCqQO8OHjLg7Ah05xTj7PsAYcoHeEg/9vYeBwGXBpRO8+Tjqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.1"
+      }
+    },
+    "node_modules/@fluentui/react-accordion": {
+      "version": "9.12.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-accordion/-/react-accordion-9.12.0.tgz",
+      "integrity": "sha512-Ay1Cet3qTdpcHQErelG/6tSAhaNCkCojZzNzhpET25ukiMNFeJVK/j/kQbrcjbdClYdz35+8/3hI8q6hSIPD/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-aria": "^9.17.12",
+        "@fluentui/react-context-selector": "^9.2.17",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-motion": "^9.16.0",
+        "@fluentui/react-motion-components-preview": "^0.15.5",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.15",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-alert": {
+      "version": "9.0.0-beta.140",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-alert/-/react-alert-9.0.0-beta.140.tgz",
+      "integrity": "sha512-IYrS7qNyN6FFya+FBdyHZU3jA+6xcU7SD1FjFbthZMx2QTYN7wnZGUdIRQQc3BQRRwRNWtH2BEF4RZY20TvfWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-avatar": "^9.11.2",
+        "@fluentui/react-button": "^9.9.2",
+        "@fluentui/react-icons": "^2.0.239",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-tabster": "^9.26.15",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-aria": {
+      "version": "9.17.12",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-aria/-/react-aria-9.17.12.tgz",
+      "integrity": "sha512-Nrgj9ND3nqtr33w0ICXs3/VrtSBZNBoFl9FkeWz3SCUeUcC8A9eFIH2HpHjbgwENs9BV+aUPi2J2vZhX1+yqQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.15",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-avatar": {
+      "version": "9.11.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-avatar/-/react-avatar-9.11.2.tgz",
+      "integrity": "sha512-OGGrpQBKbIfbX5ZDfZezCR2i1TErNopam0rUowuUl/etaiXv6Q8+1qdDPisJUR3OJJkSIXmiDhjdgJ+z/f7nFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-badge": "^9.5.3",
+        "@fluentui/react-context-selector": "^9.2.17",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-popover": "^9.14.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.15",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-tooltip": "^9.10.2",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-badge": {
+      "version": "9.5.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-badge/-/react-badge-9.5.3.tgz",
+      "integrity": "sha512-pMvzFTrMP/CvgDzne281pXyrBjSeiFwKRYuAa9Y1NkqK+H5wI0U/SsZu81mAuUA7vRxxqHkqtp5J2/huVK1yEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-breadcrumb": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-breadcrumb/-/react-breadcrumb-9.4.2.tgz",
+      "integrity": "sha512-IpLlrQkvFnQ7kMzRaVn6lmfb6gDUwRtnMDfhLTfUiJkisvuqdZGeilGTH1Yx4JLqBzCQGnRHMjcYm1DcrwX4aQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-aria": "^9.17.12",
+        "@fluentui/react-button": "^9.9.2",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-link": "^9.8.2",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.15",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-button": {
+      "version": "9.9.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-button/-/react-button-9.9.2.tgz",
+      "integrity": "sha512-zQ6EuJCb3hQ7d62lrn+wI3C9ugbi3M1d98SjOmj4WW/xG9gOKIZ+xjg6AYtAm7L94I/6JZbe5al2NvtejQWsHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.12",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.15",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-card": {
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-card/-/react-card-9.7.0.tgz",
+      "integrity": "sha512-OWfkDlCNbxbap5W5TIc+fpSEWnArug2+47yYx2DnSiUkJ+/bSdqBvGAPlQjlONV/fuA/HPWBpsni4Ao9nZicqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.15",
+        "@fluentui/react-text": "^9.6.17",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-carousel": {
+      "version": "9.9.8",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-carousel/-/react-carousel-9.9.8.tgz",
+      "integrity": "sha512-NaC7SVZF+dk1xV9FU9hsqQvoXrAzP6KMEcbzW7HLrQfM/qDyA2ERyYPZXeho24mvg4KXDalzEBwHxctASsA8iw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-aria": "^9.17.12",
+        "@fluentui/react-button": "^9.9.2",
+        "@fluentui/react-context-selector": "^9.2.17",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.15",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-tooltip": "^9.10.2",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1",
+        "embla-carousel": "^8.5.1",
+        "embla-carousel-autoplay": "^8.5.1",
+        "embla-carousel-fade": "^8.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-checkbox": {
+      "version": "9.6.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-checkbox/-/react-checkbox-9.6.2.tgz",
+      "integrity": "sha512-ONIvYhhIdwAuPD4V5CZYXXjeq0lAtpiwU0PSFP5JAabYrmPVnBALe8km1QFTSnz2pN70AfQsOm92n6PCUFbyrg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.5.2",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-label": "^9.4.2",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.15",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-color-picker": {
+      "version": "9.2.17",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-color-picker/-/react-color-picker-9.2.17.tgz",
+      "integrity": "sha512-cp9WdlrP2miMVNn5s1vjNqJCumezP/OWwGI0TV9tRMO0DvGQ8R1xwbVxxTH/C/wsMYrVIHiJaagQ5U6nzk6XLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@ctrl/tinycolor": "^3.3.4",
+        "@fluentui/react-context-selector": "^9.2.17",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.15",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-combobox": {
+      "version": "9.17.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-combobox/-/react-combobox-9.17.2.tgz",
+      "integrity": "sha512-uYFelRhb+3BOwAIm4lvCfvrIBBi2Q5A66jzTXwZaH4rg5wrTWkpv+eSVkHF5gfcxzoEYRy1Ze2Tf1B2DtYYJyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.12",
+        "@fluentui/react-context-selector": "^9.2.17",
+        "@fluentui/react-field": "^9.5.2",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-portal": "^9.8.13",
+        "@fluentui/react-positioning": "^9.22.2",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.15",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components": {
+      "version": "9.74.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-components/-/react-components-9.74.0.tgz",
+      "integrity": "sha512-pehwLFtkMNqBIONIb/gOxNRWkQPfdw32ekYV+Fa8FfJSmgAXqjhC+c4OggTHjwiX2RpbltbDjJBNP8Nxa3/RAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-accordion": "^9.12.0",
+        "@fluentui/react-alert": "9.0.0-beta.140",
+        "@fluentui/react-aria": "^9.17.12",
+        "@fluentui/react-avatar": "^9.11.2",
+        "@fluentui/react-badge": "^9.5.3",
+        "@fluentui/react-breadcrumb": "^9.4.2",
+        "@fluentui/react-button": "^9.9.2",
+        "@fluentui/react-card": "^9.7.0",
+        "@fluentui/react-carousel": "^9.9.8",
+        "@fluentui/react-checkbox": "^9.6.2",
+        "@fluentui/react-color-picker": "^9.2.17",
+        "@fluentui/react-combobox": "^9.17.2",
+        "@fluentui/react-dialog": "^9.18.1",
+        "@fluentui/react-divider": "^9.7.2",
+        "@fluentui/react-drawer": "^9.13.0",
+        "@fluentui/react-field": "^9.5.2",
+        "@fluentui/react-image": "^9.4.2",
+        "@fluentui/react-infobutton": "9.0.0-beta.116",
+        "@fluentui/react-infolabel": "^9.4.21",
+        "@fluentui/react-input": "^9.8.3",
+        "@fluentui/react-label": "^9.4.2",
+        "@fluentui/react-link": "^9.8.2",
+        "@fluentui/react-list": "^9.6.15",
+        "@fluentui/react-menu": "^9.25.0",
+        "@fluentui/react-message-bar": "^9.7.1",
+        "@fluentui/react-motion": "^9.16.0",
+        "@fluentui/react-nav": "^9.4.0",
+        "@fluentui/react-overflow": "^9.8.0",
+        "@fluentui/react-persona": "^9.7.4",
+        "@fluentui/react-popover": "^9.14.3",
+        "@fluentui/react-portal": "^9.8.13",
+        "@fluentui/react-positioning": "^9.22.2",
+        "@fluentui/react-progress": "^9.5.2",
+        "@fluentui/react-provider": "^9.22.17",
+        "@fluentui/react-radio": "^9.6.3",
+        "@fluentui/react-rating": "^9.4.2",
+        "@fluentui/react-search": "^9.4.3",
+        "@fluentui/react-select": "^9.5.2",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-skeleton": "^9.7.3",
+        "@fluentui/react-slider": "^9.6.3",
+        "@fluentui/react-spinbutton": "^9.6.3",
+        "@fluentui/react-spinner": "^9.8.3",
+        "@fluentui/react-swatch-picker": "^9.5.3",
+        "@fluentui/react-switch": "^9.7.3",
+        "@fluentui/react-table": "^9.19.16",
+        "@fluentui/react-tabs": "^9.12.2",
+        "@fluentui/react-tabster": "^9.26.15",
+        "@fluentui/react-tag-picker": "^9.8.7",
+        "@fluentui/react-tags": "^9.9.0",
+        "@fluentui/react-teaching-popover": "^9.7.0",
+        "@fluentui/react-text": "^9.6.17",
+        "@fluentui/react-textarea": "^9.7.3",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-toast": "^9.7.18",
+        "@fluentui/react-toolbar": "^9.8.1",
+        "@fluentui/react-tooltip": "^9.10.2",
+        "@fluentui/react-tree": "^9.16.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@fluentui/react-virtualizer": "9.0.0-alpha.113",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-context-selector": {
+      "version": "9.2.17",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.17.tgz",
+      "integrity": "sha512-pZGIz8vjK9nxHKmztV7y5T8yHseoTjm3a43TdPN6fhup0tlrGE/JUmVFEwulI3j4fMWqa0P2OhJoe+HrDMs44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.26.4",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0",
+        "scheduler": ">=0.19.0"
+      }
+    },
+    "node_modules/@fluentui/react-dialog": {
+      "version": "9.18.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-dialog/-/react-dialog-9.18.1.tgz",
+      "integrity": "sha512-tvi5MgUXY6yOySfKSEJobeBNwK3BOXVjRInxDz3ZM7g7FMMyzuf9HrXK/7caqMNRA9uQEQKFXKI9zD03L0kyPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.12",
+        "@fluentui/react-context-selector": "^9.2.17",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-motion": "^9.16.0",
+        "@fluentui/react-motion-components-preview": "^0.15.5",
+        "@fluentui/react-portal": "^9.8.13",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.15",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-divider": {
+      "version": "9.7.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-divider/-/react-divider-9.7.2.tgz",
+      "integrity": "sha512-rfzGQoGKtLBF5vxiJH2KhRiJGosozdql3d6eS7j11oRczgc5W/h38iLhiXuQzZHpkGaAOd3sY6sq4uGHJheOjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-drawer": {
+      "version": "9.13.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-drawer/-/react-drawer-9.13.0.tgz",
+      "integrity": "sha512-Xeh9kW8SiNXobx+5AUb4UVYsaqpE9uqrqFwsb5Z47oupX3zRLw7UCh5rVbJoXowZRc7z6K1FViyORqpsOXnzJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-dialog": "^9.18.1",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-motion": "^9.16.0",
+        "@fluentui/react-motion-components-preview": "^0.15.5",
+        "@fluentui/react-portal": "^9.8.13",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.15",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-field": {
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-field/-/react-field-9.5.2.tgz",
+      "integrity": "sha512-5pZXGtDVXCkoL3/sRMyhCcPd6+TDR9/wYG7/mK82BDuX4viuoSr5llcQ1PkdcXMixFFU+nXa39l7/BLP3f6W8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-context-selector": "^9.2.17",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-label": "^9.4.2",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-icons": {
+      "version": "2.0.328",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.328.tgz",
+      "integrity": "sha512-HAotR2QQjff1WJmm+QeSIU+3m1SOiz9D2M+u8M+8FWyRsyHjbOpBV9QUrABBH9z9JxyYYOvzLamjHEkIgGKLUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@griffel/react": "^1.6.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-image": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-image/-/react-image-9.4.2.tgz",
+      "integrity": "sha512-E7bOTFds8qoMiT/YDe2+ZL5h13u7M1bm8yoGFfeTw0fmE9Q0gtrx2WzJB/1ZV/4MTmjnaO9Dgx7ysTYxc3RWRw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-infobutton": {
+      "version": "9.0.0-beta.116",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-infobutton/-/react-infobutton-9.0.0-beta.116.tgz",
+      "integrity": "sha512-bnL8hRs9K8xCKvJU49F0UxcRankGb2sr+KYezdrcrgfbePrh8kyJTFGmxKQSgka8P+SySE5DxFwb2RbfpTjmnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-icons": "^2.0.237",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-label": "^9.4.2",
+        "@fluentui/react-popover": "^9.14.3",
+        "@fluentui/react-tabster": "^9.26.15",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-infolabel": {
+      "version": "9.4.21",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-infolabel/-/react-infolabel-9.4.21.tgz",
+      "integrity": "sha512-FDpbxwdEztarJ63NmHCQP5n2XXKvyVgkdIVQIbkVslYqfooy2kql8Q0+5brRN2IsjQJRZ0MpSFRoJSNVT8rJEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-label": "^9.4.2",
+        "@fluentui/react-popover": "^9.14.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.15",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <20.0.0",
+        "@types/react-dom": ">=16.8.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-input": {
+      "version": "9.8.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-input/-/react-input-9.8.3.tgz",
+      "integrity": "sha512-nnApEcsPXVXCZZl9qRpS9hc2hy18btUtbG188TYM1FAynqjx5zZC9Ww5/6IOrGT8d12nDxxTu9dp/xqMZtUbbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.5.2",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.4.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.4.3.tgz",
+      "integrity": "sha512-1QwEgITME+X24lnS68pQlU/b4BBdeS7oPdApwwoYQuAGKvImDY2nLAJt8BoHYKs9VFeX5ySEKPRM0rKXGq3EWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.26.4",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-label": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-label/-/react-label-9.4.2.tgz",
+      "integrity": "sha512-FfbOQf5caDA3yc/wukbKY0p6Pv8wkzre7E480VxqTgKrMm12KUoT+0+2S7vi0eCQJCW3pL8XjzVTbGIn8KDE8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-link": {
+      "version": "9.8.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-link/-/react-link-9.8.2.tgz",
+      "integrity": "sha512-PDziHdvp717LFc7BgxXDVldnq8UFtyqWM4ZWr0772XtuEc08jVU3MxKMUEsGOclqLRKGyjd0nG7IWKREuSETcg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.15",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-list": {
+      "version": "9.6.15",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-list/-/react-list-9.6.15.tgz",
+      "integrity": "sha512-mb2yVQC2gfILLFOZAxsYwo70YgoyacR52Qy2EGuB4wZOQtZ9KMZIOUFlQIztJBSxNIfo869/bF8EUWsVDaTeYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-checkbox": "^9.6.2",
+        "@fluentui/react-context-selector": "^9.2.17",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.15",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <20.0.0",
+        "@types/react-dom": ">=16.8.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-menu": {
+      "version": "9.25.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-menu/-/react-menu-9.25.0.tgz",
+      "integrity": "sha512-aoBlNLv8Ngr9wBiOEhvYVOSLfeen2vvdAdZM10OjJ+mo9uhdRxF4m0Uqd8mcp0bpGf5/Cnz9FIZjdgc5krdwyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.12",
+        "@fluentui/react-context-selector": "^9.2.17",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-motion": "^9.16.0",
+        "@fluentui/react-motion-components-preview": "^0.15.5",
+        "@fluentui/react-portal": "^9.8.13",
+        "@fluentui/react-positioning": "^9.22.2",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.15",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-message-bar": {
+      "version": "9.7.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-message-bar/-/react-message-bar-9.7.1.tgz",
+      "integrity": "sha512-8ImzffgVF/DJacOCiP1x75GQHE0wdB+3QoRkGKsgOZcqn6JOXzCEYvM0JplietUsNczmXRtXx9ZE+Otl6HPOHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-button": "^9.9.2",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-link": "^9.8.2",
+        "@fluentui/react-motion": "^9.16.0",
+        "@fluentui/react-motion-components-preview": "^0.15.5",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <20.0.0",
+        "@types/react-dom": ">=16.8.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-motion": {
+      "version": "9.16.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-motion/-/react-motion-9.16.0.tgz",
+      "integrity": "sha512-ZhbeRfir3V6+2kQjRqF2Bp8jwZd6TfmA9y1c6IlglsB8aNAbhnewYJsYXLrbZ+gwloiDdf46cVDqWYv5VFAgpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <20.0.0",
+        "@types/react-dom": ">=16.8.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-motion-components-preview": {
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-motion-components-preview/-/react-motion-components-preview-0.15.5.tgz",
+      "integrity": "sha512-AhDw4/6fjIDWPwx8L1vNDYu3GBJYkyAazNHNrowoRsuxZHn0vK5TMUacT4UW6/QbByCk1x76TLv+CxmwU75FPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-motion": "*",
+        "@fluentui/react-utilities": "*",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-nav": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-nav/-/react-nav-9.4.0.tgz",
+      "integrity": "sha512-gyrXwT1NFfRT4WoVXrz7656tuFOmhFgCw1OBmb+0igftXmSxz6XMIj8MlwfUv2/VUymAU4Hs0p3rZwE4l81KKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-aria": "^9.17.12",
+        "@fluentui/react-button": "^9.9.2",
+        "@fluentui/react-context-selector": "^9.2.17",
+        "@fluentui/react-divider": "^9.7.2",
+        "@fluentui/react-drawer": "^9.13.0",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-motion": "^9.16.0",
+        "@fluentui/react-motion-components-preview": "^0.15.5",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.15",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-tooltip": "^9.10.2",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-overflow": {
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-overflow/-/react-overflow-9.8.0.tgz",
+      "integrity": "sha512-6lHvfcRNFSnOIrKHUzWc/WCKvSp5ivH8QP/stzyCUyzJpDde8uAbRMfg2iDFgJ8wlySP29BoPiepaH9bHgVLdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/priority-overflow": "^9.3.0",
+        "@fluentui/react-context-selector": "^9.2.17",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-persona": {
+      "version": "9.7.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-persona/-/react-persona-9.7.4.tgz",
+      "integrity": "sha512-CtYA3aElMwTrhZcvdtrSIHWOzZqFcpJlfjchNNFTtvvFvrLGw65/1UPzLf/IUVBD1JO0XLGyQFRLUg/g+rtBfg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-avatar": "^9.11.2",
+        "@fluentui/react-badge": "^9.5.3",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-popover": {
+      "version": "9.14.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-popover/-/react-popover-9.14.3.tgz",
+      "integrity": "sha512-wR73yLdMm3/pJ92xJEeRnBAJ8tNvNv0LTSmaZvwbTgdcMT1zqfSyNO37qE7a8z+4bcp8kjyM8FR9NRqkr8OYdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.12",
+        "@fluentui/react-context-selector": "^9.2.17",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-motion": "^9.16.0",
+        "@fluentui/react-motion-components-preview": "^0.15.5",
+        "@fluentui/react-portal": "^9.8.13",
+        "@fluentui/react-positioning": "^9.22.2",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.15",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-portal": {
+      "version": "9.8.13",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-portal/-/react-portal-9.8.13.tgz",
+      "integrity": "sha512-a4EEt3KMzvW6qMk97K/8TQegmO8Ba4C2TdR7ke7g1SsEDmJGwwOD34hCwVxGi8LtxLcpAEdOx++brXnPsk5+Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.15",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-positioning": {
+      "version": "9.22.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-positioning/-/react-positioning-9.22.2.tgz",
+      "integrity": "sha512-Pmio9+lDN+rF4k0mHVXqX6W0+A0ym0dje92UVfXeuassuIuJpKfvQg1xLpgQPrGRbgERr8KgA04xQVoJKaZQmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/devtools": "^0.2.3",
+        "@floating-ui/dom": "^1.6.12",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-progress": {
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-progress/-/react-progress-9.5.2.tgz",
+      "integrity": "sha512-H2t9Q9qYPm5gGb68RiIukFAZn/IxgoxcpKwZ+AjXKCly0C8x8EWCpyQSdfvswaGbcx7H6fe3SpKytBAAuvOOtA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.5.2",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-motion": "^9.16.0",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-provider": {
+      "version": "9.22.17",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-provider/-/react-provider-9.22.17.tgz",
+      "integrity": "sha512-VIguLw2Ez9qxYCzrwKe3ttIcIbRdi7qpafImLNdpIAWRacIHw1AXSiDKcL6VFfE1+NxfQEy655wqYABi+7pJfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.15",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/core": "^1.16.0",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-radio": {
+      "version": "9.6.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-radio/-/react-radio-9.6.3.tgz",
+      "integrity": "sha512-U+funQQvlcOe3BQevUlkxsCoTQKFjw3Z/wnoAXNaNr1lTLIZnB+nesLA3ovZFWyOGTTJ2Mfa+vYpLbyyEpS8eA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.5.2",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-label": "^9.4.2",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.15",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-rating": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-rating/-/react-rating-9.4.2.tgz",
+      "integrity": "sha512-jVHv9GFKKhzH1fai4/1ArG1xjFAU/PFsY8UkBikt3LQDL5Cuw2S2uIBanso0AllNwmwaImsd5xb1Uo8mfMayBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.15",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <20.0.0",
+        "@types/react-dom": ">=16.8.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-search": {
+      "version": "9.4.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-search/-/react-search-9.4.3.tgz",
+      "integrity": "sha512-wKRakuodG76MTu2v/8PZiXA3SUFaMJhdJ5OjoVh5TpFtoYnzwJmiyW2TlgDuod2rk2fpJ3v34C6wkdx6tW8oZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-input": "^9.8.3",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-select": {
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-select/-/react-select-9.5.2.tgz",
+      "integrity": "sha512-kbLbF8DAXsbb2UwJxVzV5tS9fpSX2RZdFPZYosvQly6+h5kTojVFeZRrSkyMPYRCkTMVENdAeyahdx4ESa5qHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.5.2",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-shared-contexts": {
+      "version": "9.26.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-shared-contexts/-/react-shared-contexts-9.26.2.tgz",
+      "integrity": "sha512-upKXkwlIp5oIhELr4clAZXQkuCd4GDXM6GZEz8BOmRO+PnxyqmycCXvxDxsmi6XN+0vkGM4joiIgkB14o/FctQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-theme": "^9.2.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-skeleton": {
+      "version": "9.7.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-skeleton/-/react-skeleton-9.7.3.tgz",
+      "integrity": "sha512-4YhAux0OaYs/91xz/K25pNQxFbdQ2FcDRnwTpgsCDFH4XGQtA+rxBsLA5il3chIf++bNWr/78c5PHp6tZQuCDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.5.2",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-slider": {
+      "version": "9.6.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-slider/-/react-slider-9.6.3.tgz",
+      "integrity": "sha512-r0AP/ZqyMpVEEniIMjQ6AH5DZeCZ/XypBw+21D6mtjiy9vCg0A9lU8U+ay2Y1RyQY4PCShsUVSOb3bNTSTVUxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.5.2",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.15",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-spinbutton": {
+      "version": "9.6.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-spinbutton/-/react-spinbutton-9.6.3.tgz",
+      "integrity": "sha512-wc3GjEB3vBz8uO+Jmdch9gk5effGz6ld2SrfmpHjfTGgww9qIj5S+WbSPZjAKgtqZw/f597DMpiplRE1kvqn/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-field": "^9.5.2",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-spinner": {
+      "version": "9.8.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-spinner/-/react-spinner-9.8.3.tgz",
+      "integrity": "sha512-knnL3Yx/qC+YoYPLCQLE5iHeNMwj3bLBQrksk85lQK0AFy1rOs8rTQuxUtjg9icn5BOFExhSDOYVwp3diSt1ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-label": "^9.4.2",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-swatch-picker": {
+      "version": "9.5.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-swatch-picker/-/react-swatch-picker-9.5.3.tgz",
+      "integrity": "sha512-AiybFcvA6in1piIsPn83Wm+w5bOnLlWmqrHiTDFnt6bYb8j2MJZ+dratJVZRtidqlEyfcMS3SByLooaVzwLRLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-context-selector": "^9.2.17",
+        "@fluentui/react-field": "^9.5.2",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.15",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <20.0.0",
+        "@types/react-dom": ">=16.8.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-switch": {
+      "version": "9.7.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-switch/-/react-switch-9.7.3.tgz",
+      "integrity": "sha512-/eCYAtaoyUF//6F/OdOGj+GhLtkeJMXJUxaRPiDa6d18DX2eyoGaQ10175ysOjv4CbzIg8xH15flgpB4qUUstQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.5.2",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-label": "^9.4.2",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.15",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-table": {
+      "version": "9.19.16",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-table/-/react-table-9.19.16.tgz",
+      "integrity": "sha512-SdwpJIHwCGg+ALOhZRvixkQhWSakXDgpDGe/OWwv1PiLDPxnBh+gUd+MtveryFaX+WvJvLWzx3u9O1ogQXKx3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.12",
+        "@fluentui/react-avatar": "^9.11.2",
+        "@fluentui/react-checkbox": "^9.6.2",
+        "@fluentui/react-context-selector": "^9.2.17",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-radio": "^9.6.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.15",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-tabs": {
+      "version": "9.12.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tabs/-/react-tabs-9.12.2.tgz",
+      "integrity": "sha512-k2WsKmNQvFtNSywAb/VxXXlFdLC9fjRaRV4Ha7qDXucXuTCI1eKJuaAteePZiMAByv+AbRqRHevv5k2KMabxrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-context-selector": "^9.2.17",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.15",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-tabster": {
+      "version": "9.26.15",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tabster/-/react-tabster-9.26.15.tgz",
+      "integrity": "sha512-SugQlqXsMueTojtvPU/RIoZg6WaV4bw++NhLjnF7dFvD61/w5pPsVSLCPsLJBD+oU5Kbgx2x3KFbI69kb+kNmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1",
+        "keyborg": "^2.14.1",
+        "tabster": "^8.8.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-tag-picker": {
+      "version": "9.8.7",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tag-picker/-/react-tag-picker-9.8.7.tgz",
+      "integrity": "sha512-Jtx58RAscH/9ZsNMGO7pYgt+IfSEmGPg9C0Z7FHt16K2TT9/Z13o/khLNsEP89hTNHgweisYOlUgxLOCFEnwGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.12",
+        "@fluentui/react-combobox": "^9.17.2",
+        "@fluentui/react-context-selector": "^9.2.17",
+        "@fluentui/react-field": "^9.5.2",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-portal": "^9.8.13",
+        "@fluentui/react-positioning": "^9.22.2",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.15",
+        "@fluentui/react-tags": "^9.9.0",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-tags": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tags/-/react-tags-9.9.0.tgz",
+      "integrity": "sha512-Fo40iG+ZhslvnRIL9j/rEDQQ7j2AFAKjD7yxntzQroyHAokzu8nTtZUUNfzTTkMAWAFaLGjU4ktphCW97gevHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.12",
+        "@fluentui/react-avatar": "^9.11.2",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.15",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-teaching-popover": {
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-teaching-popover/-/react-teaching-popover-9.7.0.tgz",
+      "integrity": "sha512-8oKts1w33JbLAgVNt7Ad5vidXsIpXyVkrPwo5aZW6oqEASJGEooAOx1od+bKgwZb2wyjq5/RXxdV22r13nqajg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-aria": "^9.17.12",
+        "@fluentui/react-button": "^9.9.2",
+        "@fluentui/react-context-selector": "^9.2.17",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-popover": "^9.14.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.15",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <20.0.0",
+        "@types/react-dom": ">=16.8.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-text": {
+      "version": "9.6.17",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-text/-/react-text-9.6.17.tgz",
+      "integrity": "sha512-SqWXOKJNF6EgG4/vZeurl7MqO9OckRwK6tvk9JJVs7kbqOky+d+t1gITaqk9yIOw6LJtb76vm8cZUvKUb0WSqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-textarea": {
+      "version": "9.7.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-textarea/-/react-textarea-9.7.3.tgz",
+      "integrity": "sha512-BNStqBKO2fe3h5VAIPs33/7xj8EAr5msmb9krq02XAmvDndt3aLrQdz25vVEMvbcuUCNQoFsPtN/PrR6nXTIHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-field": "^9.5.2",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-theme": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-theme/-/react-theme-9.2.1.tgz",
+      "integrity": "sha512-lJxfz7LmmglFz+c9C41qmMqaRRZZUPtPPl9DWQ79vH+JwZd4dkN7eA78OTRwcGCOTPEKoLTX72R+EFaWEDlX+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/tokens": "1.0.0-alpha.23",
+        "@swc/helpers": "^0.5.1"
+      }
+    },
+    "node_modules/@fluentui/react-toast": {
+      "version": "9.7.18",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-toast/-/react-toast-9.7.18.tgz",
+      "integrity": "sha512-ObhaTIvnP6p5JxdRgQZ+N8VLlQGgWBL+hN9vHr+swJAkIkpcmFjD8fK4jiCky9C0ix3vm7vTH18yBE7RbaXK+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.12",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-motion": "^9.16.0",
+        "@fluentui/react-motion-components-preview": "^0.15.5",
+        "@fluentui/react-portal": "^9.8.13",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.15",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-toolbar": {
+      "version": "9.8.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-toolbar/-/react-toolbar-9.8.1.tgz",
+      "integrity": "sha512-ZzjFwFElF3bCsHXgl6YfmHzfZn2gUDe7NoYl4qloHhGacrSStvOt0h94WRz0a5ur/VIG2PDROeBLkcI2MIZQJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-button": "^9.9.2",
+        "@fluentui/react-context-selector": "^9.2.17",
+        "@fluentui/react-divider": "^9.7.2",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-radio": "^9.6.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.15",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-tooltip": {
+      "version": "9.10.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tooltip/-/react-tooltip-9.10.2.tgz",
+      "integrity": "sha512-1qewqiTNKpbRuoINhytyaMoUsBLE4TRPXf9ilJnvN3UtN5TYtS/8Oe6zMocHEnCLETsFOyCn8sAlufWOo5efpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-portal": "^9.8.13",
+        "@fluentui/react-positioning": "^9.22.2",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.15",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-tree": {
+      "version": "9.16.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tree/-/react-tree-9.16.1.tgz",
+      "integrity": "sha512-e87Fa+8ttbYh0XY4qxJ9NcmIWSfYouw8Rc68c10UczK2TcsWSII84cV9fHrbL7FtX8DlyncZuSjukoJYm5LD7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.12",
+        "@fluentui/react-avatar": "^9.11.2",
+        "@fluentui/react-button": "^9.9.2",
+        "@fluentui/react-checkbox": "^9.6.2",
+        "@fluentui/react-context-selector": "^9.2.17",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-motion": "^9.16.0",
+        "@fluentui/react-motion-components-preview": "^0.15.5",
+        "@fluentui/react-radio": "^9.6.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.15",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-utilities": {
+      "version": "9.26.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-utilities/-/react-utilities-9.26.4.tgz",
+      "integrity": "sha512-Rg1kg0ZPFOBi6VtQNkgV+K3z3O7PY5QFJQ4Y+qkZv7a8fUSNkEK151coaGOLps4P77fY2DiHhqKqeOehN7vFOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-virtualizer": {
+      "version": "9.0.0-alpha.113",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-virtualizer/-/react-virtualizer-9.0.0-alpha.113.tgz",
+      "integrity": "sha512-MGmdlm+0HwwMypCpUCpddQjgKvZkL9oGvjXNcoIHYhMVy4WSc5ha8XqOxAo2cfWvKGN0jMiW3H3IebLdcFpd7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@fluentui/react-jsx-runtime": "^9.4.3",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-utilities": "^9.26.4",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/tokens": {
+      "version": "1.0.0-alpha.23",
+      "resolved": "https://registry.npmjs.org/@fluentui/tokens/-/tokens-1.0.0-alpha.23.tgz",
+      "integrity": "sha512-uxrzF9Z+J10naP0pGS7zPmzSkspSS+3OJDmYIK3o1nkntQrgBXq3dBob4xSlTDm5aOQ0kw6EvB9wQgtlyy4eKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.1"
+      }
+    },
+    "node_modules/@griffel/core": {
+      "version": "1.21.2",
+      "resolved": "https://registry.npmjs.org/@griffel/core/-/core-1.21.2.tgz",
+      "integrity": "sha512-vDvEdbIe7OhU15UkvUHe+Ut2sgCZ5PBj/RYLFwjUtkXS4ewNK9P6b4YRFNI2zgaNYI7GOuZqG7DLyaQbUP3+jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/hash": "^0.9.0",
+        "@griffel/style-types": "^1.4.2",
+        "csstype": "^3.2.3",
+        "rtl-css-js": "^1.16.1",
+        "stylis": "^4.4.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@griffel/react": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@griffel/react/-/react-1.7.4.tgz",
+      "integrity": "sha512-XsB+YOC4MOBg6GF5CJWJLf8ZI2AtXE8EvQdwJEmFNKX0cQu/An0azl3v9+sjA73zsIG2Wayo2pkT0JANYnKauA==",
+      "license": "MIT",
+      "dependencies": {
+        "@griffel/core": "^1.21.2",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@griffel/style-types": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@griffel/style-types/-/style-types-1.4.2.tgz",
+      "integrity": "sha512-MsSghfpyxR2MpTrYdcCozISsSLkmFjNw94wNPi4bDBRLW8W43718W/ZjmUdVkoM0KXMtJPYuEkx8Mzibqb03qA==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
+      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.22",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.22.tgz",
+      "integrity": "sha512-/e2Ly3Docn9kYByap6TV4oquJ3wQuz3c+kC74riqtkwU9CwTMeuj6t2rW+bRr4pyOx/CYQM4wr0RgaKQwGEz0A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.29",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.29.tgz",
+      "integrity": "sha512-ch0qJdr2JY0r04NXSprbK6TXOgnaJ1Tz23fm5W+z0/CBah6BSBc3n96h7K9GOtwh0HrilNWHIBzE1Ko4Dcw/Wg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.32",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.32.tgz",
+      "integrity": "sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001793",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.362",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.362.tgz",
+      "integrity": "sha512-PUY2DrLvkjkUuWqq+KPL2iWshrJsZOcIojzRQ7eXFacc9dWga7MGMJAa15VbiejSZB1PAXaRLAiKgruHP8LB1w==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/embla-carousel": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
+      "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
+      "license": "MIT"
+    },
+    "node_modules/embla-carousel-autoplay": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-autoplay/-/embla-carousel-autoplay-8.6.0.tgz",
+      "integrity": "sha512-OBu5G3nwaSXkZCo1A6LTaFMZ8EpkYbwIaH+bPqdBnDGQ2fh4+NbzjXjs2SktoPNKCtflfVMc75njaDHOYXcrsA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "embla-carousel": "8.6.0"
+      }
+    },
+    "node_modules/embla-carousel-fade": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-fade/-/embla-carousel-fade-8.6.0.tgz",
+      "integrity": "sha512-qaYsx5mwCz72ZrjlsXgs1nKejSrW+UhkbOMwLgfRT7w2LtdEB03nPRI06GHuHv5ac2USvbEiX2/nAHctcDwvpg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "embla-carousel": "8.6.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/keyborg": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/keyborg/-/keyborg-2.14.1.tgz",
+      "integrity": "sha512-/WmmVBa6Me3hIKAOIyIq1sql+6oydQZzGMBDLNfOcJ8710byMsq3KSLS8GQhBJHOMtvnXnUBrDAIbABcZVipcg==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.46",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.46.tgz",
+      "integrity": "sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-dom/node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
+      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
+      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.2",
+        "react-router": "6.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rtl-css-js": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/rtl-css-js/-/rtl-css-js-1.16.1.tgz",
+      "integrity": "sha512-lRQgou1mu19e+Ya0LsTvKrVJ5TYUbqCVPAiImX3UfLTenarvPUl1QFdvu5Z3PYmHT9RCcwIfbjRQBntExyj3Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.1.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stylis": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
+      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
+      "license": "MIT"
+    },
+    "node_modules/tabster": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/tabster/-/tabster-8.8.0.tgz",
+      "integrity": "sha512-eGFXgtvKOQP5BywDI9Ngs+Atm6TRj45epAAqWKyVoi+HmOmdamEB//1H/FttLdNly/+Cz+GJ4RN8TnXTw0KwfA==",
+      "license": "MIT",
+      "dependencies": {
+        "keyborg": "^2.14.0",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/portal/package.json
+++ b/portal/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "mcp-gateway-portal",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "MCP Gateway management portal (React + TypeScript SPA).",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@azure/msal-browser": "^3.27.0",
+    "@azure/msal-react": "^2.2.0",
+    "@fluentui/react-components": "^9.55.1",
+    "@fluentui/react-icons": "^2.0.260",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.28.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.19.41",
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-react": "^4.3.3",
+    "typescript": "^5.6.3",
+    "vite": "^5.4.10"
+  }
+}

--- a/portal/src/App.tsx
+++ b/portal/src/App.tsx
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
+import { Layout } from "./components/Layout";
+import { AdaptersPage } from "./pages/AdaptersPage";
+import { AdapterCreatePage } from "./pages/AdapterCreatePage";
+import { AdapterDetailPage } from "./pages/AdapterDetailPage";
+import { ToolsPage } from "./pages/ToolsPage";
+import { ToolCreatePage } from "./pages/ToolCreatePage";
+import { ToolDetailPage } from "./pages/ToolDetailPage";
+
+export function App() {
+  return (
+    <BrowserRouter basename="/portal">
+      <Routes>
+        <Route element={<Layout />}>
+          <Route index element={<Navigate to="/adapters" replace />} />
+          <Route path="/adapters" element={<AdaptersPage />} />
+          <Route path="/adapters/new" element={<AdapterCreatePage />} />
+          <Route path="/adapters/:name" element={<AdapterDetailPage />} />
+          <Route path="/tools" element={<ToolsPage />} />
+          <Route path="/tools/new" element={<ToolCreatePage />} />
+          <Route path="/tools/:name" element={<ToolDetailPage />} />
+          <Route path="*" element={<Navigate to="/adapters" replace />} />
+        </Route>
+      </Routes>
+    </BrowserRouter>
+  );
+}

--- a/portal/src/api/client.ts
+++ b/portal/src/api/client.ts
@@ -1,0 +1,235 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type {
+  AdapterData,
+  AdapterResource,
+  AdapterStatus,
+  PortalConfig,
+  ToolData,
+  ToolResource,
+} from "./types";
+import { acquireToken } from "../auth/msal";
+import { devIdentityHeaders, loadDevIdentity } from "../auth/devIdentity";
+
+export class ApiError extends Error {
+  status: number;
+  body: string;
+
+  constructor(status: number, message: string, body: string) {
+    super(message);
+    this.status = status;
+    this.body = body;
+  }
+}
+
+interface RequestOptions {
+  method?: string;
+  body?: unknown;
+  query?: Record<string, string | number | undefined>;
+  /** When true, attach the bearer/dev headers; defaults to true. */
+  authenticated?: boolean;
+  signal?: AbortSignal;
+  /** Override Accept header for streaming endpoints (e.g. SSE). */
+  accept?: string;
+}
+
+/**
+ * Lightweight wrapper around `fetch` that adds auth headers based on the
+ * runtime configuration. We deliberately keep this small: every controller in
+ * the gateway returns plain JSON with sensible status codes, so a single
+ * `request` helper handles all CRUD calls.
+ */
+export class GatewayApi {
+  constructor(private readonly config: PortalConfig) {}
+
+  // ---- Adapters -------------------------------------------------------
+
+  listAdapters(signal?: AbortSignal): Promise<AdapterResource[]> {
+    return this.request<AdapterResource[]>("/adapters", { signal });
+  }
+
+  getAdapter(name: string, signal?: AbortSignal): Promise<AdapterResource> {
+    return this.request<AdapterResource>(`/adapters/${encodeURIComponent(name)}`, { signal });
+  }
+
+  getAdapterStatus(name: string, signal?: AbortSignal): Promise<AdapterStatus> {
+    return this.request<AdapterStatus>(
+      `/adapters/${encodeURIComponent(name)}/status`,
+      { signal },
+    );
+  }
+
+  getAdapterLogs(name: string, instance = 0, signal?: AbortSignal): Promise<unknown> {
+    return this.request<unknown>(`/adapters/${encodeURIComponent(name)}/logs`, {
+      query: { instance },
+      signal,
+    });
+  }
+
+  createAdapter(payload: AdapterData): Promise<AdapterResource> {
+    return this.request<AdapterResource>("/adapters", { method: "POST", body: payload });
+  }
+
+  updateAdapter(payload: AdapterData): Promise<AdapterResource> {
+    return this.request<AdapterResource>(
+      `/adapters/${encodeURIComponent(payload.name)}`,
+      { method: "PUT", body: payload },
+    );
+  }
+
+  deleteAdapter(name: string): Promise<void> {
+    return this.request<void>(`/adapters/${encodeURIComponent(name)}`, { method: "DELETE" });
+  }
+
+  // ---- Tools ----------------------------------------------------------
+
+  listTools(signal?: AbortSignal): Promise<ToolResource[]> {
+    return this.request<ToolResource[]>("/tools", { signal });
+  }
+
+  getTool(name: string, signal?: AbortSignal): Promise<ToolResource> {
+    return this.request<ToolResource>(`/tools/${encodeURIComponent(name)}`, { signal });
+  }
+
+  getToolStatus(name: string, signal?: AbortSignal): Promise<AdapterStatus> {
+    return this.request<AdapterStatus>(
+      `/tools/${encodeURIComponent(name)}/status`,
+      { signal },
+    );
+  }
+
+  getToolLogs(name: string, instance = 0, signal?: AbortSignal): Promise<unknown> {
+    return this.request<unknown>(`/tools/${encodeURIComponent(name)}/logs`, {
+      query: { instance },
+      signal,
+    });
+  }
+
+  createTool(payload: ToolData): Promise<ToolResource> {
+    return this.request<ToolResource>("/tools", { method: "POST", body: payload });
+  }
+
+  updateTool(payload: ToolData): Promise<ToolResource> {
+    return this.request<ToolResource>(
+      `/tools/${encodeURIComponent(payload.name)}`,
+      { method: "PUT", body: payload },
+    );
+  }
+
+  deleteTool(name: string): Promise<void> {
+    return this.request<void>(`/tools/${encodeURIComponent(name)}`, { method: "DELETE" });
+  }
+
+  // ---- MCP proxy ------------------------------------------------------
+
+  /**
+   * Issues a raw HTTP request against an adapter's MCP endpoint
+   * (`POST /adapters/{name}/mcp`) or the tool router endpoint (`POST /mcp`)
+   * when `name` is omitted. Returns the response so the caller can inspect
+   * both the body and the headers (which carry `mcp-session-id`).
+   */
+  async sendMcpRequest(
+    name: string | undefined,
+    body: unknown,
+    options?: { sessionId?: string; signal?: AbortSignal; accept?: string },
+  ): Promise<Response> {
+    const path = name ? `/adapters/${encodeURIComponent(name)}/mcp` : "/mcp";
+    const headers = await this.buildHeaders({
+      accept: options?.accept ?? "application/json, text/event-stream",
+      contentType: "application/json",
+    });
+    if (options?.sessionId) {
+      headers.set("mcp-session-id", options.sessionId);
+    }
+    return fetch(path, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+      signal: options?.signal,
+      credentials: "same-origin",
+    });
+  }
+
+  // ---- Internals ------------------------------------------------------
+
+  private async request<T>(path: string, options: RequestOptions = {}): Promise<T> {
+    const url = options.query ? appendQuery(path, options.query) : path;
+    const method = options.method ?? "GET";
+
+    const headers = options.authenticated === false
+      ? new Headers()
+      : await this.buildHeaders({ accept: options.accept });
+
+    if (options.body !== undefined) {
+      headers.set("Content-Type", "application/json");
+    }
+
+    const response = await fetch(url, {
+      method,
+      headers,
+      body: options.body === undefined ? undefined : JSON.stringify(options.body),
+      credentials: "same-origin",
+      signal: options.signal,
+    });
+
+    if (response.status === 204 || response.status === 205) {
+      return undefined as T;
+    }
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      throw new ApiError(
+        response.status,
+        `${method} ${url} failed: ${response.status} ${response.statusText}`,
+        text,
+      );
+    }
+
+    const contentType = response.headers.get("content-type") ?? "";
+    if (contentType.includes("application/json")) {
+      return (await response.json()) as T;
+    }
+    // The /logs endpoints return JSON-ish strings; fall back to text + parse.
+    const text = await response.text();
+    if (!text) return undefined as T;
+    try {
+      return JSON.parse(text) as T;
+    } catch {
+      return text as unknown as T;
+    }
+  }
+
+  private async buildHeaders(options: {
+    accept?: string;
+    contentType?: string;
+  }): Promise<Headers> {
+    const headers = new Headers();
+    headers.set("Accept", options.accept ?? "application/json");
+    if (options.contentType) headers.set("Content-Type", options.contentType);
+
+    if (this.config.isDevelopment) {
+      const identity = loadDevIdentity();
+      for (const [key, value] of Object.entries(devIdentityHeaders(identity))) {
+        headers.set(key, value as string);
+      }
+      return headers;
+    }
+
+    const token = await acquireToken(this.config);
+    if (token) {
+      headers.set("Authorization", `Bearer ${token}`);
+    }
+    return headers;
+  }
+}
+
+function appendQuery(path: string, query: Record<string, string | number | undefined>): string {
+  const search = new URLSearchParams();
+  for (const [key, value] of Object.entries(query)) {
+    if (value === undefined || value === null) continue;
+    search.append(key, String(value));
+  }
+  const qs = search.toString();
+  return qs ? `${path}?${qs}` : path;
+}

--- a/portal/src/api/types.ts
+++ b/portal/src/api/types.ts
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// TypeScript projections of the contracts exposed by Microsoft.McpGateway.
+// Keep these in sync with the C# DTOs under
+// dotnet/Microsoft.McpGateway.Management/src/Contracts/.
+
+export interface AdapterData {
+  name: string;
+  imageName: string;
+  imageVersion: string;
+  environmentVariables: Record<string, string>;
+  replicaCount: number;
+  description: string;
+  useWorkloadIdentity: boolean;
+  requiredRoles: string[];
+}
+
+export interface AdapterResource extends AdapterData {
+  id: string;
+  createdBy: string;
+  createdAt: string;
+  lastUpdatedAt: string;
+}
+
+export interface AdapterStatus {
+  readyReplicas: number | null;
+  updatedReplicas: number | null;
+  availableReplicas: number | null;
+  image: string | null;
+  replicaStatus: string | null;
+}
+
+export interface PodLogs {
+  // The gateway returns the raw log text per pod instance; the precise shape
+  // is opaque to the portal so we accept whatever JSON the gateway returns.
+  [key: string]: unknown;
+}
+
+export interface ToolDefinitionTool {
+  name: string;
+  description?: string;
+  inputSchema?: Record<string, unknown>;
+}
+
+export interface ToolDefinition {
+  tool: ToolDefinitionTool;
+  port: number;
+  path: string;
+}
+
+export interface ToolData extends AdapterData {
+  toolDefinition: ToolDefinition;
+}
+
+export interface ToolResource extends ToolData {
+  id: string;
+  createdBy: string;
+  createdAt: string;
+  lastUpdatedAt: string;
+}
+
+/** Discriminator used by the UI to render the right list/detail view. */
+export type ResourceKind = "adapter" | "tool";
+
+/** Runtime configuration returned by GET /portal/config. */
+export interface PortalConfig {
+  /** True when the gateway is running under the Development auth handler. */
+  isDevelopment: boolean;
+  /** Public origin of the gateway (used to build MCP endpoint URLs). */
+  publicOrigin: string;
+  /** Whether the agents/sessions preview endpoints are wired up. */
+  agentsEnabled: boolean;
+  /** Entra ID configuration, only populated in cloud mode. */
+  azureAd?: {
+    tenantId: string;
+    clientId: string;
+    /**
+     * Default scope requested by the portal. Defaults to
+     * `api://<clientId>/.default` when not provided by the server.
+     */
+    scopes: string[];
+  };
+}

--- a/portal/src/auth/PortalProvider.tsx
+++ b/portal/src/auth/PortalProvider.tsx
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import { Spinner, MessageBar, MessageBarBody, MessageBarTitle } from "@fluentui/react-components";
+import type { PortalConfig } from "../api/types";
+import { GatewayApi } from "../api/client";
+import { loadPortalConfig } from "./config";
+import { ensureMsalInitialized } from "./msal";
+
+interface PortalContextValue {
+  config: PortalConfig;
+  api: GatewayApi;
+}
+
+const PortalContext = createContext<PortalContextValue | undefined>(undefined);
+
+/**
+ * Loads the runtime config (and, in cloud mode, initializes MSAL) before
+ * rendering its children. Until those promises settle we render a spinner so
+ * components downstream can safely assume `useGateway()` returns a real value.
+ */
+export function PortalProvider({ children }: { children: ReactNode }) {
+  const [config, setConfig] = useState<PortalConfig | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const loaded = await loadPortalConfig();
+        // Cloud mode: complete the MSAL redirect handshake before we let
+        // pages start firing authenticated requests.
+        await ensureMsalInitialized(loaded);
+        if (!cancelled) setConfig(loaded);
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err : new Error(String(err)));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const value = useMemo<PortalContextValue | null>(
+    () => (config ? { config, api: new GatewayApi(config) } : null),
+    [config],
+  );
+
+  if (error) {
+    return (
+      <div style={{ padding: 24 }}>
+        <MessageBar intent="error">
+          <MessageBarBody>
+            <MessageBarTitle>Unable to start the portal</MessageBarTitle>
+            {error.message}
+          </MessageBarBody>
+        </MessageBar>
+      </div>
+    );
+  }
+
+  if (!value) {
+    return (
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "center", height: "100vh" }}>
+        <Spinner label="Loading MCP Gateway portal…" />
+      </div>
+    );
+  }
+
+  return <PortalContext.Provider value={value}>{children}</PortalContext.Provider>;
+}
+
+export function useGateway(): PortalContextValue {
+  const ctx = useContext(PortalContext);
+  if (!ctx) {
+    throw new Error("useGateway must be used inside <PortalProvider>.");
+  }
+  return ctx;
+}

--- a/portal/src/auth/config.ts
+++ b/portal/src/auth/config.ts
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type { PortalConfig } from "../api/types";
+
+const CONFIG_ENDPOINT = "/portal/config";
+
+let cached: Promise<PortalConfig> | undefined;
+
+/**
+ * Load the gateway's runtime configuration. The portal can't know up front
+ * whether the gateway is in dev or cloud mode, so the result determines
+ * whether MSAL is initialized and how API calls authenticate.
+ *
+ * The promise is cached so the config is only fetched once per page load.
+ */
+export function loadPortalConfig(): Promise<PortalConfig> {
+  if (!cached) {
+    cached = fetch(CONFIG_ENDPOINT, { credentials: "same-origin" })
+      .then(async (res) => {
+        if (!res.ok) {
+          throw new Error(await formatHttpError(res));
+        }
+        const raw = (await res.json()) as PortalConfig;
+        return normalize(raw);
+      })
+      .catch((err) => {
+        // Don't poison the cache — let the caller retry next time.
+        cached = undefined;
+        throw err;
+      });
+  }
+  return cached;
+}
+
+async function formatHttpError(res: Response): Promise<string> {
+  const head = `Failed to load portal config (${res.status} ${res.statusText}).`;
+  // ASP.NET Core ProblemDetails responses include {title, detail, ...}.
+  // Surface them when present so the operator sees the real cause instead
+  // of a bare HTTP status. Body might also be plain text or empty.
+  let body = "";
+  try {
+    body = await res.text();
+  } catch {
+    return head;
+  }
+  if (!body) return head;
+  try {
+    const parsed = JSON.parse(body) as { title?: string; detail?: string };
+    const fragments = [parsed.title, parsed.detail].filter(Boolean);
+    if (fragments.length > 0) {
+      return `${head} ${fragments.join(": ")}`;
+    }
+  } catch {
+    // not JSON — fall through and append the raw body
+  }
+  const trimmed = body.length > 300 ? `${body.slice(0, 300)}…` : body;
+  return `${head} ${trimmed}`;
+}
+
+function normalize(raw: PortalConfig): PortalConfig {
+  const azureAd = raw.azureAd;
+  if (azureAd && (!azureAd.scopes || azureAd.scopes.length === 0)) {
+    return {
+      ...raw,
+      azureAd: {
+        ...azureAd,
+        scopes: [`api://${azureAd.clientId}/.default`],
+      },
+    };
+  }
+  return raw;
+}

--- a/portal/src/auth/devIdentity.ts
+++ b/portal/src/auth/devIdentity.ts
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Synthetic identity used in development mode. The DevelopmentAuthenticationHandler
+// on the server side picks up X-Dev-UserId / X-Dev-Name / X-Dev-Roles headers and
+// mints a matching ClaimsPrincipal. We persist the choice in localStorage so it
+// survives reloads while we exercise role-based behaviour.
+
+const STORAGE_KEY = "mcp-gateway-portal.dev-identity";
+
+export interface DevIdentity {
+  userId: string;
+  displayName: string;
+  /** Comma-separated role list as expected by the dev auth handler. */
+  roles: string;
+}
+
+export const defaultDevIdentity: DevIdentity = {
+  userId: "dev",
+  displayName: "Local Developer",
+  roles: "mcp.dev",
+};
+
+export function loadDevIdentity(): DevIdentity {
+  if (typeof window === "undefined") return defaultDevIdentity;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return defaultDevIdentity;
+    const parsed = JSON.parse(raw) as Partial<DevIdentity>;
+    return {
+      userId: parsed.userId?.trim() || defaultDevIdentity.userId,
+      displayName: parsed.displayName?.trim() || defaultDevIdentity.displayName,
+      roles: parsed.roles?.trim() || defaultDevIdentity.roles,
+    };
+  } catch {
+    return defaultDevIdentity;
+  }
+}
+
+export function saveDevIdentity(identity: DevIdentity): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(identity));
+}
+
+export function devIdentityHeaders(identity: DevIdentity): HeadersInit {
+  // Only forward headers that are actually populated to avoid clobbering the
+  // gateway's own defaults with empty strings.
+  const headers: Record<string, string> = {};
+  if (identity.userId.trim()) headers["X-Dev-UserId"] = identity.userId.trim();
+  if (identity.displayName.trim()) headers["X-Dev-Name"] = identity.displayName.trim();
+  if (identity.roles.trim()) headers["X-Dev-Roles"] = identity.roles.trim();
+  return headers;
+}

--- a/portal/src/auth/msal.ts
+++ b/portal/src/auth/msal.ts
@@ -1,0 +1,117 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+  PublicClientApplication,
+  type AccountInfo,
+  type Configuration,
+  type SilentRequest,
+  InteractionRequiredAuthError,
+} from "@azure/msal-browser";
+import type { PortalConfig } from "../api/types";
+
+let instance: PublicClientApplication | undefined;
+let initializePromise: Promise<void> | undefined;
+let activeAccount: AccountInfo | null = null;
+
+/**
+ * Create (or return the cached) MSAL `PublicClientApplication`. Only meaningful
+ * when the gateway is running in cloud mode and `config.azureAd` is populated.
+ *
+ * The function returns `undefined` when the gateway runs in development mode —
+ * callers should treat that as "no auth required" and skip token acquisition.
+ */
+export function getMsalInstance(config: PortalConfig): PublicClientApplication | undefined {
+  if (config.isDevelopment || !config.azureAd) return undefined;
+  if (instance) return instance;
+
+  const msalConfig: Configuration = {
+    auth: {
+      clientId: config.azureAd.clientId,
+      authority: `https://login.microsoftonline.com/${config.azureAd.tenantId}`,
+      // The SPA is mounted under /portal/, so redirect users back there
+      // after the interactive sign-in completes.
+      redirectUri: window.location.origin + "/portal/",
+      postLogoutRedirectUri: window.location.origin + "/portal/",
+      navigateToLoginRequestUrl: false,
+    },
+    cache: {
+      cacheLocation: "sessionStorage",
+      // Keeps SSO across same-origin tabs without persisting tokens to disk.
+      storeAuthStateInCookie: false,
+    },
+  };
+
+  instance = new PublicClientApplication(msalConfig);
+  return instance;
+}
+
+/**
+ * Lazily initialize the MSAL instance and process any redirect response.
+ * Safe to call multiple times — subsequent calls await the original promise.
+ */
+export async function ensureMsalInitialized(config: PortalConfig): Promise<void> {
+  const msal = getMsalInstance(config);
+  if (!msal) return;
+  if (!initializePromise) {
+    initializePromise = (async () => {
+      await msal.initialize();
+      const response = await msal.handleRedirectPromise();
+      if (response?.account) {
+        msal.setActiveAccount(response.account);
+        activeAccount = response.account;
+      } else {
+        const accounts = msal.getAllAccounts();
+        if (accounts.length > 0) {
+          msal.setActiveAccount(accounts[0]);
+          activeAccount = accounts[0];
+        }
+      }
+    })();
+  }
+  return initializePromise;
+}
+
+export function getActiveAccount(): AccountInfo | null {
+  return activeAccount;
+}
+
+/**
+ * Acquire an access token for the configured API scope. Falls back to an
+ * interactive redirect when no usable token is cached.
+ */
+export async function acquireToken(config: PortalConfig): Promise<string | undefined> {
+  const msal = getMsalInstance(config);
+  if (!msal || !config.azureAd) return undefined;
+  await ensureMsalInitialized(config);
+
+  const account = msal.getActiveAccount() ?? msal.getAllAccounts()[0];
+  if (!account) {
+    // Trigger sign-in; the function never returns because the page redirects.
+    await msal.loginRedirect({ scopes: config.azureAd.scopes });
+    return undefined;
+  }
+
+  const request: SilentRequest = {
+    account,
+    scopes: config.azureAd.scopes,
+  };
+
+  try {
+    const result = await msal.acquireTokenSilent(request);
+    return result.accessToken;
+  } catch (err) {
+    if (err instanceof InteractionRequiredAuthError) {
+      await msal.acquireTokenRedirect(request);
+      return undefined;
+    }
+    throw err;
+  }
+}
+
+/** Trigger the interactive sign-out flow. */
+export async function signOut(config: PortalConfig): Promise<void> {
+  const msal = getMsalInstance(config);
+  if (!msal) return;
+  await msal.logoutRedirect({ postLogoutRedirectUri: window.location.origin + "/portal/" });
+}

--- a/portal/src/components/AdapterFormFields.tsx
+++ b/portal/src/components/AdapterFormFields.tsx
@@ -1,0 +1,355 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { useState } from "react";
+import {
+  Button,
+  Caption1,
+  Field,
+  Input,
+  Switch,
+  Tag,
+  TagGroup,
+  Textarea,
+  makeStyles,
+  tokens,
+  SpinButton,
+  MessageBar,
+  MessageBarBody,
+} from "@fluentui/react-components";
+import {
+  AddRegular,
+  ShieldKeyholeRegular,
+} from "@fluentui/react-icons";
+import type { AdapterData } from "../api/types";
+import { formatApiError } from "../hooks/useAsync";
+
+const useStyles = makeStyles({
+  form: {
+    display: "grid",
+    gap: "16px",
+    maxWidth: "720px",
+  },
+  row: {
+    display: "grid",
+    gap: "16px",
+    gridTemplateColumns: "2fr 1fr",
+  },
+  envEditor: {
+    display: "grid",
+    gap: "8px",
+  },
+  envRow: {
+    display: "grid",
+    gridTemplateColumns: "1fr 1fr auto",
+    gap: "8px",
+    alignItems: "end",
+  },
+  rolesEditor: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "8px",
+  },
+  rolesInputRow: {
+    display: "grid",
+    gridTemplateColumns: "1fr auto",
+    gap: "8px",
+    alignItems: "end",
+  },
+  rolesEmpty: {
+    color: tokens.colorNeutralForeground3,
+    fontStyle: "italic",
+  },
+  helper: {
+    color: tokens.colorNeutralForeground3,
+  },
+  actions: {
+    display: "flex",
+    gap: "12px",
+    marginTop: "8px",
+  },
+});
+
+/**
+ * The set of fields shared by adapters and tools. The tool form layers a
+ * separate `ToolDefinition` editor on top of this component (see ToolForm).
+ */
+export interface AdapterFormValues extends AdapterData {}
+
+interface Props {
+  initial?: Partial<AdapterFormValues>;
+  /** When true, the `name` field is read-only (we never rename resources). */
+  disableName?: boolean;
+  submitLabel: string;
+  onSubmit: (values: AdapterFormValues) => Promise<void>;
+  onCancel?: () => void;
+  /** Extra slot rendered between the metadata fields and the submit row. */
+  children?: React.ReactNode;
+}
+
+const blank: AdapterFormValues = {
+  name: "",
+  imageName: "",
+  imageVersion: "latest",
+  environmentVariables: {},
+  replicaCount: 1,
+  description: "",
+  useWorkloadIdentity: false,
+  requiredRoles: [],
+};
+
+export function AdapterFormFields({
+  initial,
+  disableName,
+  submitLabel,
+  onSubmit,
+  onCancel,
+  children,
+}: Props) {
+  const styles = useStyles();
+  const [values, setValues] = useState<AdapterFormValues>(() => ({
+    ...blank,
+    ...initial,
+    environmentVariables: { ...(initial?.environmentVariables ?? {}) },
+    requiredRoles: [...(initial?.requiredRoles ?? [])],
+  }));
+  // The env-var editor is row-oriented (ordered, duplicates / empties allowed
+  // while the user is typing). We keep it in its own state and only collapse
+  // it back into a dictionary at submit time so half-typed rows don't get
+  // dropped or merged.
+  const [envRows, setEnvRows] = useState<Array<{ key: string; value: string }>>(
+    () =>
+      Object.entries(initial?.environmentVariables ?? {}).map(([key, value]) => ({
+        key,
+        value,
+      })),
+  );
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | undefined>();
+  // The role picker uses a small input + Add button and renders existing roles
+  // as dismissible chips. We keep the in-progress role text in its own state
+  // so submit can flush a pending value if the user forgot to press Add.
+  const [roleDraft, setRoleDraft] = useState("");
+
+  const setEnvRowAt = (idx: number, patch: Partial<{ key: string; value: string }>) => {
+    setEnvRows((rows) => rows.map((row, i) => (i === idx ? { ...row, ...patch } : row)));
+  };
+
+  const addRole = (raw: string) => {
+    const trimmed = raw.trim();
+    if (!trimmed) return;
+    setValues((s) =>
+      s.requiredRoles.includes(trimmed)
+        ? s
+        : { ...s, requiredRoles: [...s.requiredRoles, trimmed] },
+    );
+    setRoleDraft("");
+  };
+
+  const removeRole = (role: string) => {
+    setValues((s) => ({
+      ...s,
+      requiredRoles: s.requiredRoles.filter((r) => r !== role),
+    }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(undefined);
+    try {
+      // Collapse the env editor rows into a dictionary at submit, dropping
+      // rows whose key is blank and trimming whitespace. Last write wins on
+      // duplicate keys, matching how Kubernetes treats env entries.
+      const environmentVariables: Record<string, string> = {};
+      for (const { key, value } of envRows) {
+        const trimmed = key.trim();
+        if (!trimmed) continue;
+        environmentVariables[trimmed] = value;
+      }
+      // Flush a pending role draft so users don't lose what's in the input.
+      const pendingRole = roleDraft.trim();
+      const finalRoles = [...values.requiredRoles.map((r) => r.trim()).filter(Boolean)];
+      if (pendingRole && !finalRoles.includes(pendingRole)) {
+        finalRoles.push(pendingRole);
+      }
+      await onSubmit({
+        ...values,
+        environmentVariables,
+        requiredRoles: finalRoles,
+      });
+    } catch (err) {
+      setError(formatApiError(err));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form className={styles.form} onSubmit={handleSubmit}>
+      {error && (
+        <MessageBar intent="error">
+          <MessageBarBody>{error}</MessageBarBody>
+        </MessageBar>
+      )}
+
+      <div className={styles.row}>
+        <Field label="Name" required hint="lowercase letters, numbers and dashes only">
+          <Input
+            value={values.name}
+            disabled={disableName}
+            onChange={(_, d) => setValues((s) => ({ ...s, name: d.value }))}
+          />
+        </Field>
+        <Field label="Replicas" required>
+          <SpinButton
+            min={0}
+            max={32}
+            value={values.replicaCount}
+            onChange={(_, d) =>
+              setValues((s) => ({ ...s, replicaCount: d.value ?? s.replicaCount }))
+            }
+          />
+        </Field>
+      </div>
+
+      <div className={styles.row}>
+        <Field label="Image name" required>
+          <Input
+            value={values.imageName}
+            onChange={(_, d) => setValues((s) => ({ ...s, imageName: d.value }))}
+          />
+        </Field>
+        <Field label="Image version" required>
+          <Input
+            value={values.imageVersion}
+            onChange={(_, d) => setValues((s) => ({ ...s, imageVersion: d.value }))}
+          />
+        </Field>
+      </div>
+
+      <Field label="Description">
+        <Textarea
+          rows={3}
+          value={values.description}
+          onChange={(_, d) => setValues((s) => ({ ...s, description: d.value }))}
+        />
+      </Field>
+
+      <Field
+        label="Required roles"
+        hint="App role values (Entra ID app roles, e.g. mcp.engineer) that grant read access. Leave empty to allow any authenticated user."
+      >
+        <div className={styles.rolesEditor}>
+          {values.requiredRoles.length > 0 ? (
+            <TagGroup
+              aria-label="Required roles"
+              onDismiss={(_, data) => removeRole(String(data.value))}
+            >
+              {values.requiredRoles.map((role) => (
+                <Tag
+                  key={role}
+                  value={role}
+                  shape="rounded"
+                  appearance="brand"
+                  dismissible
+                  dismissIcon={{ "aria-label": `Remove ${role}` }}
+                  media={<ShieldKeyholeRegular />}
+                >
+                  {role}
+                </Tag>
+              ))}
+            </TagGroup>
+          ) : (
+            <Caption1 className={styles.rolesEmpty}>
+              No roles required — any authenticated user can read this resource.
+            </Caption1>
+          )}
+          <div className={styles.rolesInputRow}>
+            <Input
+              value={roleDraft}
+              placeholder="e.g. mcp.engineer"
+              onChange={(_, d) => setRoleDraft(d.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === ",") {
+                  e.preventDefault();
+                  addRole(roleDraft);
+                } else if (
+                  e.key === "Backspace" &&
+                  roleDraft === "" &&
+                  values.requiredRoles.length > 0
+                ) {
+                  // Quick-delete the last chip when the input is empty.
+                  removeRole(values.requiredRoles[values.requiredRoles.length - 1]);
+                }
+              }}
+            />
+            <Button
+              type="button"
+              appearance="secondary"
+              icon={<AddRegular />}
+              disabled={!roleDraft.trim()}
+              onClick={() => addRole(roleDraft)}
+            >
+              Add role
+            </Button>
+          </div>
+        </div>
+      </Field>
+
+      <Field label="Use workload identity">
+        <Switch
+          checked={values.useWorkloadIdentity}
+          onChange={(_, d) => setValues((s) => ({ ...s, useWorkloadIdentity: d.checked }))}
+        />
+      </Field>
+
+      <div>
+        <Caption1 block>Environment variables</Caption1>
+        <div className={styles.envEditor}>
+          {envRows.map((row, idx) => (
+            <div key={idx} className={styles.envRow}>
+              <Input
+                placeholder="KEY"
+                value={row.key}
+                onChange={(_, d) => setEnvRowAt(idx, { key: d.value })}
+              />
+              <Input
+                placeholder="value"
+                value={row.value}
+                onChange={(_, d) => setEnvRowAt(idx, { value: d.value })}
+              />
+              <Button
+                appearance="subtle"
+                type="button"
+                onClick={() => setEnvRows((rows) => rows.filter((_, i) => i !== idx))}
+              >
+                Remove
+              </Button>
+            </div>
+          ))}
+          <Button
+            appearance="secondary"
+            type="button"
+            onClick={() => setEnvRows((rows) => [...rows, { key: "", value: "" }])}
+          >
+            Add variable
+          </Button>
+        </div>
+      </div>
+
+      {children}
+
+      <div className={styles.actions}>
+        <Button type="submit" appearance="primary" disabled={submitting}>
+          {submitting ? "Saving…" : submitLabel}
+        </Button>
+        {onCancel && (
+          <Button appearance="secondary" onClick={onCancel} disabled={submitting}>
+            Cancel
+          </Button>
+        )}
+      </div>
+    </form>
+  );
+}

--- a/portal/src/components/AdapterFormFields.tsx
+++ b/portal/src/components/AdapterFormFields.tsx
@@ -238,7 +238,7 @@ export function AdapterFormFields({
 
       <Field
         label="Required roles"
-        hint="App role values (Entra ID app roles, e.g. mcp.engineer) that grant read access. Leave empty to allow any authenticated user."
+        hint="App role values (Entra ID app roles, e.g. mcp.engineer) that grant read access. Leave empty to restrict visibility to the creator and admins only."
       >
         <div className={styles.rolesEditor}>
           {values.requiredRoles.length > 0 ? (
@@ -262,7 +262,8 @@ export function AdapterFormFields({
             </TagGroup>
           ) : (
             <Caption1 className={styles.rolesEmpty}>
-              No roles required — any authenticated user can read this resource.
+              No roles required — only the creator and admins can read this
+              resource.
             </Caption1>
           )}
           <div className={styles.rolesInputRow}>

--- a/portal/src/components/Layout.tsx
+++ b/portal/src/components/Layout.tsx
@@ -1,0 +1,459 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { useState, type ReactNode } from "react";
+import {
+  Avatar,
+  Button,
+  Caption1,
+  Dialog,
+  DialogActions,
+  DialogBody,
+  DialogContent,
+  DialogSurface,
+  DialogTitle,
+  DialogTrigger,
+  Field,
+  Input,
+  makeStyles,
+  mergeClasses,
+  tokens,
+  Tooltip,
+} from "@fluentui/react-components";
+import {
+  Link as RouterLink,
+  NavLink,
+  Outlet,
+  useLocation,
+} from "react-router-dom";
+import {
+  AppsListRegular,
+  ChevronDoubleLeftRegular,
+  ChevronDoubleRightRegular,
+  PersonRegular,
+  PuzzlePieceRegular,
+  SignOutRegular,
+} from "@fluentui/react-icons";
+import { useGateway } from "../auth/PortalProvider";
+import { signOut, getActiveAccount } from "../auth/msal";
+import {
+  defaultDevIdentity,
+  loadDevIdentity,
+  saveDevIdentity,
+  type DevIdentity,
+} from "../auth/devIdentity";
+
+const HEADER_HEIGHT = "44px";
+const RAIL_EXPANDED = "240px";
+const RAIL_COLLAPSED = "52px";
+
+const useStyles = makeStyles({
+  root: {
+    minHeight: "100vh",
+    display: "grid",
+    gridTemplateRows: `${HEADER_HEIGHT} 1fr`,
+    backgroundColor: tokens.colorNeutralBackground2,
+  },
+  header: {
+    gridRow: "1 / 2",
+    display: "flex",
+    alignItems: "center",
+    padding: "0 16px",
+    backgroundColor: tokens.colorNeutralBackground1,
+    borderBottom: `1px solid ${tokens.colorNeutralStroke2}`,
+    gap: "12px",
+    position: "sticky",
+    top: 0,
+    zIndex: 10,
+  },
+  headerBrand: {
+    display: "flex",
+    alignItems: "center",
+    gap: "10px",
+    color: tokens.colorNeutralForeground1,
+    textDecoration: "none",
+    paddingLeft: "4px",
+  },
+  brandMark: {
+    width: "22px",
+    height: "22px",
+    display: "grid",
+    gridTemplateColumns: "1fr 1fr",
+    gridTemplateRows: "1fr 1fr",
+    gap: "2px",
+    flexShrink: 0,
+  },
+  brandMarkTile: {
+    width: "100%",
+    height: "100%",
+  },
+  brandWordmark: {
+    fontSize: "15px",
+    fontWeight: tokens.fontWeightSemibold,
+    color: tokens.colorNeutralForeground1,
+    letterSpacing: "0",
+  },
+  brandDivider: {
+    width: "1px",
+    height: "22px",
+    backgroundColor: tokens.colorNeutralStroke1,
+    margin: "0 10px",
+  },
+  brandProduct: {
+    fontSize: tokens.fontSizeBase300,
+    fontWeight: tokens.fontWeightRegular,
+    color: tokens.colorNeutralForeground2,
+  },
+  headerSpacer: { flex: 1 },
+  body: {
+    gridRow: "2 / 3",
+    display: "grid",
+    gridTemplateColumns: `${RAIL_EXPANDED} 1fr`,
+    minHeight: 0,
+  },
+  bodyCollapsed: {
+    gridTemplateColumns: `${RAIL_COLLAPSED} 1fr`,
+  },
+  rail: {
+    backgroundColor: tokens.colorNeutralBackground1,
+    borderRight: `1px solid ${tokens.colorNeutralStroke2}`,
+    padding: "12px 8px",
+    display: "flex",
+    flexDirection: "column",
+    gap: "2px",
+    position: "sticky",
+    top: HEADER_HEIGHT,
+    height: `calc(100vh - ${HEADER_HEIGHT})`,
+    boxSizing: "border-box",
+    overflowY: "auto",
+  },
+  railToggle: {
+    alignSelf: "flex-end",
+    marginBottom: "4px",
+  },
+  navItem: {
+    position: "relative",
+    display: "flex",
+    alignItems: "center",
+    gap: "12px",
+    padding: "8px 12px",
+    borderRadius: tokens.borderRadiusMedium,
+    color: tokens.colorNeutralForeground2,
+    textDecoration: "none",
+    fontSize: tokens.fontSizeBase300,
+    fontWeight: tokens.fontWeightRegular,
+    transitionProperty: "background-color, color",
+    transitionDuration: tokens.durationFaster,
+    "&:hover": {
+      backgroundColor: tokens.colorNeutralBackground1Hover,
+      color: tokens.colorNeutralForeground1,
+    },
+    "&:focus-visible": {
+      outline: `2px solid ${tokens.colorStrokeFocus2}`,
+      outlineOffset: "-2px",
+    },
+  },
+  navItemActive: {
+    backgroundColor: tokens.colorNeutralBackground1Selected,
+    color: tokens.colorNeutralForeground1,
+    fontWeight: tokens.fontWeightSemibold,
+    "&:hover": {
+      backgroundColor: tokens.colorNeutralBackground1Hover,
+      color: tokens.colorNeutralForeground1,
+    },
+    "&::before": {
+      content: '""',
+      position: "absolute",
+      left: 0,
+      top: "6px",
+      bottom: "6px",
+      width: "3px",
+      borderRadius: "0 2px 2px 0",
+      backgroundColor: tokens.colorBrandStroke1,
+    },
+  },
+  navIcon: {
+    fontSize: "20px",
+    width: "20px",
+    height: "20px",
+    display: "grid",
+    placeItems: "center",
+    flexShrink: 0,
+  },
+  navLabel: {
+    whiteSpace: "nowrap",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+  },
+  navLabelHidden: {
+    display: "none",
+  },
+  navItemCollapsed: {
+    justifyContent: "center",
+    padding: "10px 0",
+  },
+  content: {
+    minWidth: 0,
+    padding: "24px 32px",
+    maxWidth: "1440px",
+    width: "100%",
+    boxSizing: "border-box",
+    margin: "0 auto",
+  },
+  identity: {
+    display: "flex",
+    alignItems: "center",
+    gap: "10px",
+  },
+  identityName: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "flex-end",
+    lineHeight: 1.1,
+  },
+  identityPrimary: {
+    fontSize: tokens.fontSizeBase300,
+    fontWeight: tokens.fontWeightSemibold,
+    color: tokens.colorNeutralForeground1,
+  },
+  identityCaption: {
+    fontSize: tokens.fontSizeBase200,
+    color: tokens.colorNeutralForeground3,
+  },
+});
+
+interface NavEntry {
+  to: string;
+  label: string;
+  icon: ReactNode;
+  match: (pathname: string) => boolean;
+}
+
+const navEntries: NavEntry[] = [
+  {
+    to: "/adapters",
+    label: "MCP Servers",
+    icon: <AppsListRegular />,
+    match: (p) => p.startsWith("/adapters") || p === "/",
+  },
+  {
+    to: "/tools",
+    label: "Tools",
+    icon: <PuzzlePieceRegular />,
+    match: (p) => p.startsWith("/tools"),
+  },
+];
+
+export function Layout() {
+  const styles = useStyles();
+  const { config } = useGateway();
+  const location = useLocation();
+  const [collapsed, setCollapsed] = useState(false);
+
+  return (
+    <div className={styles.root}>
+      <header className={styles.header}>
+        <RouterLink className={styles.headerBrand} to="/">
+          <span className={styles.brandMark} aria-hidden="true">
+            <span
+              className={styles.brandMarkTile}
+              style={{ backgroundColor: "#F25022" }}
+            />
+            <span
+              className={styles.brandMarkTile}
+              style={{ backgroundColor: "#7FBA00" }}
+            />
+            <span
+              className={styles.brandMarkTile}
+              style={{ backgroundColor: "#00A4EF" }}
+            />
+            <span
+              className={styles.brandMarkTile}
+              style={{ backgroundColor: "#FFB900" }}
+            />
+          </span>
+          <span className={styles.brandWordmark}>Microsoft</span>
+          <span className={styles.brandDivider} />
+          <span className={styles.brandProduct}>MCP Gateway</span>
+        </RouterLink>
+        <div className={styles.headerSpacer} />
+        <div className={styles.identity}>
+          {config.isDevelopment ? <DevIdentitySwitcher /> : <SignedInUser />}
+        </div>
+      </header>
+      <div
+        className={mergeClasses(
+          styles.body,
+          collapsed ? styles.bodyCollapsed : undefined,
+        )}
+      >
+        <nav className={styles.rail} aria-label="Primary">
+          <Tooltip
+            content={collapsed ? "Expand navigation" : "Collapse navigation"}
+            relationship="label"
+          >
+            <Button
+              appearance="subtle"
+              size="small"
+              className={styles.railToggle}
+              icon={
+                collapsed ? (
+                  <ChevronDoubleRightRegular />
+                ) : (
+                  <ChevronDoubleLeftRegular />
+                )
+              }
+              onClick={() => setCollapsed((v) => !v)}
+              aria-label={
+                collapsed ? "Expand navigation" : "Collapse navigation"
+              }
+            />
+          </Tooltip>
+          {navEntries.map((entry) => {
+            const active = entry.match(location.pathname);
+            const item = (
+              <NavLink
+                key={entry.to}
+                to={entry.to}
+                className={mergeClasses(
+                  styles.navItem,
+                  active ? styles.navItemActive : undefined,
+                  collapsed ? styles.navItemCollapsed : undefined,
+                )}
+                aria-current={active ? "page" : undefined}
+              >
+                <span className={styles.navIcon} aria-hidden="true">
+                  {entry.icon}
+                </span>
+                <span
+                  className={mergeClasses(
+                    styles.navLabel,
+                    collapsed ? styles.navLabelHidden : undefined,
+                  )}
+                >
+                  {entry.label}
+                </span>
+              </NavLink>
+            );
+            return collapsed ? (
+              <Tooltip
+                key={entry.to}
+                content={entry.label}
+                relationship="label"
+                positioning="after"
+              >
+                {item}
+              </Tooltip>
+            ) : (
+              item
+            );
+          })}
+        </nav>
+        <main className={styles.content}>
+          <Outlet />
+        </main>
+      </div>
+    </div>
+  );
+}
+
+function SignedInUser() {
+  const styles = useStyles();
+  const { config } = useGateway();
+  const account = getActiveAccount();
+  if (!account) return null;
+  const name = account.name ?? account.username;
+  return (
+    <>
+      <Avatar name={name} size={28} color="colorful" />
+      <div className={styles.identityName}>
+        <span className={styles.identityPrimary}>{name}</span>
+        <span className={styles.identityCaption}>{account.username}</span>
+      </div>
+      <Tooltip content="Sign out" relationship="label">
+        <Button
+          appearance="subtle"
+          icon={<SignOutRegular />}
+          onClick={() => {
+            void signOut(config);
+          }}
+          aria-label="Sign out"
+        />
+      </Tooltip>
+    </>
+  );
+}
+
+function DevIdentitySwitcher() {
+  const styles = useStyles();
+  const [identity, setIdentity] = useState<DevIdentity>(() => loadDevIdentity());
+  const [open, setOpen] = useState(false);
+  const [draft, setDraft] = useState<DevIdentity>(identity);
+
+  const apply = () => {
+    saveDevIdentity(draft);
+    setIdentity(draft);
+    setOpen(false);
+    // Force any in-flight queries to re-run with the new headers.
+    window.location.reload();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(_, data) => setOpen(data.open)}>
+      <DialogTrigger disableButtonEnhancement>
+        <Tooltip content="Switch dev identity" relationship="label">
+          <Button
+            appearance="subtle"
+            icon={<PersonRegular />}
+            onClick={() => setDraft(identity)}
+          >
+            <span className={styles.identityPrimary}>{identity.displayName}</span>
+          </Button>
+        </Tooltip>
+      </DialogTrigger>
+      <DialogSurface>
+        <DialogBody>
+          <DialogTitle>Development identity</DialogTitle>
+          <DialogContent>
+            <Caption1 block style={{ marginBottom: 12 }}>
+              These values are sent to the gateway via the <code>X-Dev-UserId</code>,
+              {" "}<code>X-Dev-Name</code>, and <code>X-Dev-Roles</code> headers so the
+              local <code>DevelopmentAuthenticationHandler</code> mints a matching
+              principal. Use roles like <code>mcp.admin</code>, <code>mcp.engineer</code>,
+              or any value you configured for your adapters / tools.
+            </Caption1>
+            <Field label="User id" required>
+              <Input
+                value={draft.userId}
+                onChange={(_, d) => setDraft((s) => ({ ...s, userId: d.value }))}
+              />
+            </Field>
+            <Field label="Display name">
+              <Input
+                value={draft.displayName}
+                onChange={(_, d) => setDraft((s) => ({ ...s, displayName: d.value }))}
+              />
+            </Field>
+            <Field
+              label="Roles (comma-separated)"
+              hint="e.g. mcp.admin,mcp.engineer"
+            >
+              <Input
+                value={draft.roles}
+                onChange={(_, d) => setDraft((s) => ({ ...s, roles: d.value }))}
+              />
+            </Field>
+          </DialogContent>
+          <DialogActions>
+            <Button appearance="secondary" onClick={() => setDraft(defaultDevIdentity)}>
+              Reset
+            </Button>
+            <Button appearance="primary" onClick={apply}>
+              Apply
+            </Button>
+          </DialogActions>
+        </DialogBody>
+      </DialogSurface>
+    </Dialog>
+  );
+}

--- a/portal/src/components/McpTestPanel.tsx
+++ b/portal/src/components/McpTestPanel.tsx
@@ -1,0 +1,1034 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { useCallback, useState } from "react";
+import {
+  Badge,
+  Button,
+  Caption1,
+  Card,
+  CardHeader,
+  Dropdown,
+  Field,
+  Input,
+  MessageBar,
+  MessageBarBody,
+  Option,
+  Spinner,
+  Subtitle2,
+  Switch,
+  Tab,
+  TabList,
+  Textarea,
+  Tooltip,
+  makeStyles,
+  tokens,
+} from "@fluentui/react-components";
+import {
+  ArrowClockwiseRegular,
+  ChevronDown24Regular,
+  ChevronRight24Regular,
+  DismissRegular,
+  PlayRegular,
+  PlugConnected24Regular,
+  PlugDisconnected24Regular,
+} from "@fluentui/react-icons";
+import { useGateway } from "../auth/PortalProvider";
+import { formatApiError } from "../hooks/useAsync";
+
+const useStyles = makeStyles({
+  root: {
+    display: "grid",
+    gap: "12px",
+  },
+  headerRow: {
+    display: "flex",
+    alignItems: "center",
+    gap: "8px",
+    flexWrap: "wrap",
+  },
+  endpoint: {
+    fontFamily: tokens.fontFamilyMonospace,
+    fontSize: tokens.fontSizeBase200,
+    color: tokens.colorNeutralForeground3,
+  },
+  serverInfo: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "2px",
+    padding: "8px 12px",
+    backgroundColor: tokens.colorNeutralBackground2,
+    borderRadius: tokens.borderRadiusMedium,
+  },
+  toolGrid: {
+    display: "grid",
+    gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))",
+    gap: "8px",
+  },
+  toolCard: {
+    padding: "12px",
+    border: `1px solid ${tokens.colorNeutralStroke2}`,
+    borderRadius: tokens.borderRadiusMedium,
+    cursor: "pointer",
+    backgroundColor: tokens.colorNeutralBackground1,
+    textAlign: "left",
+    transition: "background-color 80ms ease-in",
+    ":hover": {
+      backgroundColor: tokens.colorNeutralBackground1Hover,
+    },
+  },
+  toolCardSelected: {
+    border: `1px solid ${tokens.colorBrandStroke1}`,
+    backgroundColor: tokens.colorBrandBackground2,
+  },
+  toolName: {
+    fontWeight: tokens.fontWeightSemibold,
+    fontFamily: tokens.fontFamilyMonospace,
+    fontSize: tokens.fontSizeBase300,
+  },
+  toolDesc: {
+    color: tokens.colorNeutralForeground3,
+    fontSize: tokens.fontSizeBase200,
+    marginTop: "4px",
+    display: "-webkit-box",
+    WebkitLineClamp: 2,
+    WebkitBoxOrient: "vertical",
+    overflow: "hidden",
+  },
+  runCard: {
+    padding: "12px",
+    border: `1px solid ${tokens.colorNeutralStroke2}`,
+    borderRadius: tokens.borderRadiusMedium,
+    display: "grid",
+    gap: "10px",
+  },
+  pre: {
+    margin: 0,
+    padding: "12px",
+    backgroundColor: tokens.colorNeutralBackground3,
+    borderRadius: tokens.borderRadiusMedium,
+    fontFamily: tokens.fontFamilyMonospace,
+    fontSize: tokens.fontSizeBase200,
+    whiteSpace: "pre-wrap",
+    wordBreak: "break-word",
+    maxHeight: "320px",
+    overflow: "auto",
+  },
+  advancedHeader: {
+    display: "flex",
+    alignItems: "center",
+    gap: "4px",
+    cursor: "pointer",
+    color: tokens.colorNeutralForeground2,
+    padding: "4px 0",
+    userSelect: "none",
+  },
+  toolbar: {
+    display: "flex",
+    gap: "8px",
+    flexWrap: "wrap",
+    alignItems: "center",
+  },
+  sessionRow: {
+    display: "flex",
+    alignItems: "center",
+    gap: "8px",
+  },
+});
+
+interface Props {
+  /**
+   * Adapter / tool name to target. Omit for the dynamic tool-router endpoint
+   * (`POST /mcp`).
+   */
+  resourceName?: string;
+}
+
+interface McpTool {
+  name: string;
+  title?: string;
+  description?: string;
+  inputSchema?: JsonSchema;
+}
+
+interface JsonSchema {
+  type?: string;
+  properties?: Record<string, JsonSchema>;
+  required?: string[];
+  description?: string;
+  enum?: unknown[];
+  default?: unknown;
+  items?: JsonSchema;
+}
+
+interface ServerInfo {
+  name?: string;
+  version?: string;
+  protocolVersion?: string;
+}
+
+interface ToolCallResult {
+  isError: boolean;
+  content: Array<{ type: string; text?: string; [key: string]: unknown }>;
+  structuredContent?: unknown;
+}
+
+interface HistoryEntry {
+  id: number;
+  method: string;
+  request: unknown;
+  response: unknown;
+  status: number;
+  contentType: string | null;
+  durationMs: number;
+  error?: string;
+}
+
+let counter = 0;
+
+/**
+ * Friendly MCP test console. The default view connects to the server, lists
+ * its tools, and lets the user run them by filling out a form derived from the
+ * tool's JSON Schema. The full JSON-RPC sandbox is still available under the
+ * Advanced section for power users.
+ */
+export function McpTestPanel({ resourceName }: Props) {
+  const styles = useStyles();
+  const { api } = useGateway();
+
+  // -- session / discovery state ---------------------------------------
+  const [sessionId, setSessionId] = useState<string | undefined>();
+  const [serverInfo, setServerInfo] = useState<ServerInfo | undefined>();
+  const [tools, setTools] = useState<McpTool[]>([]);
+  const [connecting, setConnecting] = useState(false);
+  const [connectError, setConnectError] = useState<string | undefined>();
+  const [refreshing, setRefreshing] = useState(false);
+
+  // -- per-tool run state ----------------------------------------------
+  const [selectedTool, setSelectedTool] = useState<string | undefined>();
+  const [toolArgs, setToolArgs] = useState<Record<string, unknown>>({});
+  const [running, setRunning] = useState(false);
+  const [result, setResult] = useState<ToolCallResult | undefined>();
+  const [runError, setRunError] = useState<string | undefined>();
+
+  // -- advanced (raw JSON-RPC) state -----------------------------------
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+  const [rawText, setRawText] = useState<string>(
+    JSON.stringify(rawSamples.initialize, null, 2),
+  );
+  const [rawHistory, setRawHistory] = useState<HistoryEntry[]>([]);
+  const [rawSending, setRawSending] = useState(false);
+  const [rawParseError, setRawParseError] = useState<string | undefined>();
+  const [rawTransportError, setRawTransportError] = useState<string | undefined>();
+  const [rawSelectedTab, setRawSelectedTab] = useState<"request" | "response">(
+    "response",
+  );
+
+  const endpointPath = resourceName
+    ? `POST /adapters/${resourceName}/mcp`
+    : "POST /mcp";
+
+  const sendRpc = useCallback(
+    async (body: unknown, session?: string) => {
+      const response = await api.sendMcpRequest(resourceName, body, {
+        sessionId: session ?? sessionId,
+      });
+      const contentType = response.headers.get("content-type");
+      const newSession = response.headers.get("mcp-session-id");
+      const parsed = await readBody(response, contentType);
+      return { response, contentType, newSession, parsed };
+    },
+    [api, resourceName, sessionId],
+  );
+
+  // -- connect: initialize → notifications/initialized → tools/list ----
+  const connect = async () => {
+    setConnecting(true);
+    setConnectError(undefined);
+    setResult(undefined);
+    setRunError(undefined);
+    try {
+      const init = await sendRpc(
+        {
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: {
+            protocolVersion: "2025-06-18",
+            capabilities: {},
+            clientInfo: { name: "mcp-gateway-portal", version: "0.1.0" },
+          },
+        },
+        undefined,
+      );
+      if (!init.response.ok) {
+        throw new Error(
+          `initialize failed: HTTP ${init.response.status} ${init.response.statusText}`,
+        );
+      }
+      const initResult = extractRpcResult(init.parsed) as
+        | { protocolVersion?: string; serverInfo?: { name?: string; version?: string } }
+        | undefined;
+      const newSession = init.newSession ?? undefined;
+      setSessionId(newSession);
+      setServerInfo({
+        name: initResult?.serverInfo?.name,
+        version: initResult?.serverInfo?.version,
+        protocolVersion: initResult?.protocolVersion,
+      });
+
+      // Ack the handshake (best-effort; MCP servers return 202 with null body).
+      await sendRpc(
+        { jsonrpc: "2.0", method: "notifications/initialized" },
+        newSession,
+      );
+
+      const list = await sendRpc(
+        { jsonrpc: "2.0", id: 2, method: "tools/list" },
+        newSession,
+      );
+      if (!list.response.ok) {
+        throw new Error(
+          `tools/list failed: HTTP ${list.response.status} ${list.response.statusText}`,
+        );
+      }
+      const listResult = extractRpcResult(list.parsed) as
+        | { tools?: McpTool[] }
+        | undefined;
+      const fetched = listResult?.tools ?? [];
+      setTools(fetched);
+      // Auto-select the first tool so the user immediately sees a runnable form.
+      if (fetched.length > 0) {
+        const first = fetched[0];
+        setSelectedTool(first.name);
+        setToolArgs(defaultArgsFor(first.inputSchema));
+      } else {
+        setSelectedTool(undefined);
+        setToolArgs({});
+      }
+    } catch (err) {
+      setConnectError(formatApiError(err));
+    } finally {
+      setConnecting(false);
+    }
+  };
+
+  const refreshTools = async () => {
+    if (!sessionId) return;
+    setRefreshing(true);
+    setRunError(undefined);
+    try {
+      const list = await sendRpc({
+        jsonrpc: "2.0",
+        id: ++counter,
+        method: "tools/list",
+      });
+      if (!list.response.ok) {
+        throw new Error(
+          `tools/list failed: HTTP ${list.response.status} ${list.response.statusText}`,
+        );
+      }
+      const listResult = extractRpcResult(list.parsed) as
+        | { tools?: McpTool[] }
+        | undefined;
+      setTools(listResult?.tools ?? []);
+    } catch (err) {
+      setRunError(formatApiError(err));
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  const disconnect = () => {
+    setSessionId(undefined);
+    setServerInfo(undefined);
+    setTools([]);
+    setSelectedTool(undefined);
+    setToolArgs({});
+    setResult(undefined);
+    setRunError(undefined);
+    setConnectError(undefined);
+  };
+
+  const currentTool = tools.find((t) => t.name === selectedTool);
+
+  const selectTool = (tool: McpTool) => {
+    setSelectedTool(tool.name);
+    setToolArgs(defaultArgsFor(tool.inputSchema));
+    setResult(undefined);
+    setRunError(undefined);
+  };
+
+  const runTool = async () => {
+    if (!currentTool) return;
+    setRunning(true);
+    setRunError(undefined);
+    setResult(undefined);
+    try {
+      const call = await sendRpc({
+        jsonrpc: "2.0",
+        id: ++counter,
+        method: "tools/call",
+        params: {
+          name: currentTool.name,
+          arguments: toolArgs,
+        },
+      });
+      if (!call.response.ok) {
+        throw new Error(
+          `tools/call failed: HTTP ${call.response.status} ${call.response.statusText}`,
+        );
+      }
+      const callResult = extractRpcResult(call.parsed) as ToolCallResult | undefined;
+      setResult(
+        callResult ?? {
+          isError: false,
+          content: [
+            { type: "text", text: "(server returned no result payload)" },
+          ],
+        },
+      );
+    } catch (err) {
+      setRunError(formatApiError(err));
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  // ----- advanced raw JSON-RPC ---------------------------------------
+  const loadRawSample = (key: keyof typeof rawSamples) => {
+    setRawText(JSON.stringify(rawSamples[key], null, 2));
+    setRawParseError(undefined);
+  };
+
+  const sendRaw = async () => {
+    setRawParseError(undefined);
+    setRawTransportError(undefined);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(rawText);
+    } catch (err) {
+      setRawParseError((err as Error).message);
+      return;
+    }
+    setRawSending(true);
+    const started = performance.now();
+    try {
+      const response = await api.sendMcpRequest(resourceName, parsed, {
+        sessionId,
+      });
+      const elapsed = Math.round(performance.now() - started);
+      const newSession = response.headers.get("mcp-session-id");
+      if (newSession && newSession !== sessionId) setSessionId(newSession);
+      const contentType = response.headers.get("content-type");
+      const body = await readBody(response, contentType);
+      const method = extractMethod(parsed) ?? "<unknown>";
+      const entry: HistoryEntry = {
+        id: ++counter,
+        method,
+        request: parsed,
+        response: body,
+        status: response.status,
+        contentType,
+        durationMs: elapsed,
+        error: response.ok
+          ? undefined
+          : `HTTP ${response.status} ${response.statusText}`,
+      };
+      setRawHistory((h) => [entry, ...h].slice(0, 20));
+      setRawSelectedTab("response");
+    } catch (err) {
+      setRawTransportError(formatApiError(err));
+    } finally {
+      setRawSending(false);
+    }
+  };
+
+  const rawLatest = rawHistory[0];
+
+  const connected = Boolean(sessionId);
+
+  return (
+    <Card className={styles.root}>
+      <CardHeader
+        header={<Subtitle2>Test connection</Subtitle2>}
+        description={<span className={styles.endpoint}>{endpointPath}</span>}
+        action={
+          <div className={styles.sessionRow}>
+            {connected ? (
+              <>
+                <Tooltip content={sessionId!} relationship="label">
+                  <Badge appearance="filled" color="success">
+                    connected · session {sessionId!.slice(0, 6)}…
+                  </Badge>
+                </Tooltip>
+                <Tooltip content="Disconnect & reset session" relationship="label">
+                  <Button
+                    appearance="subtle"
+                    icon={<DismissRegular />}
+                    onClick={disconnect}
+                  />
+                </Tooltip>
+              </>
+            ) : (
+              <Badge appearance="outline" color="informative">
+                disconnected
+              </Badge>
+            )}
+          </div>
+        }
+      />
+
+      {/* connect / server info */}
+      {!connected ? (
+        <div className={styles.toolbar}>
+          <Button
+            appearance="primary"
+            icon={connecting ? <Spinner size="tiny" /> : <PlugConnected24Regular />}
+            onClick={connect}
+            disabled={connecting}
+          >
+            {connecting ? "Connecting…" : "Connect"}
+          </Button>
+          <Caption1>
+            Runs <code>initialize</code> + <code>tools/list</code> against the
+            server and shows the discovered tools.
+          </Caption1>
+        </div>
+      ) : (
+        <div className={styles.serverInfo}>
+          <div>
+            <strong>{serverInfo?.name ?? "(unnamed server)"}</strong>
+            {serverInfo?.version ? ` · v${serverInfo.version}` : ""}
+          </div>
+          <Caption1>
+            MCP protocol {serverInfo?.protocolVersion ?? "unknown"} · session{" "}
+            <code>{sessionId}</code>
+          </Caption1>
+          <div className={styles.toolbar} style={{ marginTop: 4 }}>
+            <Button
+              size="small"
+              appearance="secondary"
+              icon={<ArrowClockwiseRegular />}
+              onClick={refreshTools}
+              disabled={refreshing}
+            >
+              {refreshing ? "Refreshing…" : "Refresh tools"}
+            </Button>
+            <Button
+              size="small"
+              appearance="subtle"
+              icon={<PlugDisconnected24Regular />}
+              onClick={disconnect}
+            >
+              Disconnect
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {connectError && (
+        <MessageBar intent="error">
+          <MessageBarBody>{connectError}</MessageBarBody>
+        </MessageBar>
+      )}
+
+      {/* tool list */}
+      {connected && (
+        <div>
+          <Caption1 block style={{ marginBottom: 6 }}>
+            {tools.length === 0
+              ? "Server reported zero tools."
+              : `Tools (${tools.length})`}
+          </Caption1>
+          {tools.length > 0 && (
+            <div className={styles.toolGrid}>
+              {tools.map((t) => {
+                const isSelected = t.name === selectedTool;
+                return (
+                  <button
+                    key={t.name}
+                    type="button"
+                    className={`${styles.toolCard} ${
+                      isSelected ? styles.toolCardSelected : ""
+                    }`}
+                    onClick={() => selectTool(t)}
+                  >
+                    <div className={styles.toolName}>{t.name}</div>
+                    {(t.title || t.description) && (
+                      <div className={styles.toolDesc}>
+                        {t.title ?? t.description}
+                      </div>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* run form */}
+      {connected && currentTool && (
+        <div className={styles.runCard}>
+          <div>
+            <Subtitle2>{currentTool.title ?? currentTool.name}</Subtitle2>
+            {currentTool.description && (
+              <Caption1 block style={{ marginTop: 2 }}>
+                {currentTool.description}
+              </Caption1>
+            )}
+          </div>
+
+          <SchemaForm
+            schema={currentTool.inputSchema}
+            value={toolArgs}
+            onChange={setToolArgs}
+          />
+
+          <div className={styles.toolbar}>
+            <Button
+              appearance="primary"
+              icon={running ? <Spinner size="tiny" /> : <PlayRegular />}
+              onClick={runTool}
+              disabled={running}
+            >
+              {running ? "Running…" : `Run ${currentTool.name}`}
+            </Button>
+          </div>
+
+          {runError && (
+            <MessageBar intent="error">
+              <MessageBarBody>{runError}</MessageBarBody>
+            </MessageBar>
+          )}
+
+          {result && <ToolResultView result={result} />}
+        </div>
+      )}
+
+      {/* advanced raw console */}
+      <div
+        className={styles.advancedHeader}
+        onClick={() => setAdvancedOpen((v) => !v)}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") setAdvancedOpen((v) => !v);
+        }}
+      >
+        {advancedOpen ? <ChevronDown24Regular /> : <ChevronRight24Regular />}
+        <strong>Advanced</strong>
+        <Caption1>Send raw JSON-RPC requests</Caption1>
+      </div>
+
+      {advancedOpen && (
+        <div className={styles.runCard}>
+          <div className={styles.toolbar}>
+            {(Object.keys(rawSamples) as Array<keyof typeof rawSamples>).map(
+              (key) => (
+                <Button
+                  key={key}
+                  appearance="secondary"
+                  size="small"
+                  onClick={() => loadRawSample(key)}
+                >
+                  {key}
+                </Button>
+              ),
+            )}
+          </div>
+          <Field
+            label="JSON-RPC request"
+            validationMessage={rawParseError}
+            validationState={rawParseError ? "error" : "none"}
+          >
+            <Textarea
+              rows={8}
+              textarea={{
+                style: {
+                  fontFamily: tokens.fontFamilyMonospace,
+                  fontSize: 13,
+                },
+              }}
+              value={rawText}
+              onChange={(_, d) => setRawText(d.value)}
+            />
+          </Field>
+          <div className={styles.toolbar}>
+            <Button
+              appearance="primary"
+              icon={<PlayRegular />}
+              onClick={sendRaw}
+              disabled={rawSending}
+            >
+              {rawSending ? "Sending…" : "Send"}
+            </Button>
+          </div>
+          {rawTransportError && (
+            <MessageBar intent="error">
+              <MessageBarBody>{rawTransportError}</MessageBarBody>
+            </MessageBar>
+          )}
+          {rawLatest && (
+            <div>
+              <TabList
+                selectedValue={rawSelectedTab}
+                onTabSelect={(_, d) =>
+                  setRawSelectedTab(d.value as "request" | "response")
+                }
+              >
+                <Tab value="response">
+                  Response{" "}
+                  <Badge
+                    appearance="tint"
+                    color={rawLatest.error ? "danger" : "success"}
+                    style={{ marginLeft: 6 }}
+                  >
+                    {rawLatest.status} · {rawLatest.durationMs}ms
+                  </Badge>
+                </Tab>
+                <Tab value="request">Request</Tab>
+              </TabList>
+              <pre className={styles.pre}>
+                {rawSelectedTab === "request"
+                  ? prettyJson(rawLatest.request)
+                  : prettyJson(rawLatest.response)}
+              </pre>
+            </div>
+          )}
+        </div>
+      )}
+    </Card>
+  );
+}
+
+// ---------- subcomponents ------------------------------------------------
+
+interface SchemaFormProps {
+  schema: JsonSchema | undefined;
+  value: Record<string, unknown>;
+  onChange: (next: Record<string, unknown>) => void;
+}
+
+/**
+ * Renders a simple Fluent UI form from a JSON Schema object. Supports the
+ * common MCP cases (string / number / integer / boolean / enum / array /
+ * nested object). Anything we can't render natively falls back to a JSON
+ * textarea so the user can still provide a value.
+ */
+function SchemaForm({ schema, value, onChange }: SchemaFormProps) {
+  const properties = schema?.properties ?? {};
+  const required = new Set(schema?.required ?? []);
+  const entries = Object.entries(properties);
+
+  if (entries.length === 0) {
+    return <Caption1>This tool takes no input parameters.</Caption1>;
+  }
+
+  const set = (key: string, v: unknown) => onChange({ ...value, [key]: v });
+
+  return (
+    <div style={{ display: "grid", gap: 10 }}>
+      {entries.map(([key, propSchema]) => (
+        <SchemaField
+          key={key}
+          name={key}
+          required={required.has(key)}
+          schema={propSchema}
+          value={value[key]}
+          onChange={(v) => set(key, v)}
+        />
+      ))}
+    </div>
+  );
+}
+
+interface SchemaFieldProps {
+  name: string;
+  required: boolean;
+  schema: JsonSchema;
+  value: unknown;
+  onChange: (next: unknown) => void;
+}
+
+function SchemaField({ name, required, schema, value, onChange }: SchemaFieldProps) {
+  const label = (
+    <span>
+      <code>{name}</code>
+      {schema.description ? ` — ${schema.description}` : ""}
+    </span>
+  );
+
+  // enum → Dropdown
+  if (Array.isArray(schema.enum) && schema.enum.length > 0) {
+    const current = value === undefined ? "" : String(value);
+    return (
+      <Field label={label} required={required}>
+        <Dropdown
+          value={current}
+          selectedOptions={current ? [current] : []}
+          onOptionSelect={(_, d) => onChange(d.optionValue)}
+        >
+          {schema.enum.map((opt) => {
+            const v = String(opt);
+            return (
+              <Option key={v} value={v}>
+                {v}
+              </Option>
+            );
+          })}
+        </Dropdown>
+      </Field>
+    );
+  }
+
+  switch (schema.type) {
+    case "boolean":
+      return (
+        <Field label={label} required={required}>
+          <Switch
+            checked={Boolean(value)}
+            onChange={(_, d) => onChange(d.checked)}
+          />
+        </Field>
+      );
+    case "integer":
+    case "number":
+      return (
+        <Field label={label} required={required}>
+          <Input
+            type="number"
+            value={value === undefined || value === null ? "" : String(value)}
+            onChange={(_, d) => {
+              if (d.value === "") {
+                onChange(undefined);
+                return;
+              }
+              const parsed = schema.type === "integer"
+                ? parseInt(d.value, 10)
+                : parseFloat(d.value);
+              onChange(Number.isNaN(parsed) ? d.value : parsed);
+            }}
+          />
+        </Field>
+      );
+    case "object":
+    case "array": {
+      const text =
+        value === undefined || value === null
+          ? ""
+          : typeof value === "string"
+          ? value
+          : prettyJson(value);
+      return (
+        <Field
+          label={label}
+          required={required}
+          hint={`Enter a JSON ${schema.type}`}
+        >
+          <Textarea
+            rows={4}
+            textarea={{
+              style: {
+                fontFamily: tokens.fontFamilyMonospace,
+                fontSize: 13,
+              },
+            }}
+            value={text}
+            onChange={(_, d) => {
+              try {
+                onChange(d.value === "" ? undefined : JSON.parse(d.value));
+              } catch {
+                // Keep the raw string so the user can keep typing; it will be
+                // sent as-is and the server will reject malformed JSON.
+                onChange(d.value);
+              }
+            }}
+          />
+        </Field>
+      );
+    }
+    case "string":
+    default:
+      return (
+        <Field label={label} required={required}>
+          <Input
+            value={value === undefined || value === null ? "" : String(value)}
+            onChange={(_, d) => onChange(d.value)}
+          />
+        </Field>
+      );
+  }
+}
+
+function ToolResultView({ result }: { result: ToolCallResult }) {
+  const styles = useStyles();
+  return (
+    <div style={{ display: "grid", gap: 8 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <Subtitle2>Result</Subtitle2>
+        <Badge
+          appearance="tint"
+          color={result.isError ? "danger" : "success"}
+        >
+          {result.isError ? "error" : "ok"}
+        </Badge>
+      </div>
+      {result.content?.map((item, i) => {
+        if (item.type === "text" && typeof item.text === "string") {
+          return (
+            <pre key={i} className={styles.pre}>
+              {item.text}
+            </pre>
+          );
+        }
+        return (
+          <pre key={i} className={styles.pre}>
+            {prettyJson(item)}
+          </pre>
+        );
+      })}
+      {result.structuredContent !== undefined && (
+        <>
+          <Caption1>structuredContent</Caption1>
+          <pre className={styles.pre}>{prettyJson(result.structuredContent)}</pre>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ---------- helpers ------------------------------------------------------
+
+const rawSamples: Record<string, object> = {
+  initialize: {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {
+      protocolVersion: "2025-06-18",
+      capabilities: {},
+      clientInfo: { name: "mcp-gateway-portal", version: "0.1.0" },
+    },
+  },
+  "notifications/initialized": {
+    jsonrpc: "2.0",
+    method: "notifications/initialized",
+  },
+  "tools/list": { jsonrpc: "2.0", id: 2, method: "tools/list" },
+  "tools/call": {
+    jsonrpc: "2.0",
+    id: 3,
+    method: "tools/call",
+    params: { name: "<tool-name>", arguments: {} },
+  },
+  ping: { jsonrpc: "2.0", id: 4, method: "ping" },
+};
+
+function defaultArgsFor(schema: JsonSchema | undefined): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  const props = schema?.properties ?? {};
+  for (const [name, prop] of Object.entries(props)) {
+    if (prop.default !== undefined) out[name] = prop.default;
+  }
+  return out;
+}
+
+/**
+ * Pulls the `.result` field out of whatever the MCP server returned. The
+ * server may answer with a plain JSON object, an SSE stream (in which case
+ * `readBody` returns an array of event payloads), or a raw string. We pick
+ * the first entry that looks like a JSON-RPC response.
+ */
+function extractRpcResult(body: unknown): unknown {
+  if (body === null || body === undefined) return undefined;
+  if (Array.isArray(body)) {
+    for (const evt of body) {
+      const r = extractRpcResult(evt);
+      if (r !== undefined) return r;
+    }
+    return undefined;
+  }
+  if (typeof body === "object") {
+    const obj = body as { result?: unknown; error?: unknown };
+    if (obj.result !== undefined) return obj.result;
+  }
+  return undefined;
+}
+
+async function readBody(
+  response: Response,
+  contentType: string | null,
+): Promise<unknown> {
+  // MCP servers may answer with either JSON or text/event-stream. We accept
+  // both: SSE is decoded line by line and the `data:` payloads are collected
+  // into an array.
+  if (contentType?.includes("text/event-stream")) {
+    return await readSse(response);
+  }
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+async function readSse(response: Response): Promise<unknown[]> {
+  const reader = response.body?.getReader();
+  if (!reader) return [];
+  const decoder = new TextDecoder();
+  let buffer = "";
+  const events: unknown[] = [];
+
+  // Accept both LF-only and CRLF event delimiters and flush any trailing
+  // partial event when the stream closes — FastMCP / streamable-http servers
+  // emit `\r\n\r\n` between events and may not append a final blank line.
+  const flush = (chunk: string) => {
+    const data = chunk
+      .split(/\r?\n/)
+      .filter((l) => l.startsWith("data:"))
+      .map((l) => l.slice(5).trim())
+      .join("\n");
+    if (!data) return;
+    try {
+      events.push(JSON.parse(data));
+    } catch {
+      events.push(data);
+    }
+  };
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    // Match a blank line that may use either LF or CRLF separators.
+    const re = /\r?\n\r?\n/g;
+    let match: RegExpExecArray | null;
+    let lastEnd = 0;
+    while ((match = re.exec(buffer)) !== null) {
+      flush(buffer.slice(lastEnd, match.index));
+      lastEnd = match.index + match[0].length;
+    }
+    buffer = lastEnd > 0 ? buffer.slice(lastEnd) : buffer;
+  }
+  // Final flush: some servers close the stream without a trailing blank line.
+  if (buffer.trim()) flush(buffer);
+  return events;
+}
+
+function extractMethod(req: unknown): string | undefined {
+  if (typeof req !== "object" || req === null) return undefined;
+  const value = (req as { method?: unknown }).method;
+  return typeof value === "string" ? value : undefined;
+}
+
+function prettyJson(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}

--- a/portal/src/components/McpTestPanel.tsx
+++ b/portal/src/components/McpTestPanel.tsx
@@ -142,6 +142,13 @@ interface Props {
    * (`POST /mcp`).
    */
   resourceName?: string;
+  /**
+   * When set, the panel auto-selects this tool (instead of the first one
+   * returned by `tools/list`) after connecting. Used by the tool detail page
+   * so Run exercises the tool shown in the header rather than whichever tool
+   * happens to come back first from the dynamic router.
+   */
+  pinnedTool?: string;
 }
 
 interface McpTool {
@@ -192,7 +199,7 @@ let counter = 0;
  * tool's JSON Schema. The full JSON-RPC sandbox is still available under the
  * Advanced section for power users.
  */
-export function McpTestPanel({ resourceName }: Props) {
+export function McpTestPanel({ resourceName, pinnedTool }: Props) {
   const styles = useStyles();
   const { api } = useGateway();
 
@@ -297,11 +304,15 @@ export function McpTestPanel({ resourceName }: Props) {
         | undefined;
       const fetched = listResult?.tools ?? [];
       setTools(fetched);
-      // Auto-select the first tool so the user immediately sees a runnable form.
-      if (fetched.length > 0) {
-        const first = fetched[0];
-        setSelectedTool(first.name);
-        setToolArgs(defaultArgsFor(first.inputSchema));
+      // Prefer the pinned tool (tool detail page) so Run targets the tool the
+      // user is looking at; otherwise auto-select the first tool so the user
+      // immediately sees a runnable form.
+      const initial =
+        (pinnedTool ? fetched.find((t) => t.name === pinnedTool) : undefined) ??
+        fetched[0];
+      if (initial) {
+        setSelectedTool(initial.name);
+        setToolArgs(defaultArgsFor(initial.inputSchema));
       } else {
         setSelectedTool(undefined);
         setToolArgs({});

--- a/portal/src/components/PageHeader.tsx
+++ b/portal/src/components/PageHeader.tsx
@@ -1,0 +1,140 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { type ReactNode } from "react";
+import {
+  Breadcrumb,
+  BreadcrumbButton,
+  BreadcrumbDivider,
+  BreadcrumbItem,
+  Caption1,
+  makeStyles,
+  tokens,
+} from "@fluentui/react-components";
+import { useNavigate } from "react-router-dom";
+
+export interface BreadcrumbEntry {
+  label: string;
+  to?: string;
+}
+
+const useStyles = makeStyles({
+  root: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "8px",
+    marginBottom: "20px",
+  },
+  breadcrumb: {
+    minHeight: "20px",
+  },
+  titleRow: {
+    display: "flex",
+    alignItems: "flex-start",
+    justifyContent: "space-between",
+    gap: "16px",
+    flexWrap: "wrap",
+  },
+  titleBlock: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "4px",
+    minWidth: 0,
+    flex: "1 1 320px",
+  },
+  titleLine: {
+    display: "flex",
+    alignItems: "center",
+    gap: "10px",
+    flexWrap: "wrap",
+    minWidth: 0,
+  },
+  title: {
+    fontSize: tokens.fontSizeHero700,
+    fontWeight: tokens.fontWeightSemibold,
+    color: tokens.colorNeutralForeground1,
+    lineHeight: tokens.lineHeightHero700,
+    margin: 0,
+    overflowWrap: "break-word",
+  },
+  description: {
+    color: tokens.colorNeutralForeground3,
+    maxWidth: "780px",
+  },
+  badges: {
+    display: "flex",
+    alignItems: "center",
+    gap: "6px",
+    flexWrap: "wrap",
+  },
+  commands: {
+    display: "flex",
+    alignItems: "center",
+    gap: "8px",
+    flexShrink: 0,
+  },
+});
+
+export interface PageHeaderProps {
+  title: ReactNode;
+  description?: ReactNode;
+  breadcrumbs?: BreadcrumbEntry[];
+  badges?: ReactNode;
+  commands?: ReactNode;
+}
+
+export function PageHeader({
+  title,
+  description,
+  breadcrumbs,
+  badges,
+  commands,
+}: PageHeaderProps) {
+  const styles = useStyles();
+  const navigate = useNavigate();
+
+  return (
+    <div className={styles.root}>
+      {breadcrumbs && breadcrumbs.length > 0 && (
+        <Breadcrumb
+          aria-label="Breadcrumb"
+          size="small"
+          className={styles.breadcrumb}
+        >
+          {breadcrumbs.map((entry, i) => {
+            const isLast = i === breadcrumbs.length - 1;
+            return (
+              <span key={`${entry.label}-${i}`} style={{ display: "contents" }}>
+                <BreadcrumbItem>
+                  <BreadcrumbButton
+                    current={isLast}
+                    onClick={
+                      !isLast && entry.to ? () => navigate(entry.to!) : undefined
+                    }
+                  >
+                    {entry.label}
+                  </BreadcrumbButton>
+                </BreadcrumbItem>
+                {!isLast && <BreadcrumbDivider />}
+              </span>
+            );
+          })}
+        </Breadcrumb>
+      )}
+      <div className={styles.titleRow}>
+        <div className={styles.titleBlock}>
+          <div className={styles.titleLine}>
+            <h1 className={styles.title}>{title}</h1>
+            {badges && <div className={styles.badges}>{badges}</div>}
+          </div>
+          {description && (
+            <Caption1 block className={styles.description}>
+              {description}
+            </Caption1>
+          )}
+        </div>
+        {commands && <div className={styles.commands}>{commands}</div>}
+      </div>
+    </div>
+  );
+}

--- a/portal/src/components/StatusBadge.tsx
+++ b/portal/src/components/StatusBadge.tsx
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { Badge } from "@fluentui/react-components";
+import type { AdapterStatus } from "../api/types";
+
+interface Props {
+  status: AdapterStatus | undefined;
+  loading?: boolean;
+}
+
+/**
+ * Render the rollout state of a deployment as a Fluent UI badge. The gateway
+ * exposes a free-form `replicaStatus` string plus replica counters; we map
+ * that to a coarse severity so the list view stays scannable.
+ */
+export function StatusBadge({ status, loading }: Props) {
+  if (loading) return <Badge appearance="outline">…</Badge>;
+  if (!status) return <Badge appearance="outline" color="informative">Unknown</Badge>;
+
+  const label = describe(status);
+  const color = colorFor(status);
+  return <Badge appearance="filled" color={color}>{label}</Badge>;
+}
+
+function describe(s: AdapterStatus): string {
+  const ready = s.readyReplicas ?? 0;
+  const available = s.availableReplicas ?? 0;
+  const updated = s.updatedReplicas ?? 0;
+  if (s.replicaStatus && s.replicaStatus.toLowerCase() !== "ready") {
+    return `${s.replicaStatus} (${ready}/${updated})`;
+  }
+  return `Ready ${ready}/${Math.max(available, updated, ready)}`;
+}
+
+function colorFor(s: AdapterStatus): "success" | "warning" | "danger" | "informative" {
+  const ready = s.readyReplicas ?? 0;
+  const desired = Math.max(s.updatedReplicas ?? 0, s.availableReplicas ?? 0, ready);
+  if (desired === 0) return "informative";
+  if (ready >= desired) return "success";
+  if (ready === 0) return "danger";
+  return "warning";
+}

--- a/portal/src/components/ToolForm.tsx
+++ b/portal/src/components/ToolForm.tsx
@@ -1,0 +1,145 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { useState } from "react";
+import {
+  Field,
+  Input,
+  Textarea,
+  Caption1,
+  Subtitle2,
+  makeStyles,
+  tokens,
+  SpinButton,
+} from "@fluentui/react-components";
+import type { ToolData, ToolDefinition } from "../api/types";
+import { AdapterFormFields } from "./AdapterFormFields";
+
+const useStyles = makeStyles({
+  section: {
+    padding: "16px",
+    border: `1px solid ${tokens.colorNeutralStroke2}`,
+    borderRadius: tokens.borderRadiusMedium,
+    display: "grid",
+    gap: "12px",
+  },
+  row: {
+    display: "grid",
+    gap: "12px",
+    gridTemplateColumns: "1fr 1fr",
+  },
+});
+
+interface Props {
+  initial?: Partial<ToolData>;
+  disableName?: boolean;
+  submitLabel: string;
+  onSubmit: (values: ToolData) => Promise<void>;
+  onCancel?: () => void;
+}
+
+const blankDefinition: ToolDefinition = {
+  tool: { name: "", description: "", inputSchema: { type: "object", properties: {} } },
+  port: 443,
+  path: "/score",
+};
+
+export function ToolForm({ initial, disableName, submitLabel, onSubmit, onCancel }: Props) {
+  const styles = useStyles();
+  const [definition, setDefinition] = useState<ToolDefinition>(() => ({
+    ...blankDefinition,
+    ...(initial?.toolDefinition ?? {}),
+    tool: {
+      ...blankDefinition.tool,
+      ...(initial?.toolDefinition?.tool ?? {}),
+    },
+  }));
+  const [schemaText, setSchemaText] = useState<string>(() =>
+    JSON.stringify(initial?.toolDefinition?.tool?.inputSchema ?? blankDefinition.tool.inputSchema, null, 2),
+  );
+  const [schemaError, setSchemaError] = useState<string | undefined>();
+
+  return (
+    <AdapterFormFields
+      initial={initial}
+      disableName={disableName}
+      submitLabel={submitLabel}
+      onSubmit={async (base) => {
+        // Validate the schema JSON once at submit time so the user gets
+        // immediate feedback inline instead of failing server-side.
+        let schema: Record<string, unknown> | undefined;
+        try {
+          schema = schemaText.trim() ? JSON.parse(schemaText) : undefined;
+          setSchemaError(undefined);
+        } catch (err) {
+          setSchemaError((err as Error).message);
+          throw err;
+        }
+
+        // The server requires Tool.Name === ToolData.Name to enforce the
+        // 1:1 mapping between the deployment and the MCP tool it exposes.
+        const payload: ToolData = {
+          ...base,
+          toolDefinition: {
+            ...definition,
+            tool: {
+              ...definition.tool,
+              name: base.name,
+              inputSchema: schema,
+            },
+          },
+        };
+        await onSubmit(payload);
+      }}
+      onCancel={onCancel}
+    >
+      <div className={styles.section}>
+        <Subtitle2>Tool definition</Subtitle2>
+        <Caption1>
+          This is what the gateway advertises to MCP clients when they call
+          {" "}<code>tools/list</code>. The tool name is locked to the deployment name.
+        </Caption1>
+        <Field label="Description">
+          <Textarea
+            rows={2}
+            value={definition.tool.description ?? ""}
+            onChange={(_, d) =>
+              setDefinition((s) => ({ ...s, tool: { ...s.tool, description: d.value } }))
+            }
+          />
+        </Field>
+        <div className={styles.row}>
+          <Field label="Execution port" required>
+            <SpinButton
+              min={1}
+              max={65535}
+              value={definition.port}
+              onChange={(_, d) =>
+                setDefinition((s) => ({ ...s, port: d.value ?? s.port }))
+              }
+            />
+          </Field>
+          <Field label="Execution path" required>
+            <Input
+              value={definition.path}
+              onChange={(_, d) => setDefinition((s) => ({ ...s, path: d.value }))}
+            />
+          </Field>
+        </div>
+        <Field
+          label="Input schema (JSON)"
+          hint="JSON Schema describing the tool's arguments. Leave empty for no arguments."
+          validationMessage={schemaError}
+          validationState={schemaError ? "error" : "none"}
+        >
+          <Textarea
+            rows={10}
+            textarea={{ style: { fontFamily: tokens.fontFamilyMonospace, fontSize: 13 } }}
+            value={schemaText}
+            onChange={(_, d) => setSchemaText(d.value)}
+          />
+        </Field>
+      </div>
+    </AdapterFormFields>
+  );
+}

--- a/portal/src/hooks/useAsync.ts
+++ b/portal/src/hooks/useAsync.ts
@@ -11,6 +11,15 @@ export interface AsyncState<T> {
   reload: () => void;
 }
 
+export interface UseAsyncOptions {
+  /**
+   * When `false`, the factory is not invoked and the hook stays idle
+   * (no request, no loading state). Useful for data that should only load
+   * when a particular tab/panel is active. Defaults to `true`.
+   */
+  enabled?: boolean;
+}
+
 /**
  * Tiny `useAsync` so we don't pull a full data-fetching library for the few
  * places that need refresh-on-demand semantics. Cancels in-flight work when
@@ -19,10 +28,12 @@ export interface AsyncState<T> {
 export function useAsync<T>(
   factory: (signal: AbortSignal) => Promise<T>,
   deps: ReadonlyArray<unknown>,
+  options?: UseAsyncOptions,
 ): AsyncState<T> {
+  const enabled = options?.enabled ?? true;
   const [data, setData] = useState<T | undefined>(undefined);
   const [error, setError] = useState<Error | undefined>(undefined);
-  const [loading, setLoading] = useState<boolean>(true);
+  const [loading, setLoading] = useState<boolean>(enabled);
   const [tick, setTick] = useState(0);
   const factoryRef = useRef(factory);
   factoryRef.current = factory;
@@ -30,6 +41,11 @@ export function useAsync<T>(
   const reload = useCallback(() => setTick((n) => n + 1), []);
 
   useEffect(() => {
+    if (!enabled) {
+      // Skip the request entirely; clear any stale loading flag.
+      setLoading(false);
+      return;
+    }
     const ac = new AbortController();
     setLoading(true);
     setError(undefined);
@@ -47,7 +63,7 @@ export function useAsync<T>(
     );
     return () => ac.abort();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [...deps, tick]);
+  }, [...deps, tick, enabled]);
 
   return { data, error, loading, reload };
 }

--- a/portal/src/hooks/useAsync.ts
+++ b/portal/src/hooks/useAsync.ts
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ApiError } from "../api/client";
+
+export interface AsyncState<T> {
+  data: T | undefined;
+  error: Error | undefined;
+  loading: boolean;
+  reload: () => void;
+}
+
+/**
+ * Tiny `useAsync` so we don't pull a full data-fetching library for the few
+ * places that need refresh-on-demand semantics. Cancels in-flight work when
+ * the component unmounts or the key changes.
+ */
+export function useAsync<T>(
+  factory: (signal: AbortSignal) => Promise<T>,
+  deps: ReadonlyArray<unknown>,
+): AsyncState<T> {
+  const [data, setData] = useState<T | undefined>(undefined);
+  const [error, setError] = useState<Error | undefined>(undefined);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [tick, setTick] = useState(0);
+  const factoryRef = useRef(factory);
+  factoryRef.current = factory;
+
+  const reload = useCallback(() => setTick((n) => n + 1), []);
+
+  useEffect(() => {
+    const ac = new AbortController();
+    setLoading(true);
+    setError(undefined);
+    factoryRef.current(ac.signal).then(
+      (value) => {
+        if (ac.signal.aborted) return;
+        setData(value);
+        setLoading(false);
+      },
+      (err) => {
+        if (ac.signal.aborted) return;
+        setError(err instanceof Error ? err : new Error(String(err)));
+        setLoading(false);
+      },
+    );
+    return () => ac.abort();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [...deps, tick]);
+
+  return { data, error, loading, reload };
+}
+
+export function formatApiError(err: unknown): string {
+  if (err instanceof ApiError) {
+    const detail = err.body && err.body.length < 400 ? ` — ${err.body}` : "";
+    return `${err.message}${detail}`;
+  }
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/portal/src/main.tsx
+++ b/portal/src/main.tsx
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { FluentProvider, webLightTheme } from "@fluentui/react-components";
+import { App } from "./App";
+import { PortalProvider } from "./auth/PortalProvider";
+import "./styles.css";
+
+const root = document.getElementById("root");
+if (!root) {
+  throw new Error("Missing #root element");
+}
+
+ReactDOM.createRoot(root).render(
+  <React.StrictMode>
+    <FluentProvider theme={webLightTheme}>
+      <PortalProvider>
+        <App />
+      </PortalProvider>
+    </FluentProvider>
+  </React.StrictMode>,
+);

--- a/portal/src/pages/AdapterCreatePage.tsx
+++ b/portal/src/pages/AdapterCreatePage.tsx
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { useNavigate } from "react-router-dom";
+import { makeStyles, tokens } from "@fluentui/react-components";
+import { AdapterFormFields } from "../components/AdapterFormFields";
+import { PageHeader } from "../components/PageHeader";
+import { useGateway } from "../auth/PortalProvider";
+
+const useStyles = makeStyles({
+  card: {
+    backgroundColor: tokens.colorNeutralBackground1,
+    borderRadius: tokens.borderRadiusLarge,
+    border: `1px solid ${tokens.colorNeutralStroke2}`,
+    boxShadow: tokens.shadow2,
+    padding: "24px",
+  },
+});
+
+export function AdapterCreatePage() {
+  const styles = useStyles();
+  const navigate = useNavigate();
+  const { api } = useGateway();
+
+  return (
+    <div>
+      <PageHeader
+        breadcrumbs={[
+          { label: "Home", to: "/" },
+          { label: "MCP Servers", to: "/adapters" },
+          { label: "New" },
+        ]}
+        title="New MCP server"
+        description="Deploy a new MCP server (adapter) to the gateway. The image must already be available to the gateway's container registry."
+      />
+      <div className={styles.card}>
+        <AdapterFormFields
+          submitLabel="Create adapter"
+          onSubmit={async (values) => {
+            await api.createAdapter(values);
+            navigate(`/adapters/${encodeURIComponent(values.name)}`);
+          }}
+          onCancel={() => navigate("/adapters")}
+        />
+      </div>
+    </div>
+  );
+}

--- a/portal/src/pages/AdapterDetailPage.tsx
+++ b/portal/src/pages/AdapterDetailPage.tsx
@@ -148,7 +148,8 @@ export function AdapterDetailPage() {
   );
   const logs = useAsync(
     (signal) => api.getAdapterLogs(name!, logInstance, signal),
-    [api, name, logInstance, tab === "logs"],
+    [api, name, logInstance],
+    { enabled: tab === "logs" },
   );
   const formattedLogs = useMemo(() => formatLogs(logs.data), [logs.data]);
 

--- a/portal/src/pages/AdapterDetailPage.tsx
+++ b/portal/src/pages/AdapterDetailPage.tsx
@@ -1,0 +1,453 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { useMemo, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import {
+  Badge,
+  Body1,
+  Button,
+  Caption1,
+  Dialog,
+  DialogActions,
+  DialogBody,
+  DialogContent,
+  DialogSurface,
+  DialogTitle,
+  DialogTrigger,
+  MessageBar,
+  MessageBarBody,
+  SpinButton,
+  Spinner,
+  Subtitle2,
+  Tab,
+  TabList,
+  makeStyles,
+  tokens,
+} from "@fluentui/react-components";
+import {
+  ArrowClockwiseRegular,
+  DeleteRegular,
+  EditRegular,
+} from "@fluentui/react-icons";
+import { useGateway } from "../auth/PortalProvider";
+import { useAsync, formatApiError } from "../hooks/useAsync";
+import { AdapterFormFields } from "../components/AdapterFormFields";
+import { StatusBadge } from "../components/StatusBadge";
+import { McpTestPanel } from "../components/McpTestPanel";
+import { PageHeader } from "../components/PageHeader";
+
+const useStyles = makeStyles({
+  page: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "16px",
+  },
+  tabBar: {
+    backgroundColor: tokens.colorNeutralBackground1,
+    borderRadius: tokens.borderRadiusLarge,
+    border: `1px solid ${tokens.colorNeutralStroke2}`,
+    boxShadow: tokens.shadow2,
+    padding: "0 8px",
+  },
+  card: {
+    backgroundColor: tokens.colorNeutralBackground1,
+    borderRadius: tokens.borderRadiusLarge,
+    border: `1px solid ${tokens.colorNeutralStroke2}`,
+    boxShadow: tokens.shadow2,
+    overflow: "hidden",
+  },
+  cardHeader: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    padding: "12px 16px",
+    borderBottom: `1px solid ${tokens.colorNeutralStroke2}`,
+  },
+  cardBody: {
+    padding: "16px",
+  },
+  meta: {
+    display: "grid",
+    gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))",
+    gap: "16px",
+  },
+  metaCell: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "4px",
+  },
+  metaCaption: {
+    color: tokens.colorNeutralForeground3,
+    textTransform: "uppercase",
+    letterSpacing: "0.4px",
+    fontSize: "11px",
+    fontWeight: tokens.fontWeightSemibold,
+  },
+  metaValue: {
+    color: tokens.colorNeutralForeground1,
+    fontSize: tokens.fontSizeBase300,
+    wordBreak: "break-word",
+  },
+  metaDivider: {
+    height: "1px",
+    backgroundColor: tokens.colorNeutralStroke2,
+    margin: "16px 0",
+  },
+  logs: {
+    margin: 0,
+    padding: "12px",
+    backgroundColor: tokens.colorNeutralBackground3,
+    borderRadius: tokens.borderRadiusMedium,
+    fontFamily: tokens.fontFamilyMonospace,
+    fontSize: tokens.fontSizeBase200,
+    whiteSpace: "pre-wrap",
+    wordBreak: "break-word",
+    maxHeight: "480px",
+    overflow: "auto",
+    color: tokens.colorNeutralForeground1,
+    border: `1px solid ${tokens.colorNeutralStroke2}`,
+  },
+  logsBar: {
+    display: "flex",
+    alignItems: "end",
+    gap: "12px",
+    padding: "12px 16px",
+    borderBottom: `1px solid ${tokens.colorNeutralStroke2}`,
+    backgroundColor: tokens.colorNeutralBackground2,
+  },
+  badgeStrip: {
+    display: "flex",
+    alignItems: "center",
+    gap: "6px",
+    flexWrap: "wrap",
+  },
+  mono: {
+    fontFamily: tokens.fontFamilyMonospace,
+  },
+});
+
+export function AdapterDetailPage() {
+  const styles = useStyles();
+  const { name } = useParams<{ name: string }>();
+  const navigate = useNavigate();
+  const { api } = useGateway();
+  const [tab, setTab] = useState<"overview" | "logs" | "test" | "edit">("overview");
+  const [logInstance, setLogInstance] = useState(0);
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | undefined>();
+  const [editError, setEditError] = useState<string | undefined>();
+
+  const adapter = useAsync(
+    (signal) => api.getAdapter(name!, signal),
+    [api, name],
+  );
+  const status = useAsync(
+    (signal) => api.getAdapterStatus(name!, signal),
+    [api, name],
+  );
+  const logs = useAsync(
+    (signal) => api.getAdapterLogs(name!, logInstance, signal),
+    [api, name, logInstance, tab === "logs"],
+  );
+  const formattedLogs = useMemo(() => formatLogs(logs.data), [logs.data]);
+
+  const refresh = () => {
+    adapter.reload();
+    status.reload();
+    if (tab === "logs") logs.reload();
+  };
+
+  const handleDelete = async () => {
+    setDeleting(true);
+    setDeleteError(undefined);
+    try {
+      await api.deleteAdapter(name!);
+      navigate("/adapters");
+    } catch (err) {
+      setDeleteError(formatApiError(err));
+      setDeleting(false);
+    }
+  };
+
+  if (adapter.loading) {
+    return <Spinner label="Loading adapter…" />;
+  }
+
+  if (adapter.error || !adapter.data) {
+    return (
+      <MessageBar intent="error">
+        <MessageBarBody>{formatApiError(adapter.error) || "Adapter not found."}</MessageBarBody>
+      </MessageBar>
+    );
+  }
+
+  const a = adapter.data;
+
+  return (
+    <div className={styles.page}>
+      <PageHeader
+        breadcrumbs={[
+          { label: "Home", to: "/" },
+          { label: "MCP Servers", to: "/adapters" },
+          { label: a.name },
+        ]}
+        title={a.name}
+        description={a.description || "No description"}
+        badges={
+          <div className={styles.badgeStrip}>
+            <StatusBadge status={status.data} loading={status.loading} />
+            <Badge appearance="tint" className={styles.mono}>
+              {a.imageName}:{a.imageVersion}
+            </Badge>
+            <Badge appearance="tint" color="informative">
+              {a.replicaCount} replica{a.replicaCount === 1 ? "" : "s"}
+            </Badge>
+          </div>
+        }
+        commands={
+          <>
+            <Button
+              appearance="subtle"
+              icon={<ArrowClockwiseRegular />}
+              onClick={refresh}
+            >
+              Refresh
+            </Button>
+            <Button
+              appearance="secondary"
+              icon={<EditRegular />}
+              onClick={() => setTab("edit")}
+            >
+              Edit
+            </Button>
+            <DeleteConfirmation
+              name={a.name}
+              error={deleteError}
+              deleting={deleting}
+              onConfirm={handleDelete}
+            />
+          </>
+        }
+      />
+
+      <div className={styles.tabBar}>
+        <TabList
+          selectedValue={tab}
+          onTabSelect={(_, d) => setTab(d.value as typeof tab)}
+        >
+          <Tab value="overview">Overview</Tab>
+          <Tab value="test">Test connection</Tab>
+          <Tab value="logs">Logs</Tab>
+          <Tab value="edit">Edit</Tab>
+        </TabList>
+      </div>
+
+      {tab === "overview" && (
+        <div className={styles.card}>
+          <div className={styles.cardHeader}>
+            <Subtitle2>Properties</Subtitle2>
+          </div>
+          <div className={styles.cardBody}>
+            <div className={styles.meta}>
+              <MetaCell label="Created by" value={a.createdBy} />
+              <MetaCell
+                label="Created at"
+                value={new Date(a.createdAt).toLocaleString()}
+              />
+              <MetaCell
+                label="Updated at"
+                value={new Date(a.lastUpdatedAt).toLocaleString()}
+              />
+              <MetaCell
+                label="Workload identity"
+                value={a.useWorkloadIdentity ? "Enabled" : "Disabled"}
+              />
+              <MetaCell
+                label="Required roles"
+                value={a.requiredRoles.length ? a.requiredRoles.join(", ") : "—"}
+              />
+              <MetaCell
+                label="Environment variables"
+                value={
+                  Object.keys(a.environmentVariables).length === 0
+                    ? "—"
+                    : Object.entries(a.environmentVariables)
+                        .map(([k]) => k)
+                        .join(", ")
+                }
+              />
+            </div>
+            {status.data && (
+              <>
+                <div className={styles.metaDivider} />
+                <div className={styles.meta}>
+                  <MetaCell
+                    label="Ready replicas"
+                    value={String(status.data.readyReplicas ?? "—")}
+                  />
+                  <MetaCell
+                    label="Updated replicas"
+                    value={String(status.data.updatedReplicas ?? "—")}
+                  />
+                  <MetaCell
+                    label="Available replicas"
+                    value={String(status.data.availableReplicas ?? "—")}
+                  />
+                  <MetaCell
+                    label="Image (running)"
+                    value={status.data.image ?? "—"}
+                  />
+                  <MetaCell
+                    label="Status"
+                    value={status.data.replicaStatus ?? "—"}
+                  />
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      )}
+
+      {tab === "test" && <McpTestPanel resourceName={a.name} />}
+
+      {tab === "logs" && (
+        <div className={styles.card}>
+          <div className={styles.cardHeader}>
+            <Subtitle2>Pod logs</Subtitle2>
+          </div>
+          <div className={styles.logsBar}>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+              <Caption1>Instance</Caption1>
+              <SpinButton
+                min={0}
+                max={32}
+                value={logInstance}
+                onChange={(_, d) => setLogInstance(d.value ?? 0)}
+              />
+            </div>
+            <Button
+              icon={<ArrowClockwiseRegular />}
+              onClick={logs.reload}
+              disabled={logs.loading}
+            >
+              Reload
+            </Button>
+            {logs.loading && <Spinner size="tiny" />}
+          </div>
+          <div className={styles.cardBody}>
+            {logs.error && (
+              <MessageBar intent="error" style={{ marginBottom: 12 }}>
+                <MessageBarBody>{formatApiError(logs.error)}</MessageBarBody>
+              </MessageBar>
+            )}
+            <pre className={styles.logs}>{formattedLogs || "(empty)"}</pre>
+          </div>
+        </div>
+      )}
+
+      {tab === "edit" && (
+        <div className={styles.card}>
+          <div className={styles.cardHeader}>
+            <Subtitle2>Edit adapter</Subtitle2>
+          </div>
+          <div className={styles.cardBody}>
+            {editError && (
+              <MessageBar intent="error" style={{ marginBottom: 12 }}>
+                <MessageBarBody>{editError}</MessageBarBody>
+              </MessageBar>
+            )}
+            <AdapterFormFields
+              initial={a}
+              disableName
+              submitLabel="Save changes"
+              onSubmit={async (values) => {
+                setEditError(undefined);
+                try {
+                  await api.updateAdapter({ ...values, name: a.name });
+                  adapter.reload();
+                  status.reload();
+                  setTab("overview");
+                } catch (err) {
+                  setEditError(formatApiError(err));
+                  throw err;
+                }
+              }}
+              onCancel={() => setTab("overview")}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MetaCell({ label, value }: { label: string; value: string }) {
+  const styles = useStyles();
+  return (
+    <div className={styles.metaCell}>
+      <span className={styles.metaCaption}>{label}</span>
+      <Body1 className={styles.metaValue}>{value}</Body1>
+    </div>
+  );
+}
+
+function DeleteConfirmation({
+  name,
+  error,
+  deleting,
+  onConfirm,
+}: {
+  name: string;
+  error?: string;
+  deleting: boolean;
+  onConfirm: () => void;
+}) {
+  return (
+    <Dialog>
+      <DialogTrigger disableButtonEnhancement>
+        <Button
+          appearance="subtle"
+          icon={<DeleteRegular />}
+          aria-label="Delete adapter"
+        >
+          Delete
+        </Button>
+      </DialogTrigger>
+      <DialogSurface>
+        <DialogBody>
+          <DialogTitle>Delete adapter "{name}"?</DialogTitle>
+          <DialogContent>
+            This permanently removes the adapter deployment and metadata. The
+            action cannot be undone.
+            {error && (
+              <MessageBar intent="error" style={{ marginTop: 8 }}>
+                <MessageBarBody>{error}</MessageBarBody>
+              </MessageBar>
+            )}
+          </DialogContent>
+          <DialogActions>
+            <DialogTrigger disableButtonEnhancement>
+              <Button appearance="secondary" disabled={deleting}>
+                Cancel
+              </Button>
+            </DialogTrigger>
+            <Button appearance="primary" onClick={onConfirm} disabled={deleting}>
+              {deleting ? "Deleting…" : "Delete"}
+            </Button>
+          </DialogActions>
+        </DialogBody>
+      </DialogSurface>
+    </Dialog>
+  );
+}
+
+function formatLogs(value: unknown): string {
+  if (value === undefined || value === null) return "";
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}

--- a/portal/src/pages/AdaptersPage.tsx
+++ b/portal/src/pages/AdaptersPage.tsx
@@ -1,0 +1,263 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+  Button,
+  Caption1,
+  Divider,
+  Input,
+  MessageBar,
+  MessageBarBody,
+  Spinner,
+  Table,
+  TableBody,
+  TableCell,
+  TableCellLayout,
+  TableHeader,
+  TableHeaderCell,
+  TableRow,
+  Toolbar,
+  ToolbarButton,
+  ToolbarDivider,
+  makeStyles,
+  tokens,
+} from "@fluentui/react-components";
+import {
+  AddRegular,
+  ArrowClockwiseRegular,
+  AppsListDetailRegular,
+  SearchRegular,
+} from "@fluentui/react-icons";
+import { Link, useNavigate } from "react-router-dom";
+import { useMemo, useState } from "react";
+import { useGateway } from "../auth/PortalProvider";
+import { useAsync, formatApiError } from "../hooks/useAsync";
+import { PageHeader } from "../components/PageHeader";
+
+const useStyles = makeStyles({
+  surface: {
+    backgroundColor: tokens.colorNeutralBackground1,
+    borderRadius: tokens.borderRadiusLarge,
+    border: `1px solid ${tokens.colorNeutralStroke2}`,
+    boxShadow: tokens.shadow2,
+    overflow: "hidden",
+  },
+  commandBar: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: "12px",
+    padding: "8px 12px",
+    borderBottom: `1px solid ${tokens.colorNeutralStroke2}`,
+    backgroundColor: tokens.colorNeutralBackground1,
+  },
+  commandBarLeft: {
+    display: "flex",
+    alignItems: "center",
+    gap: "4px",
+    flexWrap: "wrap",
+  },
+  search: {
+    width: "320px",
+    maxWidth: "40vw",
+  },
+  count: {
+    padding: "10px 16px",
+    color: tokens.colorNeutralForeground3,
+    fontSize: tokens.fontSizeBase200,
+    backgroundColor: tokens.colorNeutralBackground2,
+    borderBottom: `1px solid ${tokens.colorNeutralStroke2}`,
+  },
+  empty: {
+    padding: "48px 24px",
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    gap: "12px",
+    color: tokens.colorNeutralForeground3,
+    textAlign: "center",
+  },
+  emptyIcon: {
+    fontSize: "32px",
+    color: tokens.colorNeutralForeground4,
+  },
+  loading: {
+    padding: "48px",
+    display: "flex",
+    justifyContent: "center",
+  },
+  table: {
+    "& tbody tr": {
+      cursor: "pointer",
+    },
+    "& tbody tr:hover": {
+      backgroundColor: tokens.colorNeutralBackground1Hover,
+    },
+  },
+  nameCell: {
+    fontWeight: tokens.fontWeightSemibold,
+  },
+  mono: {
+    fontFamily: tokens.fontFamilyMonospace,
+    fontSize: tokens.fontSizeBase200,
+    color: tokens.colorNeutralForeground2,
+  },
+});
+
+export function AdaptersPage() {
+  const styles = useStyles();
+  const { api } = useGateway();
+  const navigate = useNavigate();
+  const [filter, setFilter] = useState("");
+  const list = useAsync((signal) => api.listAdapters(signal), [api]);
+
+  const filtered = useMemo(() => {
+    if (!list.data) return [];
+    const q = filter.trim().toLowerCase();
+    if (!q) return list.data;
+    return list.data.filter((a) =>
+      [a.name, a.imageName, a.description, a.createdBy]
+        .filter(Boolean)
+        .some((v) => v.toLowerCase().includes(q)),
+    );
+  }, [list.data, filter]);
+
+  return (
+    <div>
+      <PageHeader
+        breadcrumbs={[{ label: "Home", to: "/" }, { label: "MCP Servers" }]}
+        title="MCP Servers"
+        description="Manage the lifecycle of MCP servers (adapters) hosted by this gateway."
+      />
+
+      {list.error && (
+        <MessageBar intent="error" style={{ marginBottom: 16 }}>
+          <MessageBarBody>{formatApiError(list.error)}</MessageBarBody>
+        </MessageBar>
+      )}
+
+      <div className={styles.surface}>
+        <div className={styles.commandBar}>
+          <Toolbar className={styles.commandBarLeft} size="small">
+            <ToolbarButton
+              appearance="primary"
+              icon={<AddRegular />}
+              onClick={() => navigate("/adapters/new")}
+            >
+              New adapter
+            </ToolbarButton>
+            <ToolbarDivider />
+            <ToolbarButton
+              icon={<ArrowClockwiseRegular />}
+              onClick={list.reload}
+              disabled={list.loading}
+            >
+              Refresh
+            </ToolbarButton>
+          </Toolbar>
+          <Input
+            className={styles.search}
+            contentBefore={<SearchRegular />}
+            placeholder="Filter by name, image, owner…"
+            value={filter}
+            onChange={(_, d) => setFilter(d.value)}
+            size="small"
+          />
+        </div>
+
+        <div className={styles.count}>
+          {list.loading ? (
+            "Loading…"
+          ) : (
+            <>
+              <strong>{filtered.length}</strong> adapter
+              {filtered.length === 1 ? "" : "s"}
+              {filter && list.data && filter.trim().length > 0 ? (
+                <> of {list.data.length}</>
+              ) : null}
+            </>
+          )}
+        </div>
+
+        {list.loading ? (
+          <div className={styles.loading}>
+            <Spinner label="Loading adapters…" />
+          </div>
+        ) : filtered.length === 0 ? (
+          <div className={styles.empty}>
+            <AppsListDetailRegular className={styles.emptyIcon} />
+            <div>
+              {list.data && list.data.length === 0
+                ? "No adapters yet."
+                : "No adapters match your filter."}
+            </div>
+            {list.data && list.data.length === 0 && (
+              <Button
+                appearance="primary"
+                icon={<AddRegular />}
+                onClick={() => navigate("/adapters/new")}
+              >
+                Create your first adapter
+              </Button>
+            )}
+          </div>
+        ) : (
+          <Table size="small" aria-label="Adapter list" className={styles.table}>
+            <TableHeader>
+              <TableRow>
+                <TableHeaderCell>Name</TableHeaderCell>
+                <TableHeaderCell>Image</TableHeaderCell>
+                <TableHeaderCell>Replicas</TableHeaderCell>
+                <TableHeaderCell>Owner</TableHeaderCell>
+                <TableHeaderCell>Updated</TableHeaderCell>
+                <TableHeaderCell>Required roles</TableHeaderCell>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {filtered.map((a) => (
+                <TableRow
+                  key={a.id}
+                  onClick={() =>
+                    navigate(`/adapters/${encodeURIComponent(a.name)}`)
+                  }
+                >
+                  <TableCell>
+                    <TableCellLayout>
+                      <Link
+                        to={`/adapters/${encodeURIComponent(a.name)}`}
+                        className={styles.nameCell}
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        {a.name}
+                      </Link>
+                    </TableCellLayout>
+                  </TableCell>
+                  <TableCell>
+                    <span className={styles.mono}>
+                      {a.imageName}:{a.imageVersion}
+                    </span>
+                  </TableCell>
+                  <TableCell>{a.replicaCount}</TableCell>
+                  <TableCell>{a.createdBy}</TableCell>
+                  <TableCell>
+                    {new Date(a.lastUpdatedAt).toLocaleString()}
+                  </TableCell>
+                  <TableCell>
+                    {a.requiredRoles.length === 0 ? (
+                      <Caption1>—</Caption1>
+                    ) : (
+                      <span className={styles.mono}>
+                        {a.requiredRoles.join(", ")}
+                      </span>
+                    )}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </div>
+      <Divider style={{ visibility: "hidden", marginTop: 16 }} />
+    </div>
+  );
+}

--- a/portal/src/pages/ToolCreatePage.tsx
+++ b/portal/src/pages/ToolCreatePage.tsx
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { useNavigate } from "react-router-dom";
+import { Caption1, makeStyles, tokens } from "@fluentui/react-components";
+import { ToolForm } from "../components/ToolForm";
+import { PageHeader } from "../components/PageHeader";
+import { useGateway } from "../auth/PortalProvider";
+
+const useStyles = makeStyles({
+  card: {
+    backgroundColor: tokens.colorNeutralBackground1,
+    borderRadius: tokens.borderRadiusLarge,
+    border: `1px solid ${tokens.colorNeutralStroke2}`,
+    boxShadow: tokens.shadow2,
+    padding: "24px",
+  },
+});
+
+export function ToolCreatePage() {
+  const styles = useStyles();
+  const navigate = useNavigate();
+  const { api } = useGateway();
+
+  return (
+    <div>
+      <PageHeader
+        breadcrumbs={[
+          { label: "Home", to: "/" },
+          { label: "Tools", to: "/tools" },
+          { label: "New" },
+        ]}
+        title="New tool"
+        description={
+          <Caption1>
+            Register a tool with the gateway. The tool definition (name,
+            description and input schema) is what MCP clients see when they
+            call <code>tools/list</code>.
+          </Caption1>
+        }
+      />
+      <div className={styles.card}>
+        <ToolForm
+          submitLabel="Create tool"
+          onSubmit={async (values) => {
+            await api.createTool(values);
+            navigate(`/tools/${encodeURIComponent(values.name)}`);
+          }}
+          onCancel={() => navigate("/tools")}
+        />
+      </div>
+    </div>
+  );
+}

--- a/portal/src/pages/ToolDetailPage.tsx
+++ b/portal/src/pages/ToolDetailPage.tsx
@@ -142,7 +142,8 @@ export function ToolDetailPage() {
   );
   const logs = useAsync(
     (signal) => api.getToolLogs(name!, logInstance, signal),
-    [api, name, logInstance, tab === "logs"],
+    [api, name, logInstance],
+    { enabled: tab === "logs" },
   );
   const formattedLogs = useMemo(() => formatLogs(logs.data), [logs.data]);
 
@@ -325,7 +326,7 @@ export function ToolDetailPage() {
               <code>name: "{t.name}"</code> to exercise this tool end-to-end.
             </MessageBarBody>
           </MessageBar>
-          <McpTestPanel />
+          <McpTestPanel pinnedTool={t.name} />
         </>
       )}
 

--- a/portal/src/pages/ToolDetailPage.tsx
+++ b/portal/src/pages/ToolDetailPage.tsx
@@ -1,0 +1,421 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { useMemo, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import {
+  Badge,
+  Body1,
+  Button,
+  Caption1,
+  Dialog,
+  DialogActions,
+  DialogBody,
+  DialogContent,
+  DialogSurface,
+  DialogTitle,
+  DialogTrigger,
+  MessageBar,
+  MessageBarBody,
+  SpinButton,
+  Spinner,
+  Subtitle2,
+  Tab,
+  TabList,
+  makeStyles,
+  tokens,
+} from "@fluentui/react-components";
+import {
+  ArrowClockwiseRegular,
+  DeleteRegular,
+  EditRegular,
+} from "@fluentui/react-icons";
+import { useGateway } from "../auth/PortalProvider";
+import { useAsync, formatApiError } from "../hooks/useAsync";
+import { ToolForm } from "../components/ToolForm";
+import { StatusBadge } from "../components/StatusBadge";
+import { McpTestPanel } from "../components/McpTestPanel";
+import { PageHeader } from "../components/PageHeader";
+
+const useStyles = makeStyles({
+  page: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "16px",
+  },
+  tabBar: {
+    backgroundColor: tokens.colorNeutralBackground1,
+    borderRadius: tokens.borderRadiusLarge,
+    border: `1px solid ${tokens.colorNeutralStroke2}`,
+    boxShadow: tokens.shadow2,
+    padding: "0 8px",
+  },
+  card: {
+    backgroundColor: tokens.colorNeutralBackground1,
+    borderRadius: tokens.borderRadiusLarge,
+    border: `1px solid ${tokens.colorNeutralStroke2}`,
+    boxShadow: tokens.shadow2,
+    overflow: "hidden",
+  },
+  cardHeader: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    padding: "12px 16px",
+    borderBottom: `1px solid ${tokens.colorNeutralStroke2}`,
+  },
+  cardBody: {
+    padding: "16px",
+  },
+  meta: {
+    display: "grid",
+    gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))",
+    gap: "16px",
+  },
+  metaCell: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "4px",
+  },
+  metaCaption: {
+    color: tokens.colorNeutralForeground3,
+    textTransform: "uppercase",
+    letterSpacing: "0.4px",
+    fontSize: "11px",
+    fontWeight: tokens.fontWeightSemibold,
+  },
+  metaValue: {
+    color: tokens.colorNeutralForeground1,
+    fontSize: tokens.fontSizeBase300,
+    wordBreak: "break-word",
+  },
+  pre: {
+    margin: 0,
+    padding: "12px",
+    backgroundColor: tokens.colorNeutralBackground3,
+    borderRadius: tokens.borderRadiusMedium,
+    fontFamily: tokens.fontFamilyMonospace,
+    fontSize: tokens.fontSizeBase200,
+    whiteSpace: "pre-wrap",
+    wordBreak: "break-word",
+    maxHeight: "480px",
+    overflow: "auto",
+    color: tokens.colorNeutralForeground1,
+    border: `1px solid ${tokens.colorNeutralStroke2}`,
+  },
+  logsBar: {
+    display: "flex",
+    alignItems: "end",
+    gap: "12px",
+    padding: "12px 16px",
+    borderBottom: `1px solid ${tokens.colorNeutralStroke2}`,
+    backgroundColor: tokens.colorNeutralBackground2,
+  },
+  badgeStrip: {
+    display: "flex",
+    alignItems: "center",
+    gap: "6px",
+    flexWrap: "wrap",
+  },
+  mono: {
+    fontFamily: tokens.fontFamilyMonospace,
+  },
+});
+
+export function ToolDetailPage() {
+  const styles = useStyles();
+  const { name } = useParams<{ name: string }>();
+  const navigate = useNavigate();
+  const { api } = useGateway();
+  const [tab, setTab] = useState<"overview" | "logs" | "test" | "edit">(
+    "overview",
+  );
+  const [logInstance, setLogInstance] = useState(0);
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | undefined>();
+  const [editError, setEditError] = useState<string | undefined>();
+
+  const tool = useAsync((signal) => api.getTool(name!, signal), [api, name]);
+  const status = useAsync(
+    (signal) => api.getToolStatus(name!, signal),
+    [api, name],
+  );
+  const logs = useAsync(
+    (signal) => api.getToolLogs(name!, logInstance, signal),
+    [api, name, logInstance, tab === "logs"],
+  );
+  const formattedLogs = useMemo(() => formatLogs(logs.data), [logs.data]);
+
+  const refresh = () => {
+    tool.reload();
+    status.reload();
+    if (tab === "logs") logs.reload();
+  };
+
+  const handleDelete = async () => {
+    setDeleting(true);
+    setDeleteError(undefined);
+    try {
+      await api.deleteTool(name!);
+      navigate("/tools");
+    } catch (err) {
+      setDeleteError(formatApiError(err));
+      setDeleting(false);
+    }
+  };
+
+  if (tool.loading) return <Spinner label="Loading tool…" />;
+  if (tool.error || !tool.data) {
+    return (
+      <MessageBar intent="error">
+        <MessageBarBody>{formatApiError(tool.error) || "Tool not found."}</MessageBarBody>
+      </MessageBar>
+    );
+  }
+
+  const t = tool.data;
+
+  return (
+    <div className={styles.page}>
+      <PageHeader
+        breadcrumbs={[
+          { label: "Home", to: "/" },
+          { label: "Tools", to: "/tools" },
+          { label: t.name },
+        ]}
+        title={t.name}
+        description={
+          t.toolDefinition?.tool?.description ??
+          t.description ??
+          "No description"
+        }
+        badges={
+          <div className={styles.badgeStrip}>
+            <StatusBadge status={status.data} loading={status.loading} />
+            <Badge appearance="tint" className={styles.mono}>
+              {t.imageName}:{t.imageVersion}
+            </Badge>
+            <Badge appearance="tint" color="brand" className={styles.mono}>
+              :{t.toolDefinition?.port}
+              {t.toolDefinition?.path}
+            </Badge>
+          </div>
+        }
+        commands={
+          <>
+            <Button
+              appearance="subtle"
+              icon={<ArrowClockwiseRegular />}
+              onClick={refresh}
+            >
+              Refresh
+            </Button>
+            <Button
+              appearance="secondary"
+              icon={<EditRegular />}
+              onClick={() => setTab("edit")}
+            >
+              Edit
+            </Button>
+            <Dialog>
+              <DialogTrigger disableButtonEnhancement>
+                <Button
+                  appearance="subtle"
+                  icon={<DeleteRegular />}
+                  aria-label="Delete tool"
+                >
+                  Delete
+                </Button>
+              </DialogTrigger>
+              <DialogSurface>
+                <DialogBody>
+                  <DialogTitle>Delete tool "{t.name}"?</DialogTitle>
+                  <DialogContent>
+                    This permanently removes the tool deployment and its
+                    definition.
+                    {deleteError && (
+                      <MessageBar intent="error" style={{ marginTop: 8 }}>
+                        <MessageBarBody>{deleteError}</MessageBarBody>
+                      </MessageBar>
+                    )}
+                  </DialogContent>
+                  <DialogActions>
+                    <DialogTrigger disableButtonEnhancement>
+                      <Button appearance="secondary" disabled={deleting}>
+                        Cancel
+                      </Button>
+                    </DialogTrigger>
+                    <Button
+                      appearance="primary"
+                      onClick={handleDelete}
+                      disabled={deleting}
+                    >
+                      {deleting ? "Deleting…" : "Delete"}
+                    </Button>
+                  </DialogActions>
+                </DialogBody>
+              </DialogSurface>
+            </Dialog>
+          </>
+        }
+      />
+
+      <div className={styles.tabBar}>
+        <TabList
+          selectedValue={tab}
+          onTabSelect={(_, d) => setTab(d.value as typeof tab)}
+        >
+          <Tab value="overview">Overview</Tab>
+          <Tab value="test">Test connection</Tab>
+          <Tab value="logs">Logs</Tab>
+          <Tab value="edit">Edit</Tab>
+        </TabList>
+      </div>
+
+      {tab === "overview" && (
+        <>
+          <div className={styles.card}>
+            <div className={styles.cardHeader}>
+              <Subtitle2>Tool definition</Subtitle2>
+            </div>
+            <div className={styles.cardBody}>
+              <pre className={styles.pre}>
+                {JSON.stringify(t.toolDefinition, null, 2)}
+              </pre>
+            </div>
+          </div>
+          <div className={styles.card}>
+            <div className={styles.cardHeader}>
+              <Subtitle2>Deployment</Subtitle2>
+            </div>
+            <div className={styles.cardBody}>
+              <div className={styles.meta}>
+                <MetaCell label="Created by" value={t.createdBy} />
+                <MetaCell
+                  label="Created at"
+                  value={new Date(t.createdAt).toLocaleString()}
+                />
+                <MetaCell
+                  label="Updated at"
+                  value={new Date(t.lastUpdatedAt).toLocaleString()}
+                />
+                <MetaCell label="Replicas" value={String(t.replicaCount)} />
+                <MetaCell
+                  label="Workload identity"
+                  value={t.useWorkloadIdentity ? "Enabled" : "Disabled"}
+                />
+                <MetaCell
+                  label="Required roles"
+                  value={
+                    t.requiredRoles.length ? t.requiredRoles.join(", ") : "—"
+                  }
+                />
+              </div>
+            </div>
+          </div>
+        </>
+      )}
+
+      {tab === "test" && (
+        <>
+          <MessageBar intent="info">
+            <MessageBarBody>
+              This panel sends requests to <code>POST /mcp</code> (the tool
+              router). Use the <code>tools/call</code> sample with{" "}
+              <code>name: "{t.name}"</code> to exercise this tool end-to-end.
+            </MessageBarBody>
+          </MessageBar>
+          <McpTestPanel />
+        </>
+      )}
+
+      {tab === "logs" && (
+        <div className={styles.card}>
+          <div className={styles.cardHeader}>
+            <Subtitle2>Pod logs</Subtitle2>
+          </div>
+          <div className={styles.logsBar}>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+              <Caption1>Instance</Caption1>
+              <SpinButton
+                min={0}
+                max={32}
+                value={logInstance}
+                onChange={(_, d) => setLogInstance(d.value ?? 0)}
+              />
+            </div>
+            <Button
+              icon={<ArrowClockwiseRegular />}
+              onClick={logs.reload}
+              disabled={logs.loading}
+            >
+              Reload
+            </Button>
+            {logs.loading && <Spinner size="tiny" />}
+          </div>
+          <div className={styles.cardBody}>
+            {logs.error && (
+              <MessageBar intent="error" style={{ marginBottom: 12 }}>
+                <MessageBarBody>{formatApiError(logs.error)}</MessageBarBody>
+              </MessageBar>
+            )}
+            <pre className={styles.pre}>{formattedLogs || "(empty)"}</pre>
+          </div>
+        </div>
+      )}
+
+      {tab === "edit" && (
+        <div className={styles.card}>
+          <div className={styles.cardHeader}>
+            <Subtitle2>Edit tool</Subtitle2>
+          </div>
+          <div className={styles.cardBody}>
+            {editError && (
+              <MessageBar intent="error" style={{ marginBottom: 12 }}>
+                <MessageBarBody>{editError}</MessageBarBody>
+              </MessageBar>
+            )}
+            <ToolForm
+              initial={t}
+              disableName
+              submitLabel="Save changes"
+              onSubmit={async (values) => {
+                setEditError(undefined);
+                try {
+                  await api.updateTool({ ...values, name: t.name });
+                  tool.reload();
+                  status.reload();
+                  setTab("overview");
+                } catch (err) {
+                  setEditError(formatApiError(err));
+                  throw err;
+                }
+              }}
+              onCancel={() => setTab("overview")}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MetaCell({ label, value }: { label: string; value: string }) {
+  const styles = useStyles();
+  return (
+    <div className={styles.metaCell}>
+      <span className={styles.metaCaption}>{label}</span>
+      <Body1 className={styles.metaValue}>{value}</Body1>
+    </div>
+  );
+}
+
+function formatLogs(value: unknown): string {
+  if (value === undefined || value === null) return "";
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}

--- a/portal/src/pages/ToolsPage.tsx
+++ b/portal/src/pages/ToolsPage.tsx
@@ -1,0 +1,284 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { useMemo, useState } from "react";
+import {
+  Button,
+  Divider,
+  Input,
+  MessageBar,
+  MessageBarBody,
+  Spinner,
+  Table,
+  TableBody,
+  TableCell,
+  TableCellLayout,
+  TableHeader,
+  TableHeaderCell,
+  TableRow,
+  Toolbar,
+  ToolbarButton,
+  ToolbarDivider,
+  makeStyles,
+  tokens,
+} from "@fluentui/react-components";
+import {
+  AddRegular,
+  ArrowClockwiseRegular,
+  PuzzlePieceRegular,
+  SearchRegular,
+} from "@fluentui/react-icons";
+import { Link, useNavigate } from "react-router-dom";
+import { useGateway } from "../auth/PortalProvider";
+import { useAsync, formatApiError } from "../hooks/useAsync";
+import { PageHeader } from "../components/PageHeader";
+
+const useStyles = makeStyles({
+  surface: {
+    backgroundColor: tokens.colorNeutralBackground1,
+    borderRadius: tokens.borderRadiusLarge,
+    border: `1px solid ${tokens.colorNeutralStroke2}`,
+    boxShadow: tokens.shadow2,
+    overflow: "hidden",
+  },
+  commandBar: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: "12px",
+    padding: "8px 12px",
+    borderBottom: `1px solid ${tokens.colorNeutralStroke2}`,
+    backgroundColor: tokens.colorNeutralBackground1,
+  },
+  commandBarLeft: {
+    display: "flex",
+    alignItems: "center",
+    gap: "4px",
+    flexWrap: "wrap",
+  },
+  search: {
+    width: "320px",
+    maxWidth: "40vw",
+  },
+  count: {
+    padding: "10px 16px",
+    color: tokens.colorNeutralForeground3,
+    fontSize: tokens.fontSizeBase200,
+    backgroundColor: tokens.colorNeutralBackground2,
+    borderBottom: `1px solid ${tokens.colorNeutralStroke2}`,
+  },
+  empty: {
+    padding: "48px 24px",
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    gap: "12px",
+    color: tokens.colorNeutralForeground3,
+    textAlign: "center",
+  },
+  emptyIcon: {
+    fontSize: "32px",
+    color: tokens.colorNeutralForeground4,
+  },
+  loading: {
+    padding: "48px",
+    display: "flex",
+    justifyContent: "center",
+  },
+  table: {
+    "& tbody tr": {
+      cursor: "pointer",
+    },
+    "& tbody tr:hover": {
+      backgroundColor: tokens.colorNeutralBackground1Hover,
+    },
+  },
+  nameCell: {
+    fontWeight: tokens.fontWeightSemibold,
+  },
+  mono: {
+    fontFamily: tokens.fontFamilyMonospace,
+    fontSize: tokens.fontSizeBase200,
+    color: tokens.colorNeutralForeground2,
+  },
+  description: {
+    color: tokens.colorNeutralForeground2,
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+    maxWidth: "320px",
+    display: "block",
+  },
+});
+
+export function ToolsPage() {
+  const styles = useStyles();
+  const { api } = useGateway();
+  const navigate = useNavigate();
+  const [filter, setFilter] = useState("");
+  const list = useAsync((signal) => api.listTools(signal), [api]);
+
+  const filtered = useMemo(() => {
+    if (!list.data) return [];
+    const q = filter.trim().toLowerCase();
+    if (!q) return list.data;
+    return list.data.filter((t) =>
+      [
+        t.name,
+        t.imageName,
+        t.description,
+        t.createdBy,
+        t.toolDefinition?.tool?.description,
+      ]
+        .filter(Boolean)
+        .some((v) => (v as string).toLowerCase().includes(q)),
+    );
+  }, [list.data, filter]);
+
+  return (
+    <div>
+      <PageHeader
+        breadcrumbs={[{ label: "Home", to: "/" }, { label: "Tools" }]}
+        title="Tools"
+        description="Tools are deployments that expose a single MCP tool definition and are routed dynamically by the tool gateway router."
+      />
+
+      {list.error && (
+        <MessageBar intent="error" style={{ marginBottom: 16 }}>
+          <MessageBarBody>{formatApiError(list.error)}</MessageBarBody>
+        </MessageBar>
+      )}
+
+      <div className={styles.surface}>
+        <div className={styles.commandBar}>
+          <Toolbar className={styles.commandBarLeft} size="small">
+            <ToolbarButton
+              appearance="primary"
+              icon={<AddRegular />}
+              onClick={() => navigate("/tools/new")}
+            >
+              New tool
+            </ToolbarButton>
+            <ToolbarDivider />
+            <ToolbarButton
+              icon={<ArrowClockwiseRegular />}
+              onClick={list.reload}
+              disabled={list.loading}
+            >
+              Refresh
+            </ToolbarButton>
+          </Toolbar>
+          <Input
+            className={styles.search}
+            contentBefore={<SearchRegular />}
+            placeholder="Filter by name, image, owner…"
+            value={filter}
+            onChange={(_, d) => setFilter(d.value)}
+            size="small"
+          />
+        </div>
+
+        <div className={styles.count}>
+          {list.loading ? (
+            "Loading…"
+          ) : (
+            <>
+              <strong>{filtered.length}</strong> tool
+              {filtered.length === 1 ? "" : "s"}
+              {filter && list.data && filter.trim().length > 0 ? (
+                <> of {list.data.length}</>
+              ) : null}
+            </>
+          )}
+        </div>
+
+        {list.loading ? (
+          <div className={styles.loading}>
+            <Spinner label="Loading tools…" />
+          </div>
+        ) : filtered.length === 0 ? (
+          <div className={styles.empty}>
+            <PuzzlePieceRegular className={styles.emptyIcon} />
+            <div>
+              {list.data && list.data.length === 0
+                ? "No tools yet."
+                : "No tools match your filter."}
+            </div>
+            {list.data && list.data.length === 0 && (
+              <Button
+                appearance="primary"
+                icon={<AddRegular />}
+                onClick={() => navigate("/tools/new")}
+              >
+                Register your first tool
+              </Button>
+            )}
+          </div>
+        ) : (
+          <Table size="small" aria-label="Tool list" className={styles.table}>
+            <TableHeader>
+              <TableRow>
+                <TableHeaderCell>Name</TableHeaderCell>
+                <TableHeaderCell>Description</TableHeaderCell>
+                <TableHeaderCell>Image</TableHeaderCell>
+                <TableHeaderCell>Endpoint</TableHeaderCell>
+                <TableHeaderCell>Owner</TableHeaderCell>
+                <TableHeaderCell>Updated</TableHeaderCell>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {filtered.map((t) => (
+                <TableRow
+                  key={t.id}
+                  onClick={() => navigate(`/tools/${encodeURIComponent(t.name)}`)}
+                >
+                  <TableCell>
+                    <TableCellLayout>
+                      <Link
+                        to={`/tools/${encodeURIComponent(t.name)}`}
+                        className={styles.nameCell}
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        {t.name}
+                      </Link>
+                    </TableCellLayout>
+                  </TableCell>
+                  <TableCell>
+                    <span
+                      className={styles.description}
+                      title={
+                        t.toolDefinition?.tool?.description ??
+                        t.description ??
+                        undefined
+                      }
+                    >
+                      {t.toolDefinition?.tool?.description ??
+                        t.description ??
+                        "—"}
+                    </span>
+                  </TableCell>
+                  <TableCell>
+                    <span className={styles.mono}>
+                      {t.imageName}:{t.imageVersion}
+                    </span>
+                  </TableCell>
+                  <TableCell>
+                    <span className={styles.mono}>
+                      :{t.toolDefinition?.port}
+                      {t.toolDefinition?.path}
+                    </span>
+                  </TableCell>
+                  <TableCell>{t.createdBy}</TableCell>
+                  <TableCell>
+                    {new Date(t.lastUpdatedAt).toLocaleString()}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </div>
+      <Divider style={{ visibility: "hidden", marginTop: 16 }} />
+    </div>
+  );
+}

--- a/portal/src/styles.css
+++ b/portal/src/styles.css
@@ -1,0 +1,26 @@
+html,
+body,
+#root {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family:
+    "Segoe UI",
+    "Segoe UI Web",
+    -apple-system,
+    BlinkMacSystemFont,
+    "Helvetica Neue",
+    Arial,
+    sans-serif;
+}
+
+code {
+  font-family: "Cascadia Code", "JetBrains Mono", Consolas, monospace;
+  font-size: 0.95em;
+}
+
+a {
+  color: inherit;
+}

--- a/portal/src/vite-env.d.ts
+++ b/portal/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/portal/tsconfig.app.json
+++ b/portal/tsconfig.app.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": false,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "forceConsistentCasingInFileNames": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["src"]
+}

--- a/portal/tsconfig.json
+++ b/portal/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
+}

--- a/portal/tsconfig.node.json
+++ b/portal/tsconfig.node.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": false,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "forceConsistentCasingInFileNames": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "types": ["node"]
+  },
+  "include": ["vite.config.ts"]
+}

--- a/portal/vite.config.ts
+++ b/portal/vite.config.ts
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import path from "node:path";
+
+// The portal is built into the .NET service's wwwroot folder so a single
+// container image can serve both the API and the SPA. During `vite dev`
+// we proxy API/MCP calls to the local gateway so requests share an origin.
+const GATEWAY_DEV_TARGET = process.env.VITE_GATEWAY_URL ?? "http://localhost:8000";
+
+// Endpoints that must reach the gateway, not the Vite dev server.
+const proxyPaths = ["/portal/config", "/adapters", "/tools", "/agents", "/sessions", "/mcp", "/ping"];
+
+const proxy = Object.fromEntries(
+  proxyPaths.map((prefix) => [
+    prefix,
+    {
+      target: GATEWAY_DEV_TARGET,
+      changeOrigin: true,
+      ws: true,
+    },
+  ]),
+);
+
+export default defineConfig({
+  plugins: [react()],
+  // The SPA is mounted under /portal/ in the gateway so deep links to
+  // /adapters, /tools, etc. continue to hit the API controllers and the
+  // SPA owns its own route subtree without conflicting with them.
+  base: "/portal/",
+  server: {
+    port: 5173,
+    proxy,
+  },
+  build: {
+    outDir: path.resolve(
+      __dirname,
+      "../dotnet/Microsoft.McpGateway.Service/src/wwwroot/portal",
+    ),
+    emptyOutDir: true,
+    sourcemap: false,
+    target: "es2022",
+  },
+});


### PR DESCRIPTION
- Add portal/ SPA (Vite + React + Fluent UI v9) that lists, creates, edits, and deletes MCP server adapters and tools, surfaces pod status/logs, and ships an in-browser JSON-RPC test console.
- Serve the built SPA from the gateway at /portal/ and expose GET /portal/config so the SPA can discover MSAL settings vs dev mode at runtime.
- Build the portal automatically during dotnet publish (BuildManagementPortal target, BuildPortal=true by default), and add a Node.js setup step to the image workflow.
- Add Authentication:BypassEntra config flag (env var Authentication__BypassEntra=true) that swaps the production Entra / JWT pipeline for the existing DevelopmentAuthenticationHandler, so restricted demo / e2e clusters can run without Entra app reg redirect URIs. /portal/config reports isDevelopment: true in that mode so the SPA skips MSAL and sends X-Dev-* headers.
