### PR TITLE
feat: secure headers for remote MCP proxy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,3 +32,24 @@ jobs:
 
     - name: Test
       run: dotnet test dotnet/Microsoft.McpGateway.sln --configuration Release --verbosity normal
+
+  test-mcp-proxy:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+    - name: Checkout source
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+    - name: Setup Python
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+      with:
+        python-version: '3.12'
+
+    - name: Install dependencies
+      run: python -m pip install --disable-pip-version-check -r sample-servers/mcp-proxy/requirements-dev.txt
+
+    - name: Test MCP proxy
+      run: python -m pytest sample-servers/mcp-proxy/tests

--- a/sample-servers/mcp-proxy/README.md
+++ b/sample-servers/mcp-proxy/README.md
@@ -40,6 +40,11 @@ Set `useWorkloadIdentity` to be true if need the server to use the workload iden
 ### Proxying Remote Servers
 For proxying another internal mcp server hosted in streamable HTTP. Set the target endpoint in environment variable
   - `MCP_PROXY_URL`
+  - `MCP_PROXY_HEADERS_SECRET_URL` as an optional Azure Key Vault secret URL
+
+The referenced secret must contain a JSON object of upstream HTTP headers. Store
+credentials only in Key Vault. The gateway stores and returns the secret URL,
+but never receives the secret value. Raw `MCP_PROXY_HEADERS` values are rejected.
 
 
 ## Examples
@@ -112,8 +117,38 @@ Others use service-specific variables (e.g., `ADO_MCP_AZURE_TOKEN_CREDENTIALS`)
 }
 ```
 
+#### Example 5: Proxied Authenticated MCP Server
+
+Prefer the upstream provider's OAuth flow when available. For a server that
+requires a static bearer token, store this JSON in Key Vault:
+
+```json
+{"Authorization":"Bearer <token>"}
+```
+
+Grant the adapter workload identity permission to read that secret. Then submit
+only its URL through the management API:
+
+```json
+{
+    "name": "authenticated-remote",
+    "imageName": "mcp-proxy",
+    "imageVersion": "1.0.0",
+    "environmentVariables": {
+      "MCP_PROXY_URL": "https://mcp.example.com/mcp",
+      "MCP_PROXY_HEADERS_SECRET_URL": "https://<vault>.vault.azure.net/secrets/<secret-name>"
+    },
+    "useWorkloadIdentity": true,
+    "description": "Proxied authenticated MCP server"
+}
+```
+
 ## Security Considerations
 
 Before running in production
 - Implement appropriate access controls on the gateway level to prevent users from exploiting the workload identity access through it.
 - Always only register trusted MCP servers, enable network access policies on the server pods.
+- Do not put credentials in adapter `environmentVariables`; management GET and LIST responses include those values.
+- Store proxy headers in Key Vault and pass only `MCP_PROXY_HEADERS_SECRET_URL`.
+- Use an `https://` upstream whenever proxy headers are configured.
+- The proxy rejects redirects, malformed headers, control characters, and non-ASCII header values before connecting upstream.

--- a/sample-servers/mcp-proxy/requirements-dev.txt
+++ b/sample-servers/mcp-proxy/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest==9.1.1

--- a/sample-servers/mcp-proxy/requirements.txt
+++ b/sample-servers/mcp-proxy/requirements.txt
@@ -1,2 +1,3 @@
+azure-identity==1.25.3
+azure-keyvault-secrets==4.11.1
 fastmcp==3.2.0
-validators==0.35.0

--- a/sample-servers/mcp-proxy/src/main.py
+++ b/sample-servers/mcp-proxy/src/main.py
@@ -1,13 +1,19 @@
-from fastmcp import FastMCP
-import os, sys, shlex
-import validators
+import os
+import shlex
+import sys
+from typing import NoReturn
+
+from fastmcp.server import create_proxy
+from proxy_config import ProxyConfigurationError, remote_transport_from_environment
 
 MAX_ARGS = 64
 MAX_ARG_LEN = 512
 
-def bad(msg: str):
+
+def bad(msg: str) -> NoReturn:
     print(f"[shim] {msg}", file=sys.stderr)
     sys.exit(1)
+
 
 def safe(arg: str) -> bool:
     return (
@@ -18,18 +24,14 @@ def safe(arg: str) -> bool:
         and "\r" not in arg
     )
 
+
 proxy_url = os.environ.get("MCP_PROXY_URL")
 if proxy_url:
-    if not validators.url(proxy_url):
-        bad("Invalid MCP_PROXY_URL: must be http(s) and a well-formed URL")
-    config = {
-        "mcpServers": {
-            "default": {
-                "url": proxy_url,
-                "transport": "http"
-            }
-        }
-    }
+    try:
+        transport = remote_transport_from_environment(os.environ)
+    except ProxyConfigurationError as error:
+        bad(str(error))
+    app = create_proxy(transport, name="MCP Proxy Server")
 else:
     cmd = os.environ.get("MCP_COMMAND")
     if not cmd:
@@ -45,18 +47,17 @@ else:
         if not safe(a):
             bad(f"Unsafe arg: {a!r}")
 
-    config = {
+    config: dict[str, object] = {
         "mcpServers": {
             "default": {
                 "type": "stdio",
                 "command": cmd,
                 "args": args,
-                "env": dict(os.environ)
+                "env": dict(os.environ),
             }
         }
     }
-
-app = FastMCP.as_proxy(config, name="MCP Proxy Server")
+    app = create_proxy(config, name="MCP Proxy Server")
 
 if __name__ == "__main__":
     app.settings.host = "127.0.0.1"

--- a/sample-servers/mcp-proxy/src/proxy_config.py
+++ b/sample-servers/mcp-proxy/src/proxy_config.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Callable, Mapping
+from urllib.parse import urlparse
+
+import httpx
+from azure.identity import WorkloadIdentityCredential
+from azure.keyvault.secrets import SecretClient
+from fastmcp.client.transports import StreamableHttpTransport
+
+MAX_HEADERS = 16
+MAX_HEADER_NAME_LEN = 128
+MAX_HEADER_VALUE_LEN = 8192
+MAX_HEADERS_JSON_LEN = 65536
+HEADER_NAME_PATTERN = re.compile(r"[!#$%&'*+\-.^_`|~0-9A-Za-z]+")
+HEADER_VALUE_PATTERN = re.compile(r"[\x20-\x7e]+")
+KEY_VAULT_HOST_PATTERN = re.compile(r"[a-z0-9-]+\.vault\.azure\.net")
+KEY_VAULT_SECRET_NAME_PATTERN = re.compile(r"[0-9A-Za-z-]+")
+KEY_VAULT_SECRET_VERSION_PATTERN = re.compile(r"[0-9A-Fa-f]{32}")
+FORBIDDEN_PROXY_HEADERS = {
+    "connection",
+    "content-length",
+    "host",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    "upgrade",
+}
+
+SecretLoader = Callable[[str], str]
+
+
+class ProxyConfigurationError(ValueError):
+    """Raised when remote proxy configuration is unsafe or invalid."""
+
+
+class _JsonObject(list[tuple[str, object]]):
+    """Distinguish JSON objects from arrays while preserving duplicate keys."""
+
+
+def valid_proxy_url(url: str) -> bool:
+    if not isinstance(url, str) or any(character.isspace() for character in url):
+        return False
+
+    try:
+        parsed = urlparse(url)
+        hostname = parsed.hostname
+        port = parsed.port
+    except ValueError:
+        return False
+
+    return (
+        parsed.scheme in {"http", "https"}
+        and hostname is not None
+        and parsed.username is None
+        and parsed.password is None
+        and (port is None or 0 < port <= 65535)
+        and not parsed.fragment
+    )
+
+
+def parse_proxy_headers(raw_headers: str) -> dict[str, str]:
+    if (
+        not isinstance(raw_headers, str)
+        or not raw_headers
+        or len(raw_headers) > MAX_HEADERS_JSON_LEN
+    ):
+        raise ProxyConfigurationError(
+            "Invalid proxy header secret: expected a non-empty JSON object"
+        )
+
+    try:
+        parsed = json.loads(raw_headers, object_pairs_hook=_JsonObject)
+    except json.JSONDecodeError as error:
+        raise ProxyConfigurationError(
+            "Invalid proxy header secret: expected a JSON object"
+        ) from error
+
+    if not isinstance(parsed, _JsonObject):
+        raise ProxyConfigurationError(
+            "Invalid proxy header secret: expected a JSON object"
+        )
+    if len(parsed) > MAX_HEADERS:
+        raise ProxyConfigurationError("Too many MCP proxy headers")
+
+    headers: dict[str, str] = {}
+    normalized_names: set[str] = set()
+    for name, value in parsed:
+        if (
+            not isinstance(name, str)
+            or not name
+            or len(name) > MAX_HEADER_NAME_LEN
+            or HEADER_NAME_PATTERN.fullmatch(name) is None
+            or name.lower() in FORBIDDEN_PROXY_HEADERS
+        ):
+            raise ProxyConfigurationError("Unsafe MCP proxy header name")
+
+        normalized_name = name.lower()
+        if normalized_name in normalized_names:
+            raise ProxyConfigurationError("Duplicate MCP proxy header name")
+        normalized_names.add(normalized_name)
+
+        if (
+            not isinstance(value, str)
+            or len(value) > MAX_HEADER_VALUE_LEN
+            or HEADER_VALUE_PATTERN.fullmatch(value) is None
+        ):
+            raise ProxyConfigurationError(f"Unsafe MCP proxy header value for {name!r}")
+        headers[name] = value
+
+    return headers
+
+
+def parse_key_vault_secret_url(secret_url: str) -> tuple[str, str, str | None]:
+    try:
+        parsed = urlparse(secret_url)
+        hostname = parsed.hostname
+        port = parsed.port
+    except ValueError as error:
+        raise ProxyConfigurationError("Invalid Key Vault secret URL") from error
+
+    if (
+        parsed.scheme != "https"
+        or hostname is None
+        or KEY_VAULT_HOST_PATTERN.fullmatch(hostname) is None
+        or parsed.username is not None
+        or parsed.password is not None
+        or port is not None
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise ProxyConfigurationError("Invalid Key Vault secret URL")
+
+    path_parts = parsed.path.removeprefix("/").split("/")
+    if len(path_parts) not in {2, 3} or path_parts[0] != "secrets":
+        raise ProxyConfigurationError("Invalid Key Vault secret URL")
+
+    secret_name = path_parts[1]
+    secret_version = path_parts[2] if len(path_parts) == 3 else None
+    if KEY_VAULT_SECRET_NAME_PATTERN.fullmatch(secret_name) is None:
+        raise ProxyConfigurationError("Invalid Key Vault secret URL")
+    if (
+        secret_version is not None
+        and KEY_VAULT_SECRET_VERSION_PATTERN.fullmatch(secret_version) is None
+    ):
+        raise ProxyConfigurationError("Invalid Key Vault secret URL")
+
+    return f"https://{hostname}", secret_name, secret_version
+
+
+def load_key_vault_secret(secret_url: str) -> str:
+    vault_url, secret_name, secret_version = parse_key_vault_secret_url(secret_url)
+    credential = WorkloadIdentityCredential()
+    client = SecretClient(vault_url=vault_url, credential=credential)
+    try:
+        value = client.get_secret(secret_name, secret_version).value
+    finally:
+        client.close()
+        credential.close()
+
+    if value is None:
+        raise ProxyConfigurationError("Key Vault proxy header secret is empty")
+    return value
+
+
+def create_no_redirect_http_client(
+    *,
+    headers: dict[str, str] | None = None,
+    auth: httpx.Auth | None = None,
+    timeout: httpx.Timeout | None = None,
+    follow_redirects: bool = False,
+    transport: httpx.AsyncBaseTransport | None = None,
+) -> httpx.AsyncClient:
+    del follow_redirects
+    return httpx.AsyncClient(
+        headers=headers,
+        auth=auth,
+        timeout=timeout or httpx.Timeout(30.0, read=300.0),
+        follow_redirects=False,
+        transport=transport,
+    )
+
+
+def create_remote_transport(
+    proxy_url: str,
+    headers_secret_url: str | None,
+    *,
+    secret_loader: SecretLoader = load_key_vault_secret,
+) -> StreamableHttpTransport:
+    if not valid_proxy_url(proxy_url):
+        raise ProxyConfigurationError(
+            "Invalid MCP_PROXY_URL: expected a well-formed HTTP(S) URL"
+        )
+
+    headers: dict[str, str] = {}
+    if headers_secret_url:
+        if urlparse(proxy_url).scheme != "https":
+            raise ProxyConfigurationError(
+                "MCP_PROXY_URL must use HTTPS when proxy headers are configured"
+            )
+        parse_key_vault_secret_url(headers_secret_url)
+        try:
+            raw_headers = secret_loader(headers_secret_url)
+        except ProxyConfigurationError:
+            raise
+        except Exception as error:
+            raise ProxyConfigurationError(
+                "Unable to load MCP proxy headers from Key Vault"
+            ) from error
+        headers = parse_proxy_headers(raw_headers)
+
+    return StreamableHttpTransport(
+        proxy_url,
+        headers=headers,
+        httpx_client_factory=create_no_redirect_http_client,
+    )
+
+
+def remote_transport_from_environment(
+    environ: Mapping[str, str],
+    *,
+    secret_loader: SecretLoader = load_key_vault_secret,
+) -> StreamableHttpTransport:
+    if environ.get("MCP_PROXY_HEADERS"):
+        raise ProxyConfigurationError(
+            "MCP_PROXY_HEADERS is unsafe. Store headers in Key Vault and set "
+            "MCP_PROXY_HEADERS_SECRET_URL instead"
+        )
+
+    proxy_url = environ.get("MCP_PROXY_URL")
+    if not proxy_url:
+        raise ProxyConfigurationError("MCP_PROXY_URL is required")
+
+    return create_remote_transport(
+        proxy_url,
+        environ.get("MCP_PROXY_HEADERS_SECRET_URL"),
+        secret_loader=secret_loader,
+    )

--- a/sample-servers/mcp-proxy/tests/test_proxy_config.py
+++ b/sample-servers/mcp-proxy/tests/test_proxy_config.py
@@ -1,0 +1,207 @@
+import asyncio
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+
+SOURCE_DIR = Path(__file__).resolve().parents[1] / "src"
+sys.path.insert(0, str(SOURCE_DIR))
+
+from proxy_config import (
+    ProxyConfigurationError,
+    create_no_redirect_http_client,
+    parse_key_vault_secret_url,
+    parse_proxy_headers,
+    remote_transport_from_environment,
+    valid_proxy_url,
+)
+
+SECRET_URL = "https://example.vault.azure.net/secrets/mcp-proxy-headers"
+
+
+@pytest.mark.parametrize(
+    "proxy_url",
+    [
+        "https://internal-mcp-server/mcp",
+        "http://localhost:8000/mcp",
+        "http://mcp-service.adapter.svc.cluster.local/mcp",
+    ],
+)
+def test_valid_proxy_url_accepts_internal_servers(proxy_url: str) -> None:
+    assert valid_proxy_url(proxy_url)
+
+
+def test_parse_proxy_headers_accepts_visible_ascii_values() -> None:
+    headers = parse_proxy_headers(
+        '{"Authorization":"Bearer test-token","X-Tenant":"tenant 1"}'
+    )
+
+    assert headers == {
+        "Authorization": "Bearer test-token",
+        "X-Tenant": "tenant 1",
+    }
+
+
+@pytest.mark.parametrize("raw_headers", ["not-json", "[]", '"header"'])
+def test_parse_proxy_headers_rejects_malformed_json(raw_headers: str) -> None:
+    with pytest.raises(ProxyConfigurationError, match="expected a JSON object"):
+        parse_proxy_headers(raw_headers)
+
+
+@pytest.mark.parametrize(
+    "raw_headers",
+    [
+        '{"X-Test":"café"}',
+        '{"X-Test":"line\\nbreak"}',
+        '{"X-Test":"\\u0000"}',
+        '{"X-Test":12}',
+    ],
+)
+def test_parse_proxy_headers_rejects_invalid_values(raw_headers: str) -> None:
+    with pytest.raises(ProxyConfigurationError, match="Unsafe MCP proxy header value"):
+        parse_proxy_headers(raw_headers)
+
+
+def test_parse_proxy_headers_rejects_case_insensitive_duplicates() -> None:
+    with pytest.raises(ProxyConfigurationError, match="Duplicate MCP proxy header"):
+        parse_proxy_headers('{"Authorization":"first","authorization":"second"}')
+
+
+def test_parse_key_vault_secret_url_accepts_a_secret_reference() -> None:
+    assert parse_key_vault_secret_url(SECRET_URL) == (
+        "https://example.vault.azure.net",
+        "mcp-proxy-headers",
+        None,
+    )
+
+
+@pytest.mark.parametrize(
+    "secret_url",
+    [
+        "http://example.vault.azure.net/secrets/headers",
+        "https://[invalid]/secrets/headers",
+        "https://attacker.example/secrets/headers",
+        "https://example.vault.azure.net//secrets/headers",
+        "https://example.vault.azure.net/secrets//headers",
+        "https://example.vault.azure.net/keys/headers",
+        "https://example.vault.azure.net/secrets/headers/not-a-version",
+    ],
+)
+def test_parse_key_vault_secret_url_rejects_untrusted_urls(
+    secret_url: str,
+) -> None:
+    with pytest.raises(ProxyConfigurationError, match="Invalid Key Vault secret URL"):
+        parse_key_vault_secret_url(secret_url)
+
+
+def test_raw_header_environment_variable_is_rejected() -> None:
+    with pytest.raises(ProxyConfigurationError, match="MCP_PROXY_HEADERS is unsafe"):
+        remote_transport_from_environment(
+            {
+                "MCP_PROXY_URL": "https://upstream.example/mcp",
+                "MCP_PROXY_HEADERS": '{"Authorization":"Bearer exposed"}',
+            }
+        )
+
+
+def test_secret_reference_loads_headers_at_runtime() -> None:
+    loaded_urls: list[str] = []
+
+    def load_secret(secret_url: str) -> str:
+        loaded_urls.append(secret_url)
+        return '{"Authorization":"Bearer runtime-only"}'
+
+    transport = remote_transport_from_environment(
+        {
+            "MCP_PROXY_URL": "https://upstream.example/mcp",
+            "MCP_PROXY_HEADERS_SECRET_URL": SECRET_URL,
+        },
+        secret_loader=load_secret,
+    )
+
+    assert loaded_urls == [SECRET_URL]
+    assert transport.headers == {"Authorization": "Bearer runtime-only"}
+
+
+def test_secret_backed_headers_require_https() -> None:
+    with pytest.raises(ProxyConfigurationError, match="must use HTTPS"):
+        remote_transport_from_environment(
+            {
+                "MCP_PROXY_URL": "http://upstream.example/mcp",
+                "MCP_PROXY_HEADERS_SECRET_URL": SECRET_URL,
+            },
+            secret_loader=lambda _url: '{"Authorization":"Bearer secret"}',
+        )
+
+
+def test_http_proxy_without_static_headers_remains_supported() -> None:
+    transport = remote_transport_from_environment(
+        {"MCP_PROXY_URL": "http://mcp-service.adapter.svc.cluster.local/mcp"}
+    )
+
+    assert str(transport.url) == "http://mcp-service.adapter.svc.cluster.local/mcp"
+    assert transport.headers == {}
+
+
+def test_http_client_rejects_redirects_with_static_headers() -> None:
+    sentinel = "redirect-sentinel"
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            302,
+            headers={"Location": "https://attacker.example/collect"},
+        )
+
+    async def exercise() -> httpx.Response:
+        client = create_no_redirect_http_client(
+            headers={"X-Api-Key": sentinel},
+            follow_redirects=True,
+            transport=httpx.MockTransport(handler),
+        )
+        async with client:
+            return await client.get("https://upstream.example/mcp")
+
+    response = asyncio.run(exercise())
+
+    assert response.status_code == 302
+    assert len(requests) == 1
+    assert requests[0].url == httpx.URL("https://upstream.example/mcp")
+
+
+def test_fastmcp_debug_logs_redact_headers() -> None:
+    sentinel = "logging-sentinel"
+    script = """
+import sys
+
+sys.path.insert(0, sys.argv[1])
+
+from fastmcp.server import create_proxy
+from fastmcp.utilities.logging import get_logger
+from proxy_config import create_remote_transport
+
+sentinel = sys.argv[2]
+transport = create_remote_transport(
+    "https://upstream.example/mcp",
+    "https://example.vault.azure.net/secrets/mcp-proxy-headers",
+    secret_loader=lambda _url: '{"Authorization":"Bearer ' + sentinel + '"}',
+)
+create_proxy(transport, name="Test Proxy")
+get_logger("proxy_security_test").debug("Transport: %r", transport)
+"""
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script, str(SOURCE_DIR), sentinel],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "FASTMCP_LOG_LEVEL": "DEBUG"},
+    )
+    output = completed.stdout + completed.stderr
+
+    assert "StreamableHttpTransport" in output
+    assert sentinel not in output


### PR DESCRIPTION
## Summary

- support optional upstream headers through an Azure Key Vault secret reference
- load header values at adapter startup with workload identity
- reject raw header values in adapter metadata
- require HTTPS whenever secret-backed headers are configured
- reject redirects before credentials can reach another origin
- validate header names and visible ASCII values before connecting upstream
- keep FastMCP debug output free of header values
- run focused proxy security tests in GitHub Actions

## Security model

Adapters submit only `MCP_PROXY_HEADERS_SECRET_URL`. The gateway stores and returns that non-secret reference. The proxy retrieves the secret value directly from Key Vault. Raw `MCP_PROXY_HEADERS` configuration fails closed.

The proxy requires an `https://` upstream for secret-backed headers. It passes a redacting transport object to FastMCP instead of an MCP config containing credentials. Its HTTP client disables redirects even when FastMCP asks to follow them. Unauthenticated internal HTTP proxying remains supported.

OAuth remains preferred where an upstream supports it. The documentation uses `Authorization: Bearer <token>` for static-token servers.

## Validation

- `python -m pytest sample-servers/mcp-proxy/tests -W error`: 26 passed
- `ruff check sample-servers/mcp-proxy/src sample-servers/mcp-proxy/tests`
- `ruff format --check sample-servers/mcp-proxy/src sample-servers/mcp-proxy/tests`
- `actionlint .github/workflows/main.yml`
- `dotnet build dotnet/Microsoft.McpGateway.sln --configuration Release --no-restore`: succeeded with 0 warnings and 0 errors
- installed Python dependency set: compatible and has no known conflicts

The .NET test assemblies build locally. Execution needs the x64 .NET host provided by the GitHub runner.
