### PR TITLE
Scope MCP adapter sessions to their adapter route

### DIFF
--- a/dotnet/Microsoft.McpGateway.Service/src/Controllers/AdapterReverseProxyController.cs
+++ b/dotnet/Microsoft.McpGateway.Service/src/Controllers/AdapterReverseProxyController.cs
@@ -38,12 +38,18 @@ namespace Microsoft.McpGateway.Service.Controllers
             if (!await EnsureAdapterReadAccessAsync(name, cancellationToken).ConfigureAwait(false))
                 return;
 
+            // The adapter identity authorized above is the only route this request is allowed to
+            // use. Bind both the session lookup and any newly created session to it so a session
+            // can never be resolved through a different adapter's route than the one it was
+            // created on (stale-session authorization bypass).
+            var adapterName = name ?? ToolGateway;
+
             var sessionId = AdapterSessionRoutingHandler.GetSessionId(HttpContext);
             string? targetAddress;
             if (string.IsNullOrEmpty(sessionId))
-                targetAddress = await sessionRoutingHandler.GetNewSessionTargetAsync(name ?? ToolGateway, HttpContext, cancellationToken).ConfigureAwait(false);
+                targetAddress = await sessionRoutingHandler.GetNewSessionTargetAsync(adapterName, HttpContext, cancellationToken).ConfigureAwait(false);
             else
-                targetAddress = await sessionRoutingHandler.GetExistingSessionTargetAsync(HttpContext, cancellationToken).ConfigureAwait(false);
+                targetAddress = await sessionRoutingHandler.GetExistingSessionTargetAsync(adapterName, HttpContext, cancellationToken).ConfigureAwait(false);
 
             if (targetAddress == null)
             {
@@ -67,7 +73,7 @@ namespace Microsoft.McpGateway.Service.Controllers
                     // or breaks routing semantics.
                     if (!AdapterSessionRoutingHandler.IsValidSessionId(sessionId))
                     {
-                        logger.LogWarning("Downstream adapter returned an invalid session id for adapter {adapterName}.", (name ?? ToolGateway).Sanitize());
+                        logger.LogWarning("Downstream adapter returned an invalid session id for adapter {adapterName}.", adapterName.Sanitize());
 
                         // Drop the invalid value from the proxied response so clients cannot
                         // cache or replay it — there is no scoped-key entry it could ever
@@ -76,9 +82,10 @@ namespace Microsoft.McpGateway.Service.Controllers
                     }
                     else
                     {
-                        // Bind the session to the authenticated user so subsequent lookups
-                        // require both the session id and the same user identity.
-                        var scopedKey = AdapterSessionRoutingHandler.BuildScopedSessionKey(HttpContext, sessionId);
+                        // Bind the session to the authenticated user and the adapter route it was
+                        // created on so subsequent lookups require the same user identity and the
+                        // same adapter the caller is authorized for.
+                        var scopedKey = AdapterSessionRoutingHandler.BuildScopedSessionKey(HttpContext, adapterName, sessionId);
                         await sessionStore.SetAsync(scopedKey, targetAddress, cancellationToken).ConfigureAwait(false);
                     }
                 }

--- a/dotnet/Microsoft.McpGateway.Service/src/Session/AdapterSessionRoutingHandler.cs
+++ b/dotnet/Microsoft.McpGateway.Service/src/Session/AdapterSessionRoutingHandler.cs
@@ -30,8 +30,10 @@ namespace Microsoft.McpGateway.Service.Session
             return targetAddress;
         }
 
-        public async Task<string?> GetExistingSessionTargetAsync(HttpContext httpContext, CancellationToken cancellationToken)
+        public async Task<string?> GetExistingSessionTargetAsync(string adapterName, HttpContext httpContext, CancellationToken cancellationToken)
         {
+            ArgumentException.ThrowIfNullOrEmpty(adapterName);
+
             var sessionId = GetSessionId(httpContext);
             if (string.IsNullOrEmpty(sessionId))
             {
@@ -47,9 +49,14 @@ namespace Microsoft.McpGateway.Service.Session
                 throw new ArgumentException("Session id is not valid, or has expired.");
             }
 
-            // Scope the lookup to the authenticated user so a client cannot route into another
-            // user's session by supplying that user's session id.
-            var scopedKey = BuildScopedSessionKey(httpContext, sessionId);
+            // Scope the lookup to both the authenticated user and the adapter named on the
+            // request route. Binding to the adapter prevents a session established against one
+            // adapter from being replayed through a different adapter's URL after the caller's
+            // access to the original adapter has been revoked (stale-session authorization
+            // bypass). The route adapter is the same value already authorized by the caller, so
+            // a session can only resolve when the route the caller is currently allowed to use
+            // matches the route the session was created on.
+            var scopedKey = BuildScopedSessionKey(httpContext, adapterName, sessionId);
 
             var (targetAddress, exists) = await _sessionStore.TryGetAsync(scopedKey, cancellationToken).ConfigureAwait(false);
             if (!exists || targetAddress == null)
@@ -89,18 +96,24 @@ namespace Microsoft.McpGateway.Service.Session
             !string.IsNullOrEmpty(sessionId) && SessionIdPattern.IsMatch(sessionId);
 
         /// <summary>
-        /// Computes the session store key used for a given (user, session id) pair. Binding the
-        /// session id to the authenticated user's id prevents cross-tenant session hijacking
-        /// even when an attacker can observe or guess another user's raw session id.
+        /// Computes the session store key used for a given (user, adapter, session id) tuple.
+        /// Binding the session id to the authenticated user's id prevents cross-tenant session
+        /// hijacking even when an attacker can observe or guess another user's raw session id.
+        /// Binding it to the adapter name additionally prevents a session created on one adapter
+        /// route from being replayed through another adapter route, which would otherwise allow a
+        /// caller whose access to the original adapter was revoked to keep reaching its backend.
+        /// Both <paramref name="adapterName"/> (<c>^[a-z0-9-]+$</c>) and <paramref name="sessionId"/>
+        /// (<c>^[a-zA-Z0-9-]{1,128}$</c>) are colon-free, so the composed key is unambiguous.
         /// </summary>
         /// <exception cref="UnauthorizedAccessException">
         /// Thrown when the request has no authenticated user id. Endpoints that use the session
         /// store are expected to be guarded by <c>[Authorize]</c>; missing identity here means
         /// the request must be rejected rather than silently routed.
         /// </exception>
-        public static string BuildScopedSessionKey(HttpContext httpContext, string sessionId)
+        public static string BuildScopedSessionKey(HttpContext httpContext, string adapterName, string sessionId)
         {
             ArgumentNullException.ThrowIfNull(httpContext);
+            ArgumentException.ThrowIfNullOrEmpty(adapterName);
             ArgumentException.ThrowIfNullOrEmpty(sessionId);
 
             var userId = httpContext.User?.GetUserId();
@@ -109,7 +122,7 @@ namespace Microsoft.McpGateway.Service.Session
                 throw new UnauthorizedAccessException("Authenticated user is required to access a session.");
             }
 
-            return $"{userId}:{sessionId}";
+            return $"{userId}:{adapterName}:{sessionId}";
         }
     }
 }

--- a/dotnet/Microsoft.McpGateway.Service/src/Session/ISessionRoutingHandler.cs
+++ b/dotnet/Microsoft.McpGateway.Service/src/Session/ISessionRoutingHandler.cs
@@ -11,10 +11,11 @@ namespace Microsoft.McpGateway.Service.Session
         /// <summary>
         /// Get the target address for an existing session asynchronously.
         /// </summary>
+        /// <param name="adapterName">The name of the adapter named on the request route. The session is resolved only when it was originally created against this same adapter.</param>
         /// <param name="httpContext">The incoming HTTP context</param>
         /// <param name="cancellationToken">Token to monitor for cancellation requests</param>
         /// <returns>A task that represents the asynchronous operation, containing the target address as a string, null if no target found.</returns>
-        Task<string?> GetExistingSessionTargetAsync(HttpContext httpContext, CancellationToken cancellationToken);
+        Task<string?> GetExistingSessionTargetAsync(string adapterName, HttpContext httpContext, CancellationToken cancellationToken);
 
         /// <summary>
         /// Get the target address for a new session asynchronously.

--- a/dotnet/Microsoft.McpGateway.Service/test/AdapterSessionRoutingHandlerTests.cs
+++ b/dotnet/Microsoft.McpGateway.Service/test/AdapterSessionRoutingHandlerTests.cs
@@ -15,6 +15,7 @@ namespace Microsoft.McpGateway.Service.Tests
     public class AdapterSessionRoutingHandlerTests
     {
         private const string TestUserId = "user-1";
+        private const string TestAdapterName = "adapter-a";
 
         private readonly Mock<IServiceNodeInfoProvider> _serviceNodeInfoProviderMock;
         private readonly Mock<IAdapterSessionStore> _sessionStoreMock;
@@ -64,7 +65,7 @@ namespace Microsoft.McpGateway.Service.Tests
         {
             var httpContext = CreateAuthenticatedContext();
             var sessionId = "abc123";
-            var scopedKey = $"{TestUserId}:{sessionId}";
+            var scopedKey = $"{TestUserId}:{TestAdapterName}:{sessionId}";
             var cancellationToken = CancellationToken.None;
             httpContext.Request.QueryString = new QueryString("?session_id=" + sessionId);
 
@@ -72,7 +73,7 @@ namespace Microsoft.McpGateway.Service.Tests
                 .Setup(x => x.TryGetAsync(scopedKey, cancellationToken))
                 .ReturnsAsync(("http://target", true));
 
-            var result = await _handler.GetExistingSessionTargetAsync(httpContext, cancellationToken);
+            var result = await _handler.GetExistingSessionTargetAsync(TestAdapterName, httpContext, cancellationToken);
 
             result.Should().Be("http://target");
         }
@@ -83,7 +84,7 @@ namespace Microsoft.McpGateway.Service.Tests
             var httpContext = CreateAuthenticatedContext();
             var cancellationToken = CancellationToken.None;
 
-            Func<Task> act = () => _handler.GetExistingSessionTargetAsync(httpContext, cancellationToken);
+            Func<Task> act = () => _handler.GetExistingSessionTargetAsync(TestAdapterName, httpContext, cancellationToken);
 
             await act.Should().ThrowAsync<ArgumentException>()
                 .WithMessage("Session id not found in the request.");
@@ -96,7 +97,7 @@ namespace Microsoft.McpGateway.Service.Tests
             // which represents an expired or never-issued session.
             var httpContext = CreateAuthenticatedContext();
             var sessionId = "unknown";
-            var scopedKey = $"{TestUserId}:{sessionId}";
+            var scopedKey = $"{TestUserId}:{TestAdapterName}:{sessionId}";
             var cancellationToken = CancellationToken.None;
             httpContext.Request.QueryString = new QueryString("?session_id=" + sessionId);
 
@@ -104,7 +105,7 @@ namespace Microsoft.McpGateway.Service.Tests
                 .Setup(x => x.TryGetAsync(scopedKey, cancellationToken))
                 .ReturnsAsync((null, false));
 
-            Func<Task> act = () => _handler.GetExistingSessionTargetAsync(httpContext, cancellationToken);
+            Func<Task> act = () => _handler.GetExistingSessionTargetAsync(TestAdapterName, httpContext, cancellationToken);
 
             await act.Should().ThrowAsync<ArgumentException>()
                 .WithMessage("Session id is not valid, or has expired.");
@@ -122,7 +123,7 @@ namespace Microsoft.McpGateway.Service.Tests
             var cancellationToken = CancellationToken.None;
             httpContext.Request.Headers["mcp-session-id"] = sessionId;
 
-            Func<Task> act = () => _handler.GetExistingSessionTargetAsync(httpContext, cancellationToken);
+            Func<Task> act = () => _handler.GetExistingSessionTargetAsync(TestAdapterName, httpContext, cancellationToken);
 
             await act.Should().ThrowAsync<ArgumentException>()
                 .WithMessage("Session id is not valid, or has expired.");
@@ -144,17 +145,77 @@ namespace Microsoft.McpGateway.Service.Tests
 
             // Simulate the victim's mapping still being present under the victim's scoped key.
             _sessionStoreMock
-                .Setup(x => x.TryGetAsync($"user-A:{victimSessionId}", cancellationToken))
+                .Setup(x => x.TryGetAsync($"user-A:{TestAdapterName}:{victimSessionId}", cancellationToken))
                 .ReturnsAsync(("http://victim-pod", true));
             _sessionStoreMock
-                .Setup(x => x.TryGetAsync($"user-B:{victimSessionId}", cancellationToken))
+                .Setup(x => x.TryGetAsync($"user-B:{TestAdapterName}:{victimSessionId}", cancellationToken))
                 .ReturnsAsync((null, false));
 
-            Func<Task> act = () => _handler.GetExistingSessionTargetAsync(httpContext, cancellationToken);
+            Func<Task> act = () => _handler.GetExistingSessionTargetAsync(TestAdapterName, httpContext, cancellationToken);
 
             await act.Should().ThrowAsync<ArgumentException>()
                 .WithMessage("Session id is not valid, or has expired.");
             _sessionStoreMock.Verify(x => x.TryGetAsync(victimSessionId, cancellationToken), Times.Never);
+        }
+
+        [TestMethod]
+        public async Task GetExistingSessionTargetAsync_WithDifferentAdapterRoute_DoesNotResolveSession()
+        {
+            // SEC-0003: a session established against adapter A must NOT resolve when the same
+            // user replays adapter A's session id through adapter B's route, even though the user
+            // is still authorized for adapter B. The lookup is scoped to the route adapter, so the
+            // entry created under adapter A is never consulted, and the bypass is closed.
+            var httpContext = CreateAuthenticatedContext();
+            var sessionId = "session-on-a";
+            var cancellationToken = CancellationToken.None;
+            httpContext.Request.Headers["mcp-session-id"] = sessionId;
+
+            // Adapter A's mapping exists, but the request is being routed through adapter B.
+            _sessionStoreMock
+                .Setup(x => x.TryGetAsync($"{TestUserId}:adapter-a:{sessionId}", cancellationToken))
+                .ReturnsAsync(("http://adapter-a-backend", true));
+            _sessionStoreMock
+                .Setup(x => x.TryGetAsync($"{TestUserId}:adapter-b:{sessionId}", cancellationToken))
+                .ReturnsAsync((null, false));
+
+            Func<Task> act = () => _handler.GetExistingSessionTargetAsync("adapter-b", httpContext, cancellationToken);
+
+            await act.Should().ThrowAsync<ArgumentException>()
+                .WithMessage("Session id is not valid, or has expired.");
+
+            // Adapter A's backend mapping must never be consulted for an adapter B request.
+            _sessionStoreMock.Verify(
+                x => x.TryGetAsync($"{TestUserId}:adapter-a:{sessionId}", cancellationToken),
+                Times.Never);
+        }
+
+        [TestMethod]
+        public async Task GetExistingSessionTargetAsync_WithMatchingAdapterRoute_ResolvesSession()
+        {
+            // The same session id resolves when replayed through the adapter it was created on.
+            var httpContext = CreateAuthenticatedContext();
+            var sessionId = "session-on-a";
+            var cancellationToken = CancellationToken.None;
+            httpContext.Request.Headers["mcp-session-id"] = sessionId;
+
+            _sessionStoreMock
+                .Setup(x => x.TryGetAsync($"{TestUserId}:adapter-a:{sessionId}", cancellationToken))
+                .ReturnsAsync(("http://adapter-a-backend", true));
+
+            var result = await _handler.GetExistingSessionTargetAsync("adapter-a", httpContext, cancellationToken);
+
+            result.Should().Be("http://adapter-a-backend");
+        }
+
+        [TestMethod]
+        public async Task GetExistingSessionTargetAsync_WithEmptyAdapterName_Throws()
+        {
+            var httpContext = CreateAuthenticatedContext();
+            httpContext.Request.Headers["mcp-session-id"] = "abc123";
+
+            Func<Task> act = () => _handler.GetExistingSessionTargetAsync(string.Empty, httpContext, CancellationToken.None);
+
+            await act.Should().ThrowAsync<ArgumentException>();
         }
 
         [TestMethod]
@@ -163,7 +224,7 @@ namespace Microsoft.McpGateway.Service.Tests
             var httpContext = new DefaultHttpContext();
             httpContext.Request.Headers["mcp-session-id"] = "abc123";
 
-            Func<Task> act = () => _handler.GetExistingSessionTargetAsync(httpContext, CancellationToken.None);
+            Func<Task> act = () => _handler.GetExistingSessionTargetAsync(TestAdapterName, httpContext, CancellationToken.None);
 
             await act.Should().ThrowAsync<UnauthorizedAccessException>();
         }
@@ -173,9 +234,34 @@ namespace Microsoft.McpGateway.Service.Tests
         {
             var httpContext = CreateAuthenticatedContext("alice");
 
-            var key = AdapterSessionRoutingHandler.BuildScopedSessionKey(httpContext, "sess-1");
+            var key = AdapterSessionRoutingHandler.BuildScopedSessionKey(httpContext, "adapter-a", "sess-1");
 
-            key.Should().Be("alice:sess-1");
+            key.Should().Be("alice:adapter-a:sess-1");
+        }
+
+        [TestMethod]
+        public void BuildScopedSessionKey_BindsToAdapterName()
+        {
+            // The same (user, session id) pair under two different adapters must produce two
+            // distinct keys so a session can never be resolved through a different adapter route.
+            var httpContext = CreateAuthenticatedContext("alice");
+
+            var keyA = AdapterSessionRoutingHandler.BuildScopedSessionKey(httpContext, "adapter-a", "sess-1");
+            var keyB = AdapterSessionRoutingHandler.BuildScopedSessionKey(httpContext, "adapter-b", "sess-1");
+
+            keyA.Should().NotBe(keyB);
+            keyA.Should().Be("alice:adapter-a:sess-1");
+            keyB.Should().Be("alice:adapter-b:sess-1");
+        }
+
+        [TestMethod]
+        public void BuildScopedSessionKey_WithoutAdapterName_Throws()
+        {
+            var httpContext = CreateAuthenticatedContext("alice");
+
+            Action act = () => AdapterSessionRoutingHandler.BuildScopedSessionKey(httpContext, string.Empty, "sess-1");
+
+            act.Should().Throw<ArgumentException>();
         }
 
         [TestMethod]
@@ -183,7 +269,7 @@ namespace Microsoft.McpGateway.Service.Tests
         {
             var httpContext = new DefaultHttpContext();
 
-            Action act = () => AdapterSessionRoutingHandler.BuildScopedSessionKey(httpContext, "sess-1");
+            Action act = () => AdapterSessionRoutingHandler.BuildScopedSessionKey(httpContext, "adapter-a", "sess-1");
 
             act.Should().Throw<UnauthorizedAccessException>();
         }


### PR DESCRIPTION
## What
Include the adapter name in the reverse-proxy session store key so an existing MCP session resolves only on the adapter route it was created on.

Previously the session key was `{userId}:{sessionId}`. The reverse proxy authorizes the adapter named in the request URL, but resolved an existing session purely from user + session id — so a session established on one adapter route could be resolved while serving a request on a different adapter route. This change scopes the lookup to the route adapter so the two always agree.

## Change
- Session key is now `{userId}:{adapterName}:{sessionId}`.
- `AdapterSessionRoutingHandler.GetExistingSessionTargetAsync` / `BuildScopedSessionKey` and `ISessionRoutingHandler` now take the route adapter name.
- `AdapterReverseProxyController` threads the route adapter (`name ?? "toolgateway"`) into both the session lookup and the stored key.
- Adapter names (`^[a-z0-9-]+$`) and session ids (`^[a-zA-Z0-9-]{1,128}$`) are colon-free, so the 3-part key is unambiguous.
