### PR TITLE
Fix: app-manager Role missing patch verb blocks adapter/tool updates

### DIFF
--- a/deployment/k8s/local-deployment.yml
+++ b/deployment/k8s/local-deployment.yml
@@ -84,10 +84,10 @@ metadata:
 rules:
   - apiGroups: ["apps"]
     resources: ["statefulsets"]
-    verbs: ["get", "list", "create", "update", "delete", "watch"]
+    verbs: ["get", "list", "create", "update", "patch", "delete", "watch"]
   - apiGroups: [""]
     resources: ["services", "pods"]
-    verbs: ["get", "list", "create", "update", "delete", "watch"]
+    verbs: ["get", "list", "create", "update", "patch", "delete", "watch"]
   - apiGroups: [""]
     resources: ["pods/log"]
     verbs: ["get", "watch"]


### PR DESCRIPTION
## Summary

`local-deployment.yml`'s `app-manager` Role grants the `mcpgateway-sa` service account `update` on `statefulsets` and `services`/`pods`, but `KubernetesAdapterDeploymentManager.UpdateDeploymentAsync` calls `PatchNamespacedStatefulSetAsync` — a **patch** operation. Kubernetes RBAC treats `update` and `patch` as distinct verbs, so the Role as shipped doesn't actually authorize adapter/tool updates.

Any `PUT /adapters/{name}` or `PUT /tools/{name}` call against a gateway deployed from this manifest fails with a 500, wrapping this 403 from the Kubernetes API:

```
statefulsets.apps "<name>" is forbidden: User "system:serviceaccount:adapter:mcpgateway-sa"
cannot patch resource "statefulsets" in API group "apps" in the namespace "adapter"
```

Reproduced end to end: created an adapter, then tried to update one of its environment variables via the management portal — update failed 500, backend log showed the 403 above. Adding `patch` alongside `update` for both rules fixes it; verified the same update succeeds afterward.

## Change

Adds `"patch"` to the verb list for both the `statefulsets` rule and the `services`/`pods` rule in the `app-manager` Role.

## Test plan

- [x] Deployed `local-deployment.yml` fresh, confirmed `update` alone reproduces the 403 above
- [x] Applied this fix's verb addition, confirmed a subsequent adapter update (env var change) succeeds
- [ ] Maintainers may want to confirm this doesn't need similar treatment in the cloud/production deployment manifest if it grants RBAC separately

---
Found and patched by [Claude Code](https://claude.com/claude-code) while standing up a local instance of this gateway.