### PR TITLE
Keep built-in file tools within the session working directory

### DIFF
--- a/dotnet/Microsoft.McpGateway.Management/src/Foundry/BuiltinToolExecutor.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Foundry/BuiltinToolExecutor.cs
@@ -106,7 +106,7 @@ namespace Microsoft.McpGateway.Management.Foundry
                     functionDescription: "Read a UTF-8 text file relative to the session's working directory.",
                     functionParameters: BinaryData.FromString("""
                         {"type":"object","properties":{
-                          "path":{"type":"string","description":"Path relative to the session working directory. Absolute paths and '..' segments are rejected."}
+                          "path":{"type":"string","description":"Path relative to the session working directory. Absolute paths, '..' segments, and symlinks whose final target is outside the session directory are rejected."}
                         },"required":["path"]}
                         """)),
                 WriteFile => global::OpenAI.Chat.ChatTool.CreateFunctionTool(
@@ -114,7 +114,7 @@ namespace Microsoft.McpGateway.Management.Foundry
                     functionDescription: "Write (or overwrite) a UTF-8 text file relative to the session's working directory.",
                     functionParameters: BinaryData.FromString("""
                         {"type":"object","properties":{
-                          "path":{"type":"string","description":"Path relative to the session working directory."},
+                          "path":{"type":"string","description":"Path relative to the session working directory. Absolute paths, '..' segments, and symlinks whose final target is outside the session directory are rejected."},
                           "content":{"type":"string","description":"File content (UTF-8)."}
                         },"required":["path","content"]}
                         """)),
@@ -309,6 +309,16 @@ namespace Microsoft.McpGateway.Management.Foundry
             _sessionBytesWritten.TryRemove(workingDirectory, out _);
         }
 
+        // Compare path strings case-insensitively on Windows (case-preserving
+        // but case-insensitive file system) and case-sensitively elsewhere
+        // (Linux, where the gateway actually runs the built-ins).
+        private static readonly StringComparison PathComparison =
+            OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+        // Upper bound on symlink hops while canonicalizing, mirroring the
+        // typical kernel MAXSYMLINKS limit, to defeat symlink loops.
+        private const int MaxSymlinkHops = 40;
+
         private static (string fullPath, string? error) ResolvePath(string cwd, string relative)
         {
             if (string.IsNullOrWhiteSpace(relative))
@@ -323,13 +333,148 @@ namespace Microsoft.McpGateway.Management.Foundry
             {
                 return (string.Empty, "Path traversal ('..') is not allowed.");
             }
+
             var combined = Path.GetFullPath(Path.Combine(cwd, relative));
-            var cwdFull = Path.GetFullPath(cwd);
-            if (!combined.StartsWith(cwdFull, StringComparison.Ordinal))
+
+            // Canonicalize BOTH the session root and the requested target so the
+            // containment check is enforced AFTER symbolic links are resolved to
+            // their final filesystem target. A lexical check alone (the previous
+            // behavior) is bypassable with a session-local symlink that points
+            // outside the session directory (MSRC-122432): the path is lexically
+            // under the session root but the OS follows the link to an external
+            // target at file-access time.
+            var (canonicalRoot, rootError) = TryResolveCanonicalPath(Path.GetFullPath(cwd));
+            if (rootError != null || canonicalRoot is null)
+            {
+                return (string.Empty, "Unable to resolve the session working directory.");
+            }
+            var (canonicalTarget, targetError) = TryResolveCanonicalPath(combined);
+            if (targetError != null || canonicalTarget is null)
+            {
+                return (string.Empty, targetError ?? "Unable to resolve the requested path.");
+            }
+
+            if (!IsContainedWithin(canonicalRoot, canonicalTarget))
             {
                 return (string.Empty, "Path escapes the session working directory.");
             }
-            return (combined, null);
+
+            return (canonicalTarget, null);
+        }
+
+        /// <summary>
+        /// Returns <see langword="true"/> when <paramref name="candidate"/> is
+        /// the same path as, or a descendant of, <paramref name="root"/>. The
+        /// comparison requires a directory-separator boundary so that, for
+        /// example, "/root/session" does not match a sibling like
+        /// "/root/session-evil".
+        /// </summary>
+        private static bool IsContainedWithin(string root, string candidate)
+        {
+            if (string.Equals(root, candidate, PathComparison))
+            {
+                return true;
+            }
+            var rootWithSeparator = root.EndsWith(Path.DirectorySeparatorChar)
+                ? root
+                : root + Path.DirectorySeparatorChar;
+            return candidate.StartsWith(rootWithSeparator, PathComparison);
+        }
+
+        /// <summary>
+        /// Managed equivalent of POSIX <c>realpath</c>: walks
+        /// <paramref name="absolutePath"/> from its root one component at a time,
+        /// following any symbolic links (including intermediate directory
+        /// components and chained links) to their final target. Trailing
+        /// components that do not exist on disk are kept literally because a
+        /// non-existent entry cannot be a symlink — this lets the helper
+        /// canonicalize the destination of a not-yet-created file for write
+        /// operations. Returns an error if a symlink loop / excessive depth is
+        /// detected.
+        /// </summary>
+        private static (string? canonical, string? error) TryResolveCanonicalPath(string absolutePath)
+        {
+            var full = Path.GetFullPath(absolutePath);
+            var root = Path.GetPathRoot(full);
+            if (string.IsNullOrEmpty(root))
+            {
+                return (null, "Path is not rooted.");
+            }
+
+            var separators = new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
+            var pending = new List<string>(full[root.Length..].Split(separators, StringSplitOptions.RemoveEmptyEntries));
+
+            var resolved = root;
+            var hops = 0;
+            var index = 0;
+            while (index < pending.Count)
+            {
+                var segment = pending[index++];
+                if (segment.Length == 0 || segment == ".")
+                {
+                    continue;
+                }
+                if (segment == "..")
+                {
+                    var parent = Path.GetDirectoryName(resolved);
+                    resolved = string.IsNullOrEmpty(parent) ? root : parent;
+                    continue;
+                }
+
+                var candidate = Path.Combine(resolved, segment);
+                var linkTarget = TryGetLinkTarget(candidate);
+                if (linkTarget is null)
+                {
+                    // Not a symlink (or does not exist): accept verbatim.
+                    resolved = candidate;
+                    continue;
+                }
+
+                if (++hops > MaxSymlinkHops)
+                {
+                    return (null, "Too many levels of symbolic links.");
+                }
+
+                if (Path.IsPathRooted(linkTarget))
+                {
+                    // Absolute target: restart from the target's root, then
+                    // process the target's own components before the remaining
+                    // ones.
+                    var targetRoot = Path.GetPathRoot(linkTarget)!;
+                    resolved = targetRoot;
+                    pending.InsertRange(index, linkTarget[targetRoot.Length..].Split(separators, StringSplitOptions.RemoveEmptyEntries));
+                }
+                else
+                {
+                    // Relative target: resolve against the directory holding the
+                    // link (the current 'resolved').
+                    pending.InsertRange(index, linkTarget.Split(separators, StringSplitOptions.RemoveEmptyEntries));
+                }
+            }
+
+            return (resolved, null);
+        }
+
+        /// <summary>
+        /// Returns the immediate symbolic-link target for
+        /// <paramref name="path"/>, or <see langword="null"/> when the entry is
+        /// not a symlink (or does not exist). A fresh
+        /// <see cref="FileSystemInfo"/> is created on every call so the link
+        /// metadata is never served from a stale cache.
+        /// </summary>
+        private static string? TryGetLinkTarget(string path)
+        {
+            try
+            {
+                FileSystemInfo info = Directory.Exists(path)
+                    ? new DirectoryInfo(path)
+                    : new FileInfo(path);
+                return info.LinkTarget;
+            }
+            catch
+            {
+                return null;
+            }
         }
 
         private void Append(StringBuilder buf, string? data)

--- a/dotnet/Microsoft.McpGateway.Management/test/BuiltinToolExecutorTests.cs
+++ b/dotnet/Microsoft.McpGateway.Management/test/BuiltinToolExecutorTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Threading;
@@ -22,6 +23,7 @@ namespace Microsoft.McpGateway.Management.Tests
     {
         private readonly BuiltinToolExecutor _executor;
         private string _cwd = string.Empty;
+        private readonly List<string> _externalPaths = new();
 
         public BuiltinToolExecutorTests()
         {
@@ -48,6 +50,25 @@ namespace Microsoft.McpGateway.Management.Tests
             catch
             {
                 // Best-effort cleanup; ignore.
+            }
+
+            foreach (var path in _externalPaths)
+            {
+                try
+                {
+                    if (Directory.Exists(path))
+                    {
+                        Directory.Delete(path, recursive: true);
+                    }
+                    else if (File.Exists(path))
+                    {
+                        File.Delete(path);
+                    }
+                }
+                catch
+                {
+                    // Best-effort cleanup; ignore.
+                }
             }
         }
 
@@ -148,6 +169,263 @@ namespace Microsoft.McpGateway.Management.Tests
             finally
             {
                 Environment.SetEnvironmentVariable(variableName, null);
+            }
+        }
+
+        // ---------------------------------------------------------------------
+        // Path containment regression tests for builtin_read_file /
+        // builtin_write_file (MSRC-122432: symlink traversal bypassing the
+        // lexical path check).
+        // ---------------------------------------------------------------------
+
+        [TestMethod]
+        public async Task ExecuteAsync_ReadFile_WithinSession_Succeeds()
+        {
+            await File.WriteAllTextAsync(Path.Combine(_cwd, "inside.txt"), "INSIDE");
+
+            var result = await _executor.ExecuteAsync(
+                BuiltinToolExecutor.ReadFile,
+                Args(new { path = "inside.txt" }),
+                _cwd,
+                CancellationToken.None);
+
+            result.IsError.Should().BeFalse();
+            result.Content.Should().Contain("INSIDE");
+        }
+
+        [TestMethod]
+        public async Task ExecuteAsync_WriteThenRead_WithinSession_RoundTrips()
+        {
+            var write = await _executor.ExecuteAsync(
+                BuiltinToolExecutor.WriteFile,
+                Args(new { path = "sub/created.txt", content = "ROUNDTRIP" }),
+                _cwd,
+                CancellationToken.None);
+            write.IsError.Should().BeFalse();
+
+            var read = await _executor.ExecuteAsync(
+                BuiltinToolExecutor.ReadFile,
+                Args(new { path = "sub/created.txt" }),
+                _cwd,
+                CancellationToken.None);
+
+            read.IsError.Should().BeFalse();
+            read.Content.Should().Contain("ROUNDTRIP");
+        }
+
+        [DataTestMethod]
+        [DataRow("../outside.txt")]
+        [DataRow("sub/../../outside.txt")]
+        public async Task ExecuteAsync_ReadFile_RejectsDotDotTraversal(string path)
+        {
+            var result = await _executor.ExecuteAsync(
+                BuiltinToolExecutor.ReadFile,
+                Args(new { path }),
+                _cwd,
+                CancellationToken.None);
+
+            result.IsError.Should().BeTrue();
+            result.Content.Should().Contain("traversal");
+        }
+
+        [TestMethod]
+        public async Task ExecuteAsync_WriteFile_RejectsDotDotTraversal()
+        {
+            var result = await _executor.ExecuteAsync(
+                BuiltinToolExecutor.WriteFile,
+                Args(new { path = "../escape.txt", content = "x" }),
+                _cwd,
+                CancellationToken.None);
+
+            result.IsError.Should().BeTrue();
+            result.Content.Should().Contain("traversal");
+        }
+
+        [DataTestMethod]
+        [DataRow("/etc/passwd")]
+        [DataRow("/tmp/abs.txt")]
+        public async Task ExecuteAsync_ReadFile_RejectsAbsolutePaths(string path)
+        {
+            var result = await _executor.ExecuteAsync(
+                BuiltinToolExecutor.ReadFile,
+                Args(new { path }),
+                _cwd,
+                CancellationToken.None);
+
+            result.IsError.Should().BeTrue();
+            result.Content.Should().Contain("Absolute paths");
+        }
+
+        [TestMethod]
+        public async Task ExecuteAsync_WriteFile_RejectsAbsolutePaths()
+        {
+            var result = await _executor.ExecuteAsync(
+                BuiltinToolExecutor.WriteFile,
+                Args(new { path = "/tmp/abs-write.txt", content = "x" }),
+                _cwd,
+                CancellationToken.None);
+
+            result.IsError.Should().BeTrue();
+            result.Content.Should().Contain("Absolute paths");
+        }
+
+        [TestMethod]
+        public async Task ExecuteAsync_ReadFile_RejectsSymlinkDirectoryToOutside()
+        {
+            var external = NewExternalDirectory();
+            await File.WriteAllTextAsync(Path.Combine(external, "secret.txt"), "EXTERNAL_SECRET");
+            RequireSymlink(() => Directory.CreateSymbolicLink(Path.Combine(_cwd, "data_link"), external));
+
+            var result = await _executor.ExecuteAsync(
+                BuiltinToolExecutor.ReadFile,
+                Args(new { path = "data_link/secret.txt" }),
+                _cwd,
+                CancellationToken.None);
+
+            result.IsError.Should().BeTrue();
+            result.Content.Should().Contain("escapes the session working directory");
+            result.Content.Should().NotContain("EXTERNAL_SECRET");
+        }
+
+        [TestMethod]
+        public async Task ExecuteAsync_ReadFile_RejectsSymlinkFileToOutside()
+        {
+            var external = NewExternalDirectory();
+            var externalFile = Path.Combine(external, "secret.txt");
+            await File.WriteAllTextAsync(externalFile, "EXTERNAL_SECRET");
+            RequireSymlink(() => File.CreateSymbolicLink(Path.Combine(_cwd, "leaf_link.txt"), externalFile));
+
+            var result = await _executor.ExecuteAsync(
+                BuiltinToolExecutor.ReadFile,
+                Args(new { path = "leaf_link.txt" }),
+                _cwd,
+                CancellationToken.None);
+
+            result.IsError.Should().BeTrue();
+            result.Content.Should().Contain("escapes the session working directory");
+            result.Content.Should().NotContain("EXTERNAL_SECRET");
+        }
+
+        [TestMethod]
+        public async Task ExecuteAsync_WriteFile_RejectsSymlinkDirectoryToOutside_AndDoesNotWrite()
+        {
+            var external = NewExternalDirectory();
+            RequireSymlink(() => Directory.CreateSymbolicLink(Path.Combine(_cwd, "rw_link"), external));
+
+            var result = await _executor.ExecuteAsync(
+                BuiltinToolExecutor.WriteFile,
+                Args(new { path = "rw_link/policy.json", content = "{\"state\":\"updated\"}" }),
+                _cwd,
+                CancellationToken.None);
+
+            result.IsError.Should().BeTrue();
+            result.Content.Should().Contain("escapes the session working directory");
+            File.Exists(Path.Combine(external, "policy.json")).Should().BeFalse("the write must not follow the symlink outside the session directory");
+        }
+
+        [TestMethod]
+        public async Task ExecuteAsync_WriteFile_RejectsExistingSymlinkFileToOutside_AndDoesNotOverwrite()
+        {
+            var external = NewExternalDirectory();
+            var externalFile = Path.Combine(external, "policy.json");
+            await File.WriteAllTextAsync(externalFile, "{\"state\":\"baseline\"}");
+            RequireSymlink(() => File.CreateSymbolicLink(Path.Combine(_cwd, "policy_link.json"), externalFile));
+
+            var result = await _executor.ExecuteAsync(
+                BuiltinToolExecutor.WriteFile,
+                Args(new { path = "policy_link.json", content = "{\"state\":\"updated\"}" }),
+                _cwd,
+                CancellationToken.None);
+
+            result.IsError.Should().BeTrue();
+            result.Content.Should().Contain("escapes the session working directory");
+            (await File.ReadAllTextAsync(externalFile)).Should().Be("{\"state\":\"baseline\"}");
+        }
+
+        [TestMethod]
+        public async Task ExecuteAsync_ReadFile_RejectsNestedSymlinkChainToOutside()
+        {
+            var external = NewExternalDirectory();
+            await File.WriteAllTextAsync(Path.Combine(external, "secret.txt"), "EXTERNAL_SECRET");
+            // a -> b -> external (chained links, both inside the session dir).
+            RequireSymlink(() => Directory.CreateSymbolicLink(Path.Combine(_cwd, "b"), external));
+            RequireSymlink(() => Directory.CreateSymbolicLink(Path.Combine(_cwd, "a"), Path.Combine(_cwd, "b")));
+
+            var result = await _executor.ExecuteAsync(
+                BuiltinToolExecutor.ReadFile,
+                Args(new { path = "a/secret.txt" }),
+                _cwd,
+                CancellationToken.None);
+
+            result.IsError.Should().BeTrue();
+            result.Content.Should().Contain("escapes the session working directory");
+            result.Content.Should().NotContain("EXTERNAL_SECRET");
+        }
+
+        [TestMethod]
+        public async Task ExecuteAsync_ReadFile_RejectsCrossSessionSymlink()
+        {
+            // A sibling "session" directory that shares the parent but is not a
+            // descendant of _cwd. Also guards against the prefix-boundary bug
+            // where "/root/sessA" would be considered inside "/root/sessA-x".
+            var otherSession = NewExternalDirectory();
+            await File.WriteAllTextAsync(Path.Combine(otherSession, "other.txt"), "OTHER_SESSION_DATA");
+            RequireSymlink(() => Directory.CreateSymbolicLink(Path.Combine(_cwd, "peer"), otherSession));
+
+            var result = await _executor.ExecuteAsync(
+                BuiltinToolExecutor.ReadFile,
+                Args(new { path = "peer/other.txt" }),
+                _cwd,
+                CancellationToken.None);
+
+            result.IsError.Should().BeTrue();
+            result.Content.Should().Contain("escapes the session working directory");
+            result.Content.Should().NotContain("OTHER_SESSION_DATA");
+        }
+
+        [TestMethod]
+        public async Task ExecuteAsync_ReadFile_AllowsSymlinkResolvingInsideSession()
+        {
+            // A symlink that stays inside the session directory is still usable.
+            Directory.CreateDirectory(Path.Combine(_cwd, "real"));
+            await File.WriteAllTextAsync(Path.Combine(_cwd, "real", "ok.txt"), "INSIDE_OK");
+            RequireSymlink(() => Directory.CreateSymbolicLink(Path.Combine(_cwd, "alias"), Path.Combine(_cwd, "real")));
+
+            var result = await _executor.ExecuteAsync(
+                BuiltinToolExecutor.ReadFile,
+                Args(new { path = "alias/ok.txt" }),
+                _cwd,
+                CancellationToken.None);
+
+            result.IsError.Should().BeFalse();
+            result.Content.Should().Contain("INSIDE_OK");
+        }
+
+        private static string Args(object value) =>
+            System.Text.Json.JsonSerializer.Serialize(value);
+
+        private string NewExternalDirectory()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "mcpgw-builtin-ext-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+            _externalPaths.Add(dir);
+            return dir;
+        }
+
+        /// <summary>
+        /// Runs a symlink-creating action, marking the test inconclusive when the
+        /// host cannot create symbolic links (e.g. Windows without Developer Mode
+        /// or the create-symlink privilege) instead of failing spuriously.
+        /// </summary>
+        private static void RequireSymlink(Action create)
+        {
+            try
+            {
+                create();
+            }
+            catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)
+            {
+                Assert.Inconclusive($"Symbolic link creation is not permitted on this host: {ex.Message}");
             }
         }
     }


### PR DESCRIPTION
## Summary
Built-in `read_file` / `write_file` now resolve symbolic links when validating paths, so reads and writes stay within the per-session working directory.

## Changes
- Canonicalize the session root and the requested path (resolving symlinks, including intermediate and chained links) before the containment check.
- Enforce containment on the canonical paths with a directory-separator boundary.
- Regression tests.

## Testing
- Unit tests included. Symlink cases run on Linux/CI; they skip on Windows hosts without symlink-creation privilege.
