### PR TITLE
Restrict agent built-in tools to authorized roles

### DIFF
--- a/docs/entra-app-roles.md
+++ b/docs/entra-app-roles.md
@@ -36,3 +36,27 @@ Follow these steps to enable application roles, assign them to identities, and p
   - **Write** access if the caller is the creator or holds `mcp.admin`.
 
   > If no `requiredRoles` is configured, it by default ALLOW ALL READ access.
+
+## 4. Authorize Built-in Agent Tools (`bash`, `read_file`, `write_file`)
+
+The in-process built-in tools run shell commands and read/write files inside the gateway pod, so they are treated as a **privileged capability** rather than an ordinary resource. Unlike adapters/tools, they have no per-resource `requiredRoles`; access is gated on the **caller's role** — at agent create/update time *and* again at run time (tool resolution and invocation) — with **no creator bypass**. Even the author of an agent must hold the required role to reference or invoke a built-in.
+
+- **Default (fail-closed):** only callers holding `mcp.admin` may reference or invoke built-in tools.
+- To grant built-in access without full admin, create a dedicated app role (e.g. `mcp.builtin`), assign it (Section 2), then configure it on the gateway:
+
+  ```jsonc
+  // appsettings.json
+  {
+    "BuiltinToolSettings": {
+      "RequiredRoles": [ "mcp.builtin" ]
+    }
+  }
+  ```
+
+  The same setting via environment variables (e.g. in the pod spec) uses the array index form:
+
+  ```
+  BuiltinToolSettings__RequiredRoles__0=mcp.builtin
+  ```
+
+  `mcp.admin` is always permitted in addition to any configured roles. Leaving `RequiredRoles` empty keeps built-ins admin-only.

--- a/dotnet/Microsoft.McpGateway.Management/src/Authorization/BuiltinToolAuthorizer.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Authorization/BuiltinToolAuthorizer.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Security.Claims;
+using Microsoft.Extensions.Options;
+using Microsoft.McpGateway.Management.Extensions;
+
+namespace Microsoft.McpGateway.Management.Authorization
+{
+    /// <summary>
+    /// Default <see cref="IBuiltinToolAuthorizer"/>: a caller may use built-in
+    /// tools when they hold <c>mcp.admin</c> or any role configured in
+    /// <see cref="BuiltinToolSettings.RequiredRoles"/>. Fail-closed — with no
+    /// configuration only administrators are permitted.
+    /// </summary>
+    public sealed class BuiltinToolAuthorizer : IBuiltinToolAuthorizer
+    {
+        private const string AdminRole = "mcp.admin";
+
+        private readonly HashSet<string> _allowedRoles;
+
+        public BuiltinToolAuthorizer(IOptions<BuiltinToolSettings> options)
+        {
+            ArgumentNullException.ThrowIfNull(options);
+
+            _allowedRoles = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { AdminRole };
+            foreach (var role in options.Value?.RequiredRoles ?? Enumerable.Empty<string>())
+            {
+                if (!string.IsNullOrWhiteSpace(role))
+                {
+                    _allowedRoles.Add(role.Trim());
+                }
+            }
+        }
+
+        public bool IsAuthorized(ClaimsPrincipal principal)
+        {
+            ArgumentNullException.ThrowIfNull(principal);
+            return principal.GetUserRoles().Any(role => _allowedRoles.Contains(role));
+        }
+    }
+}

--- a/dotnet/Microsoft.McpGateway.Management/src/Authorization/BuiltinToolSettings.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Authorization/BuiltinToolSettings.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.McpGateway.Management.Authorization
+{
+    /// <summary>
+    /// Authorization configuration for the in-process built-in agent tools
+    /// (<c>bash</c>, <c>read_file</c>, <c>write_file</c>). Bound from the
+    /// "BuiltinToolSettings" section.
+    /// </summary>
+    public class BuiltinToolSettings
+    {
+        /// <summary>
+        /// Roles permitted to reference and invoke built-in tools, in addition
+        /// to <c>mcp.admin</c> (which is always allowed). When empty (the
+        /// default), built-in tools are restricted to administrators only.
+        /// </summary>
+        public IList<string> RequiredRoles { get; set; } = [];
+    }
+}

--- a/dotnet/Microsoft.McpGateway.Management/src/Authorization/IBuiltinToolAuthorizer.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Authorization/IBuiltinToolAuthorizer.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Security.Claims;
+
+namespace Microsoft.McpGateway.Management.Authorization
+{
+    /// <summary>
+    /// Authorizes use of the privileged in-process built-in tools
+    /// (<c>bash</c>, <c>read_file</c>, <c>write_file</c>). Unlike
+    /// <see cref="IPermissionProvider"/>, built-ins are not store-backed
+    /// resources, so authorization is a capability check against the caller's
+    /// roles rather than a per-resource ACL — notably there is no creator
+    /// bypass, so even the author of an agent must hold the required role.
+    /// </summary>
+    public interface IBuiltinToolAuthorizer
+    {
+        /// <summary>
+        /// Returns <see langword="true"/> when <paramref name="principal"/> is
+        /// permitted to reference and invoke built-in tools.
+        /// </summary>
+        bool IsAuthorized(ClaimsPrincipal principal);
+    }
+}

--- a/dotnet/Microsoft.McpGateway.Management/src/Foundry/AgentToolRegistry.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Foundry/AgentToolRegistry.cs
@@ -37,6 +37,7 @@ namespace Microsoft.McpGateway.Management.Foundry
         private readonly IAgentResourceStore _agentStore;
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly IPermissionProvider _permissionProvider;
+        private readonly IBuiltinToolAuthorizer _builtinToolAuthorizer;
         private readonly SubAgentInvoker? _subAgentInvoker;
         private readonly BuiltinToolExecutor? _builtinExecutor;
         private readonly ILogger<AgentToolRegistry> _logger;
@@ -46,6 +47,7 @@ namespace Microsoft.McpGateway.Management.Foundry
             IAgentResourceStore agentStore,
             IHttpClientFactory httpClientFactory,
             IPermissionProvider permissionProvider,
+            IBuiltinToolAuthorizer builtinToolAuthorizer,
             ILogger<AgentToolRegistry> logger,
             SubAgentInvoker? subAgentInvoker = null,
             BuiltinToolExecutor? builtinExecutor = null)
@@ -54,6 +56,7 @@ namespace Microsoft.McpGateway.Management.Foundry
             _agentStore = agentStore ?? throw new ArgumentNullException(nameof(agentStore));
             _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
             _permissionProvider = permissionProvider ?? throw new ArgumentNullException(nameof(permissionProvider));
+            _builtinToolAuthorizer = builtinToolAuthorizer ?? throw new ArgumentNullException(nameof(builtinToolAuthorizer));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _subAgentInvoker = subAgentInvoker;
             _builtinExecutor = builtinExecutor;
@@ -132,6 +135,14 @@ namespace Microsoft.McpGateway.Management.Foundry
                         _logger.LogWarning("Unknown builtin tool '{tool}'; supported: {kinds}.", raw, string.Join(",", BuiltinToolExecutor.SupportedKinds));
                         continue;
                     }
+                    // Built-ins are privileged in-process capabilities with no backing
+                    // resource ACL; gate them on the effective caller's role so they are
+                    // never advertised to the model for an unauthorized run.
+                    if (!_builtinToolAuthorizer.IsAuthorized(accessContext))
+                    {
+                        _logger.LogWarning("Caller lacks permission to use built-in tool '{tool}'; excluding from resolved tools.", raw);
+                        continue;
+                    }
                     resolved.Add(new BuiltinResolvedTool(fn));
                     continue;
                 }
@@ -165,16 +176,25 @@ namespace Microsoft.McpGateway.Management.Foundry
             {
                 McpResolvedTool mcp => await ExecuteMcpAsync(mcp, argumentsJson, accessContext, cancellationToken).ConfigureAwait(false),
                 SubAgentResolvedTool sub => await ExecuteSubAgentAsync(sub, argumentsJson, parentSessionId, accessContext, cancellationToken).ConfigureAwait(false),
-                BuiltinResolvedTool builtin => await ExecuteBuiltinAsync(builtin, argumentsJson, workingDirectory, cancellationToken).ConfigureAwait(false),
+                BuiltinResolvedTool builtin => await ExecuteBuiltinAsync(builtin, argumentsJson, workingDirectory, accessContext, cancellationToken).ConfigureAwait(false),
                 _ => new ToolResult(JsonSerializer.Serialize(new { error = $"Unsupported tool kind '{tool.GetType().Name}'." }), IsError: true),
             };
         }
 
-        private Task<ToolResult> ExecuteBuiltinAsync(BuiltinResolvedTool tool, string argumentsJson, string? workingDirectory, CancellationToken cancellationToken)
+        private Task<ToolResult> ExecuteBuiltinAsync(BuiltinResolvedTool tool, string argumentsJson, string? workingDirectory, ClaimsPrincipal accessContext, CancellationToken cancellationToken)
         {
             if (_builtinExecutor == null)
             {
                 return Task.FromResult(new ToolResult("{\"error\":\"BuiltinToolExecutor is not registered.\"}", IsError: true));
+            }
+            // Re-authorize at invocation time (defense in depth, mirrors the MCP /
+            // subagent re-authorization) so a caller who lost the required role
+            // after the run began — or who is running another user's agent — cannot
+            // execute privileged built-ins even if one slipped past resolution.
+            if (!_builtinToolAuthorizer.IsAuthorized(accessContext))
+            {
+                _logger.LogWarning("Caller lacks permission to execute built-in tool {tool} at invocation time; denying.", tool.Name);
+                return Task.FromResult(new ToolResult(JsonSerializer.Serialize(new { error = "You do not have permission to invoke this built-in tool." }), IsError: true));
             }
             if (string.IsNullOrWhiteSpace(workingDirectory))
             {

--- a/dotnet/Microsoft.McpGateway.Management/src/Service/AgentManagementService.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Service/AgentManagementService.cs
@@ -179,12 +179,11 @@ namespace Microsoft.McpGateway.Management.Service
         /// </summary>
         private async Task ValidateToolReferencesAsync(ClaimsPrincipal accessContext, AgentData request, CancellationToken cancellationToken)
         {
-            if (request.Tools == null || request.Tools.Count == 0)
-            {
-                return;
-            }
-
-            foreach (var entry in request.Tools)
+            // Iterate defensively over a possibly null/empty list rather than using an
+            // early return. With no entries this simply does no work; it also keeps the
+            // per-entry authorization checks below from being guarded by a user-controlled
+            // condition (avoids CodeQL cs/user-controlled-bypass-of-sensitive-method).
+            foreach (var entry in request.Tools ?? Enumerable.Empty<string>())
             {
                 if (string.IsNullOrWhiteSpace(entry))
                 {

--- a/dotnet/Microsoft.McpGateway.Management/src/Service/AgentManagementService.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Service/AgentManagementService.cs
@@ -31,17 +31,20 @@ namespace Microsoft.McpGateway.Management.Service
         private readonly IAgentResourceStore _store;
         private readonly IToolResourceStore _toolStore;
         private readonly IPermissionProvider _permissionProvider;
+        private readonly IBuiltinToolAuthorizer _builtinToolAuthorizer;
         private readonly ILogger _logger;
 
         public AgentManagementService(
             IAgentResourceStore store,
             IToolResourceStore toolStore,
             IPermissionProvider permissionProvider,
+            IBuiltinToolAuthorizer builtinToolAuthorizer,
             ILogger<AgentManagementService> logger)
         {
             _store = store ?? throw new ArgumentNullException(nameof(store));
             _toolStore = toolStore ?? throw new ArgumentNullException(nameof(toolStore));
             _permissionProvider = permissionProvider ?? throw new ArgumentNullException(nameof(permissionProvider));
+            _builtinToolAuthorizer = builtinToolAuthorizer ?? throw new ArgumentNullException(nameof(builtinToolAuthorizer));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
@@ -227,6 +230,15 @@ namespace Microsoft.McpGateway.Management.Service
                         if (!KnownBuiltins.Contains(entry))
                         {
                             throw new ArgumentException($"Unknown built-in tool '{entry}'. Supported: {string.Join(", ", KnownBuiltins)}.");
+                        }
+                        // Built-ins are privileged in-process capabilities (shell / file
+                        // access) with no backing resource ACL, so gate them on the caller's
+                        // role — never on agent ownership. This blocks persisting an agent
+                        // that references built-ins the caller may not use.
+                        if (!_builtinToolAuthorizer.IsAuthorized(accessContext))
+                        {
+                            _logger.LogWarning("User {userId} denied reference to built-in tool {tool} while saving agent {agent}.", accessContext.GetUserId(), entry.Sanitize(), request.Name.Sanitize());
+                            throw new UnauthorizedAccessException($"You do not have permission to reference built-in tool '{entry}'.");
                         }
                         break;
 

--- a/dotnet/Microsoft.McpGateway.Management/test/AgentManagementServiceTests.cs
+++ b/dotnet/Microsoft.McpGateway.Management/test/AgentManagementServiceTests.cs
@@ -23,6 +23,7 @@ namespace Microsoft.McpGateway.Management.Tests
         private readonly Mock<IAgentResourceStore> _agentStoreMock;
         private readonly Mock<IToolResourceStore> _toolStoreMock;
         private readonly Mock<IPermissionProvider> _permissionProviderMock;
+        private readonly Mock<IBuiltinToolAuthorizer> _builtinToolAuthorizerMock;
         private readonly Mock<ILogger<AgentManagementService>> _loggerMock;
         private readonly AgentManagementService _service;
         private readonly ClaimsPrincipal _accessContext;
@@ -32,6 +33,7 @@ namespace Microsoft.McpGateway.Management.Tests
             _agentStoreMock = new Mock<IAgentResourceStore>();
             _toolStoreMock = new Mock<IToolResourceStore>();
             _permissionProviderMock = new Mock<IPermissionProvider>();
+            _builtinToolAuthorizerMock = new Mock<IBuiltinToolAuthorizer>();
             _loggerMock = new Mock<ILogger<AgentManagementService>>();
 
             _permissionProviderMock
@@ -40,11 +42,17 @@ namespace Microsoft.McpGateway.Management.Tests
             _permissionProviderMock
                 .Setup(x => x.CheckAccessAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<IEnumerable<AgentResource>>(), Operation.Read))
                 .ReturnsAsync((ClaimsPrincipal _, IEnumerable<AgentResource> r, Operation _) => r.ToArray());
+            // Default to authorized so non-built-in tests are unaffected; the
+            // built-in gate tests below override this to false.
+            _builtinToolAuthorizerMock
+                .Setup(x => x.IsAuthorized(It.IsAny<ClaimsPrincipal>()))
+                .Returns(true);
 
             _service = new AgentManagementService(
                 _agentStoreMock.Object,
                 _toolStoreMock.Object,
                 _permissionProviderMock.Object,
+                _builtinToolAuthorizerMock.Object,
                 _loggerMock.Object);
 
             _accessContext = new ClaimsPrincipal(new ClaimsIdentity([new(ClaimTypes.NameIdentifier, "user1")]));
@@ -140,6 +148,47 @@ namespace Microsoft.McpGateway.Management.Tests
             Func<Task> act = () => _service.CreateAsync(_accessContext, request, CancellationToken.None);
 
             await act.Should().ThrowAsync<ArgumentException>().WithMessage("*builtin:nope*");
+        }
+
+        [TestMethod]
+        public async Task CreateAsync_ShouldThrow_WhenCallerNotAuthorizedForBuiltin()
+        {
+            var request = CreateAgentData("agent-builtin-denied", new List<string> { "builtin:bash" });
+            _agentStoreMock.Setup(x => x.TryGetAsync("agent-builtin-denied", It.IsAny<CancellationToken>())).ReturnsAsync((AgentResource?)null);
+            _builtinToolAuthorizerMock.Setup(x => x.IsAuthorized(It.IsAny<ClaimsPrincipal>())).Returns(false);
+
+            Func<Task> act = () => _service.CreateAsync(_accessContext, request, CancellationToken.None);
+
+            await act.Should().ThrowAsync<UnauthorizedAccessException>().WithMessage("*built-in tool 'builtin:bash'*");
+            _agentStoreMock.Verify(x => x.UpsertAsync(It.IsAny<AgentResource>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [TestMethod]
+        public async Task CreateAsync_ShouldRejectUnknownBuiltin_EvenWhenUnauthorized()
+        {
+            // Unknown built-ins are an ArgumentException (membership) regardless of
+            // the caller's authorization decision.
+            var request = CreateAgentData("agent-unknown-builtin", new List<string> { "builtin:nope" });
+            _agentStoreMock.Setup(x => x.TryGetAsync("agent-unknown-builtin", It.IsAny<CancellationToken>())).ReturnsAsync((AgentResource?)null);
+            _builtinToolAuthorizerMock.Setup(x => x.IsAuthorized(It.IsAny<ClaimsPrincipal>())).Returns(false);
+
+            Func<Task> act = () => _service.CreateAsync(_accessContext, request, CancellationToken.None);
+
+            await act.Should().ThrowAsync<ArgumentException>().WithMessage("*builtin:nope*");
+        }
+
+        [TestMethod]
+        public async Task UpdateAsync_ShouldThrow_WhenCallerNotAuthorizedForBuiltin()
+        {
+            var request = CreateAgentData("agent-builtin-upd", new List<string> { "builtin:bash" });
+            var existing = AgentResource.Create(CreateAgentData("agent-builtin-upd"), "user1", DateTimeOffset.UtcNow);
+            _agentStoreMock.Setup(x => x.TryGetAsync("agent-builtin-upd", It.IsAny<CancellationToken>())).ReturnsAsync(existing);
+            _builtinToolAuthorizerMock.Setup(x => x.IsAuthorized(It.IsAny<ClaimsPrincipal>())).Returns(false);
+
+            Func<Task> act = () => _service.UpdateAsync(_accessContext, request, CancellationToken.None);
+
+            await act.Should().ThrowAsync<UnauthorizedAccessException>().WithMessage("*built-in tool 'builtin:bash'*");
+            _agentStoreMock.Verify(x => x.UpsertAsync(It.IsAny<AgentResource>(), It.IsAny<CancellationToken>()), Times.Never);
         }
 
         [TestMethod]

--- a/dotnet/Microsoft.McpGateway.Management/test/AgentToolRegistryTests.cs
+++ b/dotnet/Microsoft.McpGateway.Management/test/AgentToolRegistryTests.cs
@@ -35,6 +35,7 @@ namespace Microsoft.McpGateway.Management.Tests
         private readonly Mock<ISessionResourceStore> _sessionStore = new();
         private readonly Mock<IHttpClientFactory> _httpFactory = new();
         private readonly Mock<IPermissionProvider> _permission = new();
+        private readonly Mock<IBuiltinToolAuthorizer> _builtinAuthorizer = new();
         private readonly Mock<ILogger<AgentToolRegistry>> _logger = new();
         private readonly SubAgentInvoker _subAgentInvoker;
         private readonly AgentToolRegistry _registry;
@@ -55,9 +56,28 @@ namespace Microsoft.McpGateway.Management.Tests
                 _agentStore.Object,
                 _httpFactory.Object,
                 _permission.Object,
+                _builtinAuthorizer.Object,
                 _logger.Object,
                 _subAgentInvoker,
                 builtinExecutor: null);
+        }
+
+        // Build a registry wired with a real BuiltinToolExecutor and a builtin
+        // authorizer that returns the given decision, for exercising the
+        // built-in capability gates.
+        private AgentToolRegistry CreateBuiltinRegistry(bool authorized)
+        {
+            var authorizer = new Mock<IBuiltinToolAuthorizer>();
+            authorizer.Setup(a => a.IsAuthorized(It.IsAny<ClaimsPrincipal>())).Returns(authorized);
+            return new AgentToolRegistry(
+                _toolStore.Object,
+                _agentStore.Object,
+                _httpFactory.Object,
+                _permission.Object,
+                authorizer.Object,
+                _logger.Object,
+                _subAgentInvoker,
+                new BuiltinToolExecutor(Mock.Of<ILogger<BuiltinToolExecutor>>()));
         }
 
         private static ClaimsPrincipal Caller(string userId, params string[] roles)
@@ -234,6 +254,49 @@ namespace Microsoft.McpGateway.Management.Tests
             // The child run must never start: no session persisted, no runner created.
             _runnerFactoryCalls.Should().Be(0);
             _sessionStore.Verify(s => s.UpsertAsync(It.IsAny<SessionResource>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        // ---- Built-in tools: privileged capability gate ----
+
+        [TestMethod]
+        public async Task ResolveAsync_ShouldExcludeBuiltin_WhenCallerNotAuthorized()
+        {
+            var registry = CreateBuiltinRegistry(authorized: false);
+
+            var resolved = await registry.ResolveAsync(["builtin:bash"], Caller("ordinary-poc", "ordinary-user"), CancellationToken.None);
+
+            resolved.Should().BeEmpty();
+        }
+
+        [TestMethod]
+        public async Task ResolveAsync_ShouldIncludeBuiltin_WhenCallerAuthorized()
+        {
+            var registry = CreateBuiltinRegistry(authorized: true);
+
+            var resolved = await registry.ResolveAsync(["builtin:bash"], Caller("admin-poc", "mcp.admin"), CancellationToken.None);
+
+            resolved.Should().ContainSingle()
+                .Which.Should().BeOfType<BuiltinResolvedTool>()
+                .Which.Name.Should().Be(BuiltinToolExecutor.Bash);
+        }
+
+        [TestMethod]
+        public async Task ExecuteAsync_ShouldDenyBuiltin_WhenCallerNotAuthorized()
+        {
+            // A real BuiltinToolExecutor is wired up, so reaching it would spawn
+            // bash; the authorization gate must short-circuit before that.
+            var registry = CreateBuiltinRegistry(authorized: false);
+
+            var result = await registry.ExecuteAsync(
+                new BuiltinResolvedTool(BuiltinToolExecutor.Bash),
+                "{\"command\":\"echo hi\"}",
+                parentSessionId: "parent-session",
+                workingDirectory: "/tmp/session",
+                Caller("ordinary-poc", "ordinary-user"),
+                CancellationToken.None);
+
+            result.IsError.Should().BeTrue();
+            result.Content.Should().Contain("permission");
         }
     }
 }

--- a/dotnet/Microsoft.McpGateway.Management/test/BuiltinToolAuthorizerTests.cs
+++ b/dotnet/Microsoft.McpGateway.Management/test/BuiltinToolAuthorizerTests.cs
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using Microsoft.McpGateway.Management.Authorization;
+
+namespace Microsoft.McpGateway.Management.Tests
+{
+    /// <summary>
+    /// Tests for the built-in tool capability gate: only callers holding
+    /// <c>mcp.admin</c> or a configured role may use the privileged in-process
+    /// built-ins, and there is no creator bypass.
+    /// </summary>
+    [TestClass]
+    public class BuiltinToolAuthorizerTests
+    {
+        private static ClaimsPrincipal Caller(params string[] roles)
+        {
+            var claims = new List<Claim> { new(ClaimTypes.NameIdentifier, "user1") };
+            claims.AddRange(roles.Select(r => new Claim(ClaimTypes.Role, r)));
+            return new ClaimsPrincipal(new ClaimsIdentity(claims, "test"));
+        }
+
+        private static BuiltinToolAuthorizer Create(params string[] requiredRoles) =>
+            new(Options.Create(new BuiltinToolSettings { RequiredRoles = requiredRoles.ToList() }));
+
+        [TestMethod]
+        public void IsAuthorized_AllowsAdmin_WhenNoRolesConfigured()
+        {
+            Create().IsAuthorized(Caller("mcp.admin")).Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void IsAuthorized_AdminCheckIsCaseInsensitive()
+        {
+            Create().IsAuthorized(Caller("MCP.Admin")).Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void IsAuthorized_DeniesNonAdmin_WhenNoRolesConfigured()
+        {
+            Create().IsAuthorized(Caller("mcp.engineer")).Should().BeFalse();
+        }
+
+        [TestMethod]
+        public void IsAuthorized_DeniesCaller_WithNoRoles()
+        {
+            Create().IsAuthorized(Caller()).Should().BeFalse();
+        }
+
+        [TestMethod]
+        public void IsAuthorized_AllowsConfiguredRole()
+        {
+            Create("mcp.builtin").IsAuthorized(Caller("mcp.builtin")).Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void IsAuthorized_AllowsConfiguredRole_CaseInsensitive()
+        {
+            Create("mcp.builtin").IsAuthorized(Caller("MCP.Builtin")).Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void IsAuthorized_StillAllowsAdmin_WhenOtherRolesConfigured()
+        {
+            Create("mcp.builtin").IsAuthorized(Caller("mcp.admin")).Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void IsAuthorized_DeniesUnlistedRole()
+        {
+            Create("mcp.builtin").IsAuthorized(Caller("mcp.engineer")).Should().BeFalse();
+        }
+
+        [TestMethod]
+        public void IsAuthorized_Throws_OnNullPrincipal()
+        {
+            var act = () => Create().IsAuthorized(null!);
+            act.Should().Throw<ArgumentNullException>();
+        }
+    }
+}

--- a/dotnet/Microsoft.McpGateway.Service/src/Controllers/AgentManagementController.cs
+++ b/dotnet/Microsoft.McpGateway.Service/src/Controllers/AgentManagementController.cs
@@ -32,6 +32,10 @@ namespace Microsoft.McpGateway.Service.Controllers
             {
                 return BadRequest(ex.Message);
             }
+            catch (UnauthorizedAccessException)
+            {
+                return Forbid();
+            }
         }
 
         // GET /agents/{name}

--- a/dotnet/Microsoft.McpGateway.Service/src/Program.cs
+++ b/dotnet/Microsoft.McpGateway.Service/src/Program.cs
@@ -169,6 +169,14 @@ builder.Services.AddSingleton<IKubeClientWrapper>(c =>
     return new KubeClient(kubeClientFactory, "adapter");
 });
 builder.Services.AddSingleton<IPermissionProvider, SimplePermissionProvider>();
+
+// Authorization for the privileged in-process built-in tools (bash / read_file /
+// write_file). Registered unconditionally because AgentManagementService validates
+// built-in references even when the Foundry runtime below is not configured.
+// Fail-closed: with no BuiltinToolSettings:RequiredRoles configured, only callers
+// holding mcp.admin may reference or invoke built-ins.
+builder.Services.Configure<BuiltinToolSettings>(builder.Configuration.GetSection("BuiltinToolSettings"));
+builder.Services.AddSingleton<IBuiltinToolAuthorizer, BuiltinToolAuthorizer>();
 builder.Services.AddSingleton<IAdapterDeploymentManager>(c =>
 {
     var config = builder.Configuration.GetSection("ContainerRegistrySettings");


### PR DESCRIPTION
The in-process built-in agent tools (bash, read_file, write_file) run shell commands and file I/O inside the gateway pod, so they are privileged. They were previously authorized only by a membership check on the known built-in names; this adds explicit role-based authorization so their use can be restricted.

- New IBuiltinToolAuthorizer / BuiltinToolAuthorizer backed by BuiltinToolSettings:RequiredRoles. A caller is authorized when they hold mcp.admin or a configured role; with no configuration, built-ins are admin-only (fail-closed). There is no creator bypass.
- Enforced at agent create/update validation, at run-time tool resolution, and again at invocation (defense in depth), using the effective caller so shared agents and subagents are covered.
- Register the authorizer and bind BuiltinToolSettings in DI.
- POST /agents returns 403 (previously surfaced as 500) when a referenced resource is not permitted.
- Document BuiltinToolSettings:RequiredRoles and add unit tests.

Operators can grant non-admin access via BuiltinToolSettings:RequiredRoles.