### PR TITLE
fix(security): run builtin:bash with a sanitized, minimal environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ Content-Type: application/json
 
 When an agent lists `builtin:bash` / `builtin:read_file` / `builtin:write_file` in its `tools`, those built-ins run **in the gateway pod** under a per-session working directory. They are guarded by:
 
+- A scrubbed, default-deny process environment for `builtin:bash`: the spawned shell receives only a minimal allowlist (`PATH`, locale, `TERM`, `TZ`) with `HOME` / `TMPDIR` / `PWD` pinned to the session directory. The full gateway process environment is not inherited.
 - A regex denylist for clearly dangerous shell operations (`sudo`, network egress, mounts, package managers, etc.). This is *defense-in-depth*, not a sandbox.
 - 30s default / 120s max bash timeout; 16 KiB output cap per stream; 256 KiB max file size; 4 MiB total writes per session.
 - Path resolution rejects absolute paths and `..` traversal.

--- a/dotnet/Microsoft.McpGateway.Management/src/Foundry/BuiltinToolExecutor.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Foundry/BuiltinToolExecutor.cs
@@ -13,8 +13,13 @@ namespace Microsoft.McpGateway.Management.Foundry
     /// <summary>
     /// Built-in agent tools that run in-process inside the gateway pod.
     /// All file operations are confined to a per-session
-    /// <c>workingDirectory</c>; bash commands inherit that as cwd.
-    /// P2 will add command allowlist + cgroup-style isolation.
+    /// <c>workingDirectory</c>; bash commands inherit that as cwd and run with
+    /// a sanitized, default-deny environment (see
+    /// <see cref="ApplySandboxedEnvironment"/>). A regex denylist blocks obvious
+    /// privileged / network / lateral-movement foot-guns as defense-in-depth.
+    /// This is still not a full sandbox: for multi-tenant or production use,
+    /// run built-ins in an out-of-process sandbox (gVisor / firejail /
+    /// pod-per-session).
     /// </summary>
     public class BuiltinToolExecutor
     {
@@ -37,8 +42,21 @@ namespace Microsoft.McpGateway.Management.Foundry
         // P3+ should replace this with a real sandbox (gVisor / firejail /
         // pod-per-session) and demote this to defense-in-depth.
         private static readonly Regex DenyPattern = new(
-            pattern: @"\b(?:sudo|su|mount|umount|kill|pkill|killall|reboot|shutdown|halt|poweroff|init|systemctl|service|iptables|nft|nftables|ip6tables|ufw|firewall-cmd|chroot|insmod|rmmod|modprobe|sysctl|dd|mkfs(?:\.\w+)?|fdisk|parted|crontab|at|chage|useradd|userdel|usermod|groupadd|passwd|visudo|setcap|setfacl|chown|chmod\s+[0-7]*[2367]?7+|nc|ncat|netcat|socat|nmap|ssh|scp|sftp|rsync|telnet|ftp|tftp|curl|wget|aria2c|http(?:ie)?)\b|/etc/(?:passwd|shadow|sudoers|hosts)|/proc/(?:sys|kcore|self/mem)|/sys/(?:kernel|class)|\$\(.*?(?:curl|wget|nc|sh|bash|eval|exec).*?\)|`.*?(?:curl|wget|nc|sh|bash|eval|exec).*?`|>\s*/dev/(?!null|stdout|stderr)|rm\s+-[a-zA-Z]*r[a-zA-Z]*f?\s+/(?!tmp)",
+            pattern: @"\b(?:sudo|su|mount|umount|kill|pkill|killall|reboot|shutdown|halt|poweroff|init|systemctl|service|iptables|nft|nftables|ip6tables|ufw|firewall-cmd|chroot|insmod|rmmod|modprobe|sysctl|dd|mkfs(?:\.\w+)?|fdisk|parted|crontab|at|chage|useradd|userdel|usermod|groupadd|passwd|visudo|setcap|setfacl|chown|chmod\s+[0-7]*[2367]?7+|nc|ncat|netcat|socat|nmap|ssh|scp|sftp|rsync|telnet|ftp|tftp|curl|wget|aria2c|http(?:ie)?)\b|/etc/(?:passwd|shadow|sudoers|hosts)|/proc/(?:sys|kcore|[^/\s]+/(?:mem|environ|cmdline))|/sys/(?:kernel|class)|\$\(.*?(?:curl|wget|nc|sh|bash|eval|exec).*?\)|`.*?(?:curl|wget|nc|sh|bash|eval|exec).*?`|>\s*/dev/(?!null|stdout|stderr)|rm\s+-[a-zA-Z]*r[a-zA-Z]*f?\s+/(?!tmp)",
             options: RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        // Environment variables that are safe to expose.
+        private static readonly IReadOnlyList<string> AllowedEnvironmentVariables = new[]
+        {
+            "PATH",
+            "LANG",
+            "LC_ALL",
+            "LC_CTYPE",
+            "TERM",
+            "TZ",
+        };
+
+        private const string FallbackPath = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
 
         // Tracks bytes written per session for soft disk-quota enforcement.
         // In-process (not durable across restarts); fine for single-replica
@@ -136,6 +154,8 @@ namespace Microsoft.McpGateway.Management.Foundry
                 UseShellExecute = false,
                 CreateNoWindow = true,
             };
+
+            ApplySandboxedEnvironment(psi, cwd);
 
             using var proc = new Process { StartInfo = psi, EnableRaisingEvents = true };
             var stdoutBuf = new StringBuilder();
@@ -332,6 +352,44 @@ namespace Microsoft.McpGateway.Management.Foundry
                     buf.AppendLine(data);
                 }
             }
+        }
+
+        /// <summary>
+        /// Replace the child process environment with a minimal, non-sensitive
+        /// allowlist so built-in shell commands only see a small, well-known
+        /// set of variables instead of the full gateway process environment.
+        /// </summary>
+        internal static void ApplySandboxedEnvironment(ProcessStartInfo psi, string workingDirectory)
+        {
+            // Accessing psi.Environment lazily seeds it with the parent
+            // process environment; capture the values we want to keep before
+            // clearing everything else.
+            var preserved = new Dictionary<string, string?>(StringComparer.Ordinal);
+            foreach (var name in AllowedEnvironmentVariables)
+            {
+                if (psi.Environment.TryGetValue(name, out var value) && !string.IsNullOrEmpty(value))
+                {
+                    preserved[name] = value;
+                }
+            }
+
+            psi.Environment.Clear();
+
+            foreach (var kvp in preserved)
+            {
+                psi.Environment[kvp.Key] = kvp.Value;
+            }
+
+            // Guarantee a usable PATH even if the gateway process had none.
+            if (!psi.Environment.ContainsKey("PATH"))
+            {
+                psi.Environment["PATH"] = FallbackPath;
+            }
+
+            // Confine HOME/TMPDIR/PWD to the session working directory.
+            psi.Environment["HOME"] = workingDirectory;
+            psi.Environment["TMPDIR"] = workingDirectory;
+            psi.Environment["PWD"] = workingDirectory;
         }
 
         private static void EnsureWorkingDirectory(string workingDirectory)

--- a/dotnet/Microsoft.McpGateway.Management/src/Microsoft.McpGateway.Management.csproj
+++ b/dotnet/Microsoft.McpGateway.Management/src/Microsoft.McpGateway.Management.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Microsoft.McpGateway.Management.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="KubernetesClient" />
     <PackageReference Include="Microsoft.Azure.Cosmos" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" />

--- a/dotnet/Microsoft.McpGateway.Management/test/BuiltinToolExecutorTests.cs
+++ b/dotnet/Microsoft.McpGateway.Management/test/BuiltinToolExecutorTests.cs
@@ -1,0 +1,154 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.McpGateway.Management.Foundry;
+using Moq;
+
+namespace Microsoft.McpGateway.Management.Tests
+{
+    /// <summary>
+    /// Regression tests for the built-in tool sandboxing: built-in bash runs
+    /// with a minimal, sanitized environment plus a denylist guard.
+    /// </summary>
+    [TestClass]
+    public class BuiltinToolExecutorTests
+    {
+        private readonly BuiltinToolExecutor _executor;
+        private string _cwd = string.Empty;
+
+        public BuiltinToolExecutorTests()
+        {
+            _executor = new BuiltinToolExecutor(new Mock<ILogger<BuiltinToolExecutor>>().Object);
+        }
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            _cwd = Path.Combine(Path.GetTempPath(), "mcpgw-builtin-tests-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_cwd);
+        }
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            try
+            {
+                if (Directory.Exists(_cwd))
+                {
+                    Directory.Delete(_cwd, recursive: true);
+                }
+            }
+            catch
+            {
+                // Best-effort cleanup; ignore.
+            }
+        }
+
+        [TestMethod]
+        public void ApplySandboxedEnvironment_StripsNonAllowlistedVariables()
+        {
+            var psi = new ProcessStartInfo();
+            psi.Environment["APP_CONFIG__SecretValue"] = "synthetic-1";
+            psi.Environment["APP_CONFIG__Endpoint"] = "https://synthetic.example/";
+            psi.Environment["SOME_OTHER_TOKEN"] = "synthetic-2";
+
+            BuiltinToolExecutor.ApplySandboxedEnvironment(psi, _cwd);
+
+            psi.Environment.Should().NotContainKey("APP_CONFIG__SecretValue");
+            psi.Environment.Should().NotContainKey("APP_CONFIG__Endpoint");
+            psi.Environment.Should().NotContainKey("SOME_OTHER_TOKEN");
+        }
+
+        [TestMethod]
+        public void ApplySandboxedEnvironment_PinsHomeTmpAndPwdToWorkingDirectory()
+        {
+            var psi = new ProcessStartInfo();
+
+            BuiltinToolExecutor.ApplySandboxedEnvironment(psi, _cwd);
+
+            psi.Environment["HOME"].Should().Be(_cwd);
+            psi.Environment["TMPDIR"].Should().Be(_cwd);
+            psi.Environment["PWD"].Should().Be(_cwd);
+        }
+
+        [TestMethod]
+        public void ApplySandboxedEnvironment_PreservesAllowlistedVariables()
+        {
+            var psi = new ProcessStartInfo();
+            psi.Environment["LANG"] = "en_US.UTF-8";
+            psi.Environment["TZ"] = "UTC";
+
+            BuiltinToolExecutor.ApplySandboxedEnvironment(psi, _cwd);
+
+            psi.Environment["LANG"].Should().Be("en_US.UTF-8");
+            psi.Environment["TZ"].Should().Be("UTC");
+        }
+
+        [TestMethod]
+        public void ApplySandboxedEnvironment_GuaranteesPathWhenMissing()
+        {
+            var psi = new ProcessStartInfo();
+            psi.Environment.Clear();
+
+            BuiltinToolExecutor.ApplySandboxedEnvironment(psi, _cwd);
+
+            psi.Environment.Should().ContainKey("PATH");
+            psi.Environment["PATH"].Should().NotBeNullOrEmpty();
+        }
+
+        [DataTestMethod]
+        [DataRow("cat /proc/1/environ")]
+        [DataRow("cat /proc/self/environ")]
+        [DataRow("head -c 4096 /proc/1/cmdline")]
+        [DataRow("cat /proc/self/mem")]
+        public async Task ExecuteAsync_Bash_RejectsProcEnvironmentReads(string command)
+        {
+            var argsJson = System.Text.Json.JsonSerializer.Serialize(new { command });
+
+            var result = await _executor.ExecuteAsync(BuiltinToolExecutor.Bash, argsJson, _cwd, CancellationToken.None);
+
+            result.IsError.Should().BeTrue();
+            result.Content.Should().Contain("denylist");
+        }
+
+        [TestMethod]
+        public async Task ExecuteAsync_Bash_PrintenvExposesOnlyAllowlistedVariables()
+        {
+            // This end-to-end check actually spawns /bin/bash, so it only runs
+            // on Linux where the built-ins are designed to execute.
+            if (!OperatingSystem.IsLinux() || !File.Exists("/bin/bash"))
+            {
+                Assert.Inconclusive("Requires Linux with /bin/bash to exercise the real bash built-in.");
+            }
+
+            const string variableName = "APP_CONFIG__SecretValue";
+            const string variableValue = "SYNTHETIC_VALUE";
+            Environment.SetEnvironmentVariable(variableName, variableValue);
+            try
+            {
+                var result = await _executor.ExecuteAsync(
+                    BuiltinToolExecutor.Bash,
+                    "{\"command\":\"printenv | sort\"}",
+                    _cwd,
+                    CancellationToken.None);
+
+                // The command runs and produces output (PATH is allowlisted)...
+                result.Content.Should().Contain("PATH=");
+                // ...but non-allowlisted variables must not appear in the output.
+                result.Content.Should().NotContain(variableValue);
+                result.Content.Should().NotContain(variableName);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(variableName, null);
+            }
+        }
+    }
+}


### PR DESCRIPTION
builtin:bash spawned /bin/bash inheriting the full gateway process environment. Scrub it to a minimal default-deny allowlist (PATH, locale, TERM, TZ) and pin HOME/TMPDIR/PWD to the per-session working directory so commands only see a small, well-known set of variables.

- Extend the bash denylist to block /proc/<pid>/{environ,cmdline,mem} reads as defense-in-depth.

- Add regression tests and update the README built-in tools notes.