### PR TITLE
Enforce authorization on nested agent and tool invocations

### DIFF
--- a/dotnet/Microsoft.McpGateway.Management/src/Foundry/AgentRunner.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Foundry/AgentRunner.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Runtime.CompilerServices;
+using System.Security.Claims;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Microsoft.McpGateway.Management.Contracts;
@@ -36,10 +37,14 @@ namespace Microsoft.McpGateway.Management.Foundry
         /// Run the agent loop and return only the assistant's final text response.
         /// Used by callers that don't care about intermediate events.
         /// </summary>
-        public async Task<string> RunAsync(AgentResource agent, string userInput, CancellationToken cancellationToken)
+        /// <param name="accessContext">
+        /// The effective caller. Threaded down so nested tools/subagents are
+        /// authorized against the caller's current roles (MSRC-122743).
+        /// </param>
+        public async Task<string> RunAsync(AgentResource agent, string userInput, ClaimsPrincipal accessContext, CancellationToken cancellationToken)
         {
             string answer = string.Empty;
-            await foreach (var evt in RunStreamingAsync(agent, userInput, sessionId: string.Empty, parentSessionId: null, history: null, workingDirectory: null, cancellationToken).ConfigureAwait(false))
+            await foreach (var evt in RunStreamingAsync(agent, userInput, sessionId: string.Empty, parentSessionId: null, history: null, workingDirectory: null, accessContext, cancellationToken).ConfigureAwait(false))
             {
                 if (evt.Type == SessionEventType.Completed)
                 {
@@ -77,10 +82,12 @@ namespace Microsoft.McpGateway.Management.Foundry
             string? parentSessionId,
             IList<SessionMessage>? history,
             string? workingDirectory,
+            ClaimsPrincipal accessContext,
             [EnumeratorCancellation] CancellationToken cancellationToken,
             IReadOnlyList<SessionMessage>? priorHistory = null)
         {
             ArgumentNullException.ThrowIfNull(agent);
+            ArgumentNullException.ThrowIfNull(accessContext);
 
             yield return new SessionEvent { Type = SessionEventType.Started, SessionId = sessionId, ParentSessionId = parentSessionId };
 
@@ -90,7 +97,7 @@ namespace Microsoft.McpGateway.Management.Foundry
             string? prepError = null;
             try
             {
-                resolvedTools = await _toolRegistry.ResolveAsync(agent.Tools, cancellationToken).ConfigureAwait(false);
+                resolvedTools = await _toolRegistry.ResolveAsync(agent.Tools, accessContext, cancellationToken).ConfigureAwait(false);
                 chatTools = AgentToolRegistry.BuildChatTools(resolvedTools);
                 messages = new List<ChatMessage> { new SystemChatMessage(agent.System) };
                 if (priorHistory != null)
@@ -306,7 +313,7 @@ namespace Microsoft.McpGateway.Management.Foundry
                         {
                             try
                             {
-                                toolResult = await _toolRegistry.ExecuteAsync(resolved, arguments, sessionId, workingDirectory, cancellationToken).ConfigureAwait(false);
+                                toolResult = await _toolRegistry.ExecuteAsync(resolved, arguments, sessionId, workingDirectory, accessContext, cancellationToken).ConfigureAwait(false);
                             }
                             catch (Exception ex)
                             {

--- a/dotnet/Microsoft.McpGateway.Management/src/Foundry/AgentToolRegistry.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Foundry/AgentToolRegistry.cs
@@ -1,9 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Security.Claims;
 using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
+using Microsoft.McpGateway.Management.Authorization;
 using Microsoft.McpGateway.Management.Contracts;
 using Microsoft.McpGateway.Management.Store;
 
@@ -34,6 +36,7 @@ namespace Microsoft.McpGateway.Management.Foundry
         private readonly IToolResourceStore _toolStore;
         private readonly IAgentResourceStore _agentStore;
         private readonly IHttpClientFactory _httpClientFactory;
+        private readonly IPermissionProvider _permissionProvider;
         private readonly SubAgentInvoker? _subAgentInvoker;
         private readonly BuiltinToolExecutor? _builtinExecutor;
         private readonly ILogger<AgentToolRegistry> _logger;
@@ -42,6 +45,7 @@ namespace Microsoft.McpGateway.Management.Foundry
             IToolResourceStore toolStore,
             IAgentResourceStore agentStore,
             IHttpClientFactory httpClientFactory,
+            IPermissionProvider permissionProvider,
             ILogger<AgentToolRegistry> logger,
             SubAgentInvoker? subAgentInvoker = null,
             BuiltinToolExecutor? builtinExecutor = null)
@@ -49,6 +53,7 @@ namespace Microsoft.McpGateway.Management.Foundry
             _toolStore = toolStore ?? throw new ArgumentNullException(nameof(toolStore));
             _agentStore = agentStore ?? throw new ArgumentNullException(nameof(agentStore));
             _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
+            _permissionProvider = permissionProvider ?? throw new ArgumentNullException(nameof(permissionProvider));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _subAgentInvoker = subAgentInvoker;
             _builtinExecutor = builtinExecutor;
@@ -58,8 +63,15 @@ namespace Microsoft.McpGateway.Management.Foundry
         /// Resolve the agent's declared tool list. Returns successfully resolved
         /// tools; logs and skips any that are missing or use an unsupported prefix.
         /// </summary>
-        public async Task<IReadOnlyList<ResolvedTool>> ResolveAsync(IEnumerable<string> toolNames, CancellationToken cancellationToken)
+        /// <param name="accessContext">
+        /// The effective caller of the current run. Each nested <c>mcp:</c> and
+        /// <c>agent:</c> reference is re-authorized against its <em>current</em>
+        /// <c>RequiredRoles</c> so that tools the caller may no longer access are
+        /// never advertised to the model (MSRC-122743).
+        /// </param>
+        public async Task<IReadOnlyList<ResolvedTool>> ResolveAsync(IEnumerable<string> toolNames, ClaimsPrincipal accessContext, CancellationToken cancellationToken)
         {
+            ArgumentNullException.ThrowIfNull(accessContext);
             var resolved = new List<ResolvedTool>();
             foreach (var raw in toolNames ?? Enumerable.Empty<string>())
             {
@@ -74,6 +86,11 @@ namespace Microsoft.McpGateway.Management.Foundry
                     if (resource?.ToolDefinition?.Tool == null)
                     {
                         _logger.LogWarning("MCP tool '{tool}' declared by agent but not found in store; skipping.", toolName);
+                        continue;
+                    }
+                    if (!await _permissionProvider.CheckAccessAsync(accessContext, resource, Operation.Read).ConfigureAwait(false))
+                    {
+                        _logger.LogWarning("Caller lacks permission to invoke MCP tool '{tool}'; excluding from resolved tools.", toolName);
                         continue;
                     }
                     resolved.Add(new McpResolvedTool(toolName, resource));
@@ -91,6 +108,11 @@ namespace Microsoft.McpGateway.Management.Foundry
                     if (agent == null)
                     {
                         _logger.LogWarning("Subagent '{agent}' declared by parent but not found in store; skipping.", agentName);
+                        continue;
+                    }
+                    if (!await _permissionProvider.CheckAccessAsync(accessContext, agent, Operation.Read).ConfigureAwait(false))
+                    {
+                        _logger.LogWarning("Caller lacks permission to invoke subagent '{agent}'; excluding from resolved tools.", agentName);
                         continue;
                     }
                     resolved.Add(new SubAgentResolvedTool(SubAgentFunctionPrefix + Sanitize(agentName), agent));
@@ -128,13 +150,21 @@ namespace Microsoft.McpGateway.Management.Foundry
         /// <c>ParentSessionId</c> on any spawned subagent session and to
         /// inherit auth context for the child run.
         /// </param>
-        public async Task<ToolResult> ExecuteAsync(ResolvedTool tool, string argumentsJson, string parentSessionId, string? workingDirectory, CancellationToken cancellationToken)
+        /// <param name="accessContext">
+        /// The effective caller of the current run. Nested <c>mcp:</c> and
+        /// <c>agent:</c> references are re-authorized against their current
+        /// <c>RequiredRoles</c> at invocation time, closing the window where a
+        /// stale parent reference could execute a since-restricted resource
+        /// (MSRC-122743).
+        /// </param>
+        public async Task<ToolResult> ExecuteAsync(ResolvedTool tool, string argumentsJson, string parentSessionId, string? workingDirectory, ClaimsPrincipal accessContext, CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(tool);
+            ArgumentNullException.ThrowIfNull(accessContext);
             return tool switch
             {
-                McpResolvedTool mcp => await ExecuteMcpAsync(mcp, argumentsJson, cancellationToken).ConfigureAwait(false),
-                SubAgentResolvedTool sub => await ExecuteSubAgentAsync(sub, argumentsJson, parentSessionId, cancellationToken).ConfigureAwait(false),
+                McpResolvedTool mcp => await ExecuteMcpAsync(mcp, argumentsJson, accessContext, cancellationToken).ConfigureAwait(false),
+                SubAgentResolvedTool sub => await ExecuteSubAgentAsync(sub, argumentsJson, parentSessionId, accessContext, cancellationToken).ConfigureAwait(false),
                 BuiltinResolvedTool builtin => await ExecuteBuiltinAsync(builtin, argumentsJson, workingDirectory, cancellationToken).ConfigureAwait(false),
                 _ => new ToolResult(JsonSerializer.Serialize(new { error = $"Unsupported tool kind '{tool.GetType().Name}'." }), IsError: true),
             };
@@ -153,9 +183,24 @@ namespace Microsoft.McpGateway.Management.Foundry
             return _builtinExecutor.ExecuteAsync(tool.Name, argumentsJson, workingDirectory, cancellationToken);
         }
 
-        private async Task<ToolResult> ExecuteMcpAsync(McpResolvedTool tool, string argumentsJson, CancellationToken cancellationToken)
+        private async Task<ToolResult> ExecuteMcpAsync(McpResolvedTool tool, string argumentsJson, ClaimsPrincipal accessContext, CancellationToken cancellationToken)
         {
-            var def = tool.Resource.ToolDefinition;
+            // Re-resolve and re-authorize against the tool's current state so a
+            // stale parent reference cannot execute a since-restricted tool
+            // (MSRC-122743). Roles may have been tightened after this run began.
+            var current = await _toolStore.TryGetAsync(tool.Name, cancellationToken).ConfigureAwait(false);
+            if (current?.ToolDefinition?.Tool == null)
+            {
+                _logger.LogWarning("MCP tool {tool} no longer exists at invocation time; denying.", tool.Name);
+                return new ToolResult(JsonSerializer.Serialize(new { error = $"MCP tool '{tool.Name}' is no longer available." }), IsError: true);
+            }
+            if (!await _permissionProvider.CheckAccessAsync(accessContext, current, Operation.Read).ConfigureAwait(false))
+            {
+                _logger.LogWarning("Caller lacks permission to invoke MCP tool {tool} at invocation time; denying.", tool.Name);
+                return new ToolResult(JsonSerializer.Serialize(new { error = "You do not have permission to invoke this tool." }), IsError: true);
+            }
+
+            var def = current.ToolDefinition;
             // Same convention as HttpToolExecutor: the tool's pod is reachable
             // via cluster DNS in the "adapter" namespace.
             var endpoint = $"http://{tool.Name}-service.adapter.svc.cluster.local:{def.Port}{def.Path}";
@@ -177,12 +222,29 @@ namespace Microsoft.McpGateway.Management.Foundry
             return new ToolResult(body, IsError: false);
         }
 
-        private async Task<ToolResult> ExecuteSubAgentAsync(SubAgentResolvedTool tool, string argumentsJson, string parentSessionId, CancellationToken cancellationToken)
+        private async Task<ToolResult> ExecuteSubAgentAsync(SubAgentResolvedTool tool, string argumentsJson, string parentSessionId, ClaimsPrincipal accessContext, CancellationToken cancellationToken)
         {
             if (_subAgentInvoker == null)
             {
                 return new ToolResult("{\"error\":\"SubAgentInvoker is not registered.\"}", IsError: true);
             }
+
+            // Re-resolve and re-authorize against the child agent's current
+            // state so a stale parent reference cannot execute a since-restricted
+            // child agent (MSRC-122743). The effective caller — not the parent's
+            // creator — must satisfy the child's current RequiredRoles.
+            var current = await _agentStore.TryGetAsync(tool.Agent.Name, cancellationToken).ConfigureAwait(false);
+            if (current == null)
+            {
+                _logger.LogWarning("Subagent {agent} no longer exists at invocation time; denying.", tool.Agent.Name);
+                return new ToolResult(JsonSerializer.Serialize(new { error = $"Subagent '{tool.Agent.Name}' is no longer available." }), IsError: true);
+            }
+            if (!await _permissionProvider.CheckAccessAsync(accessContext, current, Operation.Read).ConfigureAwait(false))
+            {
+                _logger.LogWarning("Caller lacks permission to invoke subagent {agent} at invocation time; denying.", tool.Agent.Name);
+                return new ToolResult(JsonSerializer.Serialize(new { error = "You do not have permission to invoke this subagent." }), IsError: true);
+            }
+
             string input;
             try
             {
@@ -203,8 +265,8 @@ namespace Microsoft.McpGateway.Management.Foundry
             }
 
             _logger.LogInformation("Invoking subagent {agent} from parent session {parent} (input {len} chars)",
-                tool.Agent.Name, parentSessionId, input.Length);
-            return await _subAgentInvoker.InvokeAsync(tool.Agent, input, parentSessionId, cancellationToken).ConfigureAwait(false);
+                current.Name, parentSessionId, input.Length);
+            return await _subAgentInvoker.InvokeAsync(current, input, parentSessionId, accessContext, cancellationToken).ConfigureAwait(false);
         }
 
         private static string Sanitize(string agentName)

--- a/dotnet/Microsoft.McpGateway.Management/src/Foundry/SubAgentInvoker.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Foundry/SubAgentInvoker.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Security.Claims;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Microsoft.McpGateway.Management.Contracts;
@@ -42,15 +43,22 @@ namespace Microsoft.McpGateway.Management.Foundry
         /// Returns a <see cref="ToolResult"/> whose content is the child's
         /// final answer (or a JSON error blob if the run failed).
         /// </summary>
+        /// <param name="accessContext">
+        /// The effective caller of the originating run. Carried into the child
+        /// run so the child's own nested tools/subagents are authorized against
+        /// the live caller rather than the parent's creator (MSRC-122743).
+        /// </param>
         public async Task<ToolResult> InvokeAsync(
             AgentResource childAgent,
             string input,
             string parentSessionId,
+            ClaimsPrincipal accessContext,
             CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(childAgent);
             ArgumentException.ThrowIfNullOrEmpty(input);
             ArgumentException.ThrowIfNullOrEmpty(parentSessionId);
+            ArgumentNullException.ThrowIfNull(accessContext);
 
             // Walk up the parent chain to enforce depth limit.
             var depth = await ComputeDepthAsync(parentSessionId, cancellationToken).ConfigureAwait(false);
@@ -63,8 +71,9 @@ namespace Microsoft.McpGateway.Management.Foundry
                     IsError: true);
             }
 
-            // Inherit auth context from the parent so downstream permission
-            // checks (when added) see the same caller.
+            // The child session is recorded under the parent's creator for
+            // lineage/observability, but authorization for the child's nested
+            // resources uses the live caller (accessContext), not this value.
             var parent = await _sessionStore.TryGetAsync(parentSessionId, cancellationToken).ConfigureAwait(false);
             var createdBy = parent?.CreatedBy ?? "subagent";
 
@@ -96,6 +105,7 @@ namespace Microsoft.McpGateway.Management.Foundry
                 parentSessionId: parentSessionId,
                 history: child.Messages,
                 workingDirectory: child.WorkingDirectory,
+                accessContext,
                 cancellationToken).ConfigureAwait(false))
             {
                 if (evt.Type == SessionEventType.Completed)

--- a/dotnet/Microsoft.McpGateway.Management/src/Service/SessionManagementService.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Service/SessionManagementService.cs
@@ -66,10 +66,12 @@ namespace Microsoft.McpGateway.Management.Service
             await _store.UpsertAsync(session, cancellationToken).ConfigureAwait(false);
 
             // Phase 3: kick off the agent loop (LLM + tool calls) in the
-            // background. Caller polls /sessions/{id} for completion.
+            // background. Caller polls /sessions/{id} for completion. The
+            // caller's principal is captured so nested tools/subagents are
+            // authorized against the live caller (MSRC-122743).
             if (_agentRunner != null)
             {
-                _ = Task.Run(() => RunSessionAsync(session.Id), CancellationToken.None);
+                _ = Task.Run(() => RunSessionAsync(session.Id, accessContext), CancellationToken.None);
             }
             else
             {
@@ -84,7 +86,7 @@ namespace Microsoft.McpGateway.Management.Service
         /// against the user's input as a one-shot chat completion. Updates the
         /// stored session with Status=Completed/Failed and Result/Error.
         /// </summary>
-        private async Task RunSessionAsync(string sessionId)
+        private async Task RunSessionAsync(string sessionId, ClaimsPrincipal accessContext)
         {
             try
             {
@@ -102,6 +104,7 @@ namespace Microsoft.McpGateway.Management.Service
                 var result = await _agentRunner!.RunAsync(
                     session.AgentSnapshot,
                     session.Input,
+                    accessContext,
                     CancellationToken.None).ConfigureAwait(false);
 
                 session.Result = result;
@@ -169,6 +172,7 @@ namespace Microsoft.McpGateway.Management.Service
                 parentSessionId: session.ParentSessionId,
                 history: session.Messages,
                 workingDirectory: session.WorkingDirectory,
+                accessContext,
                 cancellationToken).GetAsyncEnumerator(cancellationToken);
             try
             {
@@ -265,6 +269,7 @@ namespace Microsoft.McpGateway.Management.Service
                 parentSessionId: session.ParentSessionId,
                 history: session.Messages,
                 workingDirectory: session.WorkingDirectory,
+                accessContext,
                 cancellationToken,
                 priorHistory: priorHistory).GetAsyncEnumerator(cancellationToken);
             try

--- a/dotnet/Microsoft.McpGateway.Management/test/AgentToolRegistryTests.cs
+++ b/dotnet/Microsoft.McpGateway.Management/test/AgentToolRegistryTests.cs
@@ -1,0 +1,239 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Security.Claims;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.McpGateway.Management.Authorization;
+using Microsoft.McpGateway.Management.Contracts;
+using Microsoft.McpGateway.Management.Foundry;
+using Microsoft.McpGateway.Management.Store;
+using ModelContextProtocol.Protocol;
+using Moq;
+
+namespace Microsoft.McpGateway.Management.Tests
+{
+    /// <summary>
+    /// Regression tests for MSRC-122743: nested <c>agent:</c> and <c>mcp:</c>
+    /// references must be re-authorized against the effective caller's current
+    /// roles at resolve time and again at invocation time, so a stale parent
+    /// reference cannot execute a since-restricted child resource.
+    /// </summary>
+    [TestClass]
+    public class AgentToolRegistryTests
+    {
+        private readonly Mock<IToolResourceStore> _toolStore = new();
+        private readonly Mock<IAgentResourceStore> _agentStore = new();
+        private readonly Mock<ISessionResourceStore> _sessionStore = new();
+        private readonly Mock<IHttpClientFactory> _httpFactory = new();
+        private readonly Mock<IPermissionProvider> _permission = new();
+        private readonly Mock<ILogger<AgentToolRegistry>> _logger = new();
+        private readonly SubAgentInvoker _subAgentInvoker;
+        private readonly AgentToolRegistry _registry;
+        private int _runnerFactoryCalls;
+
+        public AgentToolRegistryTests()
+        {
+            // A real SubAgentInvoker so the agent: branch is reachable, but its
+            // runner factory records invocation and yields null — it must never
+            // be reached when authorization denies the nested call.
+            _subAgentInvoker = new SubAgentInvoker(
+                _sessionStore.Object,
+                () => { _runnerFactoryCalls++; return null!; },
+                Mock.Of<ILogger<SubAgentInvoker>>());
+
+            _registry = new AgentToolRegistry(
+                _toolStore.Object,
+                _agentStore.Object,
+                _httpFactory.Object,
+                _permission.Object,
+                _logger.Object,
+                _subAgentInvoker,
+                builtinExecutor: null);
+        }
+
+        private static ClaimsPrincipal Caller(string userId, params string[] roles)
+        {
+            var claims = new List<Claim> { new(ClaimTypes.NameIdentifier, userId) };
+            claims.AddRange(roles.Select(r => new Claim(ClaimTypes.Role, r)));
+            return new ClaimsPrincipal(new ClaimsIdentity(claims, "test"));
+        }
+
+        private static ToolResource CreateTool(string name, string creator, params string[] requiredRoles)
+        {
+            var schema = JsonSerializer.Deserialize<JsonElement>(
+                JsonSerializer.Serialize(new { type = "object", properties = new { } }));
+            var data = new ToolData
+            {
+                Name = name,
+                ImageName = "img",
+                ImageVersion = "v1",
+                ReplicaCount = 1,
+                EnvironmentVariables = [],
+                ToolDefinition = new ToolDefinition
+                {
+                    Tool = new Tool { Name = name, Description = "d", InputSchema = schema },
+                    Port = 443,
+                    Path = "/score",
+                },
+                RequiredRoles = requiredRoles.ToList(),
+            };
+            return ToolResource.Create(data, creator, DateTimeOffset.UtcNow);
+        }
+
+        private static AgentResource CreateAgent(string name, string creator, params string[] requiredRoles)
+        {
+            var data = new AgentData
+            {
+                Name = name,
+                Model = "gpt-4o",
+                System = "sys",
+                Tools = [],
+                RequiredRoles = requiredRoles.ToList(),
+            };
+            return AgentResource.Create(data, creator, DateTimeOffset.UtcNow);
+        }
+
+        private sealed class StubHandler(HttpStatusCode status, string body) : HttpMessageHandler
+        {
+            public int Calls { get; private set; }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                Calls++;
+                return Task.FromResult(new HttpResponseMessage(status) { Content = new StringContent(body) });
+            }
+        }
+
+        // ---- ResolveAsync: unauthorized nested resources must not be advertised ----
+
+        [TestMethod]
+        public async Task ResolveAsync_ShouldExcludeMcpTool_WhenCallerLacksPermission()
+        {
+            var tool = CreateTool("finance-ledger-tool", "admin-poc", "finance-admin");
+            _toolStore.Setup(s => s.TryGetAsync("finance-ledger-tool", It.IsAny<CancellationToken>())).ReturnsAsync(tool);
+            _permission.Setup(p => p.CheckAccessAsync(It.IsAny<ClaimsPrincipal>(), tool, Operation.Read)).ReturnsAsync(false);
+
+            var resolved = await _registry.ResolveAsync(["mcp:finance-ledger-tool"], Caller("ordinary-poc", "ordinary-user"), CancellationToken.None);
+
+            resolved.Should().BeEmpty();
+        }
+
+        [TestMethod]
+        public async Task ResolveAsync_ShouldIncludeMcpTool_WhenCallerHasPermission()
+        {
+            var tool = CreateTool("finance-ledger-tool", "admin-poc", "finance-admin");
+            _toolStore.Setup(s => s.TryGetAsync("finance-ledger-tool", It.IsAny<CancellationToken>())).ReturnsAsync(tool);
+            _permission.Setup(p => p.CheckAccessAsync(It.IsAny<ClaimsPrincipal>(), tool, Operation.Read)).ReturnsAsync(true);
+
+            var resolved = await _registry.ResolveAsync(["mcp:finance-ledger-tool"], Caller("admin-poc", "finance-admin"), CancellationToken.None);
+
+            resolved.Should().ContainSingle().Which.Should().BeOfType<McpResolvedTool>();
+        }
+
+        [TestMethod]
+        public async Task ResolveAsync_ShouldExcludeSubagent_WhenCallerLacksPermission()
+        {
+            var child = CreateAgent("finance-ledger-child-agent", "admin-poc", "finance-admin");
+            _agentStore.Setup(s => s.TryGetAsync("finance-ledger-child-agent", It.IsAny<CancellationToken>())).ReturnsAsync(child);
+            _permission.Setup(p => p.CheckAccessAsync(It.IsAny<ClaimsPrincipal>(), child, Operation.Read)).ReturnsAsync(false);
+
+            var resolved = await _registry.ResolveAsync(["agent:finance-ledger-child-agent"], Caller("ordinary-poc", "ordinary-user"), CancellationToken.None);
+
+            resolved.Should().BeEmpty();
+            _runnerFactoryCalls.Should().Be(0);
+        }
+
+        // ---- ExecuteAsync: invocation-time gate against current policy ----
+
+        [TestMethod]
+        public async Task ExecuteAsync_ShouldDenyMcpTool_WhenCallerLacksPermission()
+        {
+            var tool = CreateTool("finance-ledger-tool", "admin-poc", "finance-admin");
+            _toolStore.Setup(s => s.TryGetAsync("finance-ledger-tool", It.IsAny<CancellationToken>())).ReturnsAsync(tool);
+            _permission.Setup(p => p.CheckAccessAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<IManagedResource>(), Operation.Read)).ReturnsAsync(false);
+
+            var result = await _registry.ExecuteAsync(
+                new McpResolvedTool("finance-ledger-tool", tool),
+                "{}",
+                parentSessionId: "parent-session",
+                workingDirectory: null,
+                Caller("ordinary-poc", "ordinary-user"),
+                CancellationToken.None);
+
+            result.IsError.Should().BeTrue();
+            result.Content.Should().Contain("permission");
+            _httpFactory.Verify(f => f.CreateClient(It.IsAny<string>()), Times.Never);
+        }
+
+        [TestMethod]
+        public async Task ExecuteAsync_ShouldInvokeMcpTool_WhenCallerHasPermission()
+        {
+            var tool = CreateTool("finance-ledger-tool", "admin-poc", "finance-admin");
+            _toolStore.Setup(s => s.TryGetAsync("finance-ledger-tool", It.IsAny<CancellationToken>())).ReturnsAsync(tool);
+            _permission.Setup(p => p.CheckAccessAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<IManagedResource>(), Operation.Read)).ReturnsAsync(true);
+            var handler = new StubHandler(HttpStatusCode.OK, "{\"ok\":true}");
+            _httpFactory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(new HttpClient(handler));
+
+            var result = await _registry.ExecuteAsync(
+                new McpResolvedTool("finance-ledger-tool", tool),
+                "{}",
+                parentSessionId: "parent-session",
+                workingDirectory: null,
+                Caller("admin-poc", "finance-admin"),
+                CancellationToken.None);
+
+            result.IsError.Should().BeFalse();
+            result.Content.Should().Contain("ok");
+            handler.Calls.Should().Be(1);
+        }
+
+        [TestMethod]
+        public async Task ExecuteAsync_ShouldDenyMcpTool_WhenToolNoLongerExists()
+        {
+            var tool = CreateTool("finance-ledger-tool", "admin-poc", "finance-admin");
+            _toolStore.Setup(s => s.TryGetAsync("finance-ledger-tool", It.IsAny<CancellationToken>())).ReturnsAsync((ToolResource?)null);
+
+            var result = await _registry.ExecuteAsync(
+                new McpResolvedTool("finance-ledger-tool", tool),
+                "{}",
+                parentSessionId: "parent-session",
+                workingDirectory: null,
+                Caller("ordinary-poc", "ordinary-user"),
+                CancellationToken.None);
+
+            result.IsError.Should().BeTrue();
+            _httpFactory.Verify(f => f.CreateClient(It.IsAny<string>()), Times.Never);
+        }
+
+        [TestMethod]
+        public async Task ExecuteAsync_ShouldDenySubagent_WhenCallerLacksPermission()
+        {
+            var child = CreateAgent("finance-ledger-child-agent", "admin-poc", "finance-admin");
+            _agentStore.Setup(s => s.TryGetAsync("finance-ledger-child-agent", It.IsAny<CancellationToken>())).ReturnsAsync(child);
+            _permission.Setup(p => p.CheckAccessAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<IManagedResource>(), Operation.Read)).ReturnsAsync(false);
+
+            var result = await _registry.ExecuteAsync(
+                new SubAgentResolvedTool("agent_finance-ledger-child-agent", child),
+                "{\"input\":\"transfer funds\"}",
+                parentSessionId: "parent-session",
+                workingDirectory: null,
+                Caller("ordinary-poc", "ordinary-user"),
+                CancellationToken.None);
+
+            result.IsError.Should().BeTrue();
+            result.Content.Should().Contain("permission");
+            // The child run must never start: no session persisted, no runner created.
+            _runnerFactoryCalls.Should().Be(0);
+            _sessionStore.Verify(s => s.UpsertAsync(It.IsAny<SessionResource>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
When a session runs an agent, the gateway now re-checks the caller's access against each referenced sub-agent and MCP tool, not just the top-level agent. References the caller can't access are excluded from the model's tool list and are rejected at invocation time.

## Changes
- Thread the caller's identity through the session run path.
- Exclude nested agent/tool references the caller can't access at resolve time (so they are never advertised to the model).
- Re-validate against the referenced resource's current access at invocation time.
- Unit tests covering resolve-time filtering and invocation-time denial for both sub-agent and MCP tool references.

## Testing
- All unit tests pass (Management/Service/Tools suites).
- Local end-to-end against a running gateway: agent CRUD, role changes, and read-access checks verified.
