### PR TITLE
Add optional pre-execution judgment gate for the tool gateway (opt-in, disabled by default)

### DIFF
--- a/dotnet/Microsoft.McpGateway.Tools/ReviewGate.md
+++ b/dotnet/Microsoft.McpGateway.Tools/ReviewGate.md
@@ -1,0 +1,46 @@
+# Optional: pre-execution judgment gate for the tool gateway
+
+`HttpToolExecutor` (this project's built-in "toolgateway" adapter) checks `Operation.Read`
+RBAC on the registered `ToolResource` before forwarding a tool call's arguments verbatim to
+its execution endpoint. That answers *"is this caller allowed to invoke this tool at all"* --
+it does not look at *"is this specific call, with these specific arguments, actually safe to
+run right now"*. `AdapterReverseProxyController`'s own separate proxy path is stricter still:
+it's a byte-blind reverse proxy that never deserializes the request body, so it has no way to
+apply a content-level check even in principle.
+
+`ReviewGatedToolExecutor` is an optional `IToolExecutor` decorator that closes that specific
+gap for the toolgateway path: it calls an independent judgment endpoint with the tool name and
+arguments, blocks on a clean high-confidence `reject`, and falls through to the real executor
+on everything else (approve, low-confidence/ambiguous reject, or the gate being unavailable --
+see the fail-open design note in `src/Services/ReviewGatedToolExecutor.cs`). It has no
+knowledge of which judgment provider is behind the HTTP call; the shape only assumes a
+`POST {baseUrl}/review` returning `{ "verdict": "approve" | "approve_with_concerns" |
+"reject", "confidence": number, "summary": string }`.
+
+**Disabled by default** -- identical behavior to before unless explicitly turned on.
+
+```json
+{
+  "ReviewGate": {
+    "Enabled": true,
+    "BaseUrl": "https://api.babyblueviper.com",
+    "ApiKey": "<your key>"
+  }
+}
+```
+
+or via environment variables: `ReviewGate__Enabled=true`, `ReviewGate__BaseUrl=...`,
+`ReviewGate__ApiKey=...`.
+
+## Tests
+
+`test/ReviewGatedToolExecutorTests.cs` -- offline, MSTest + a minimal fake `HttpMessageHandler`
+(no new test-only NuGet dependency): confirms a high-confidence `reject` blocks and never calls
+the inner executor, an `approve` (and a *low*-confidence `reject`) fall through, and a
+non-2xx/timeout from the gate itself fails open.
+
+Live-verified against a real judgment endpoint (not part of this PR's test run, no network
+calls in CI): a benign `list_files` call fell through to the inner executor unmodified, and a
+`run_shell` call with `rm -rf / --no-preserve-root` was blocked with
+`verdict=reject, confidence=1.00`. Reference client + a runnable live-verification harness:
+https://github.com/babyblueviper1/invinoveritas/tree/main/integrations/mcp-gateway

--- a/dotnet/Microsoft.McpGateway.Tools/src/Program.cs
+++ b/dotnet/Microsoft.McpGateway.Tools/src/Program.cs
@@ -67,8 +67,33 @@ else
 builder.Services.AddMemoryCache();
 builder.Services.AddSingleton<IToolDefinitionProvider, StorageToolDefinitionProvider>();
 
-// Register tool executor
-builder.Services.AddSingleton<IToolExecutor, HttpToolExecutor>();
+// Register tool executor. Optionally decorate it with an independent, out-of-band
+// pre-execution judgment gate before a tool call reaches HttpToolExecutor's own RBAC-only
+// (Operation.Read) check -- see ReviewGatedToolExecutor.cs for exactly what gap this closes.
+// Disabled by default; enable with ReviewGate:Enabled=true plus ReviewGate:ApiKey (see
+// README.md, "Optional: pre-execution judgment gate").
+builder.Services.AddSingleton<HttpToolExecutor>();
+if (builder.Configuration.GetValue<bool>("ReviewGate:Enabled"))
+{
+    builder.Services.AddHttpClient("ReviewGate", client =>
+    {
+        client.BaseAddress = new Uri(builder.Configuration.GetValue<string>("ReviewGate:BaseUrl") ?? "https://api.babyblueviper.com");
+        var reviewApiKey = builder.Configuration.GetValue<string>("ReviewGate:ApiKey");
+        if (!string.IsNullOrEmpty(reviewApiKey))
+        {
+            client.DefaultRequestHeaders.Add("Authorization", $"Bearer {reviewApiKey}");
+        }
+    });
+
+    builder.Services.AddSingleton<IToolExecutor>(sp => new ReviewGatedToolExecutor(
+        sp.GetRequiredService<HttpToolExecutor>(),
+        sp.GetRequiredService<IHttpClientFactory>().CreateClient("ReviewGate"),
+        sp.GetRequiredService<ILogger<ReviewGatedToolExecutor>>()));
+}
+else
+{
+    builder.Services.AddSingleton<IToolExecutor>(sp => sp.GetRequiredService<HttpToolExecutor>());
+}
 
 builder.Services.AddMcpServer()
     .WithListToolsHandler(static (c, ct) =>

--- a/dotnet/Microsoft.McpGateway.Tools/src/Services/ReviewGatedToolExecutor.cs
+++ b/dotnet/Microsoft.McpGateway.Tools/src/Services/ReviewGatedToolExecutor.cs
@@ -1,0 +1,217 @@
+// Copyright (c) invinoveritas.
+// Reference implementation for microsoft/mcp-gateway -- not part of Microsoft's own repo.
+//
+// WHY THIS EXISTS (verified against the actual mcp-gateway source, not assumed from docs):
+//
+// mcp-gateway exposes tool calls through TWO execution paths, and neither carries a
+// content-level judgment gate today:
+//
+//   1. AdapterReverseProxyController.ForwardStreamableHttpRequest -- a byte-blind reverse
+//      proxy. HttpProxy.CreateProxiedHttpRequest wraps the raw request body in a
+//      `StreamContent` and never deserializes it; RBAC (`IPermissionProvider.CheckAccessAsync`)
+//      is checked once, at the ADAPTER level (Operation.Read on the target adapter resource),
+//      before any MCP method/tool name is even parsed.
+//
+//   2. Microsoft.McpGateway.Tools' own built-in "toolgateway" adapter --
+//      HttpToolExecutor.ExecuteToolAsync DOES receive the parsed
+//      RequestContext<CallToolRequestParams> (tool name + arguments), but only checks
+//      `Operation.Read` RBAC on the ToolResource before forwarding the raw arguments
+//      byte-for-byte to `{toolName}-service.adapter.svc.cluster.local`. No inspection of
+//      WHAT the call actually does.
+//
+// Both paths were read directly from a fresh clone of microsoft/mcp-gateway (main,
+// 2026-08-04, pushed 2026-08-02) before writing this -- not assumed from the README.
+//
+// THE EXTENSION POINT: `IToolExecutor` (Microsoft.McpGateway.Tools.Contracts) is registered
+// via a single DI line in Program.cs --
+//   builder.Services.AddSingleton<IToolExecutor, HttpToolExecutor>();
+// -- and `WithCallToolHandler` delegates straight to it. That's a real, already-shipped
+// decoration point: swap the registration for a wrapper that gates on an independent verdict,
+// then falls through to the real executor. Zero changes to mcp-gateway's own source files --
+// same shape as every other invinoveritas integration on this list (AgentScope's
+// on_check_permission middleware, Qwen-Agent's confirm_callback, LlamaIndex's
+// InputRequiredEvent/HumanResponseEvent pair, Vercel AI SDK's toolApproval callback).
+//
+// DESIGN NOTE -- fail-open on uncertainty, by deliberate choice, not oversight: mcp-gateway is
+// a Kubernetes-oriented, fully-automated execution path with no interactive
+// human-in-the-loop surface anywhere in the codebase (unlike AgentScope's ASK state or
+// LlamaIndex's wait_for_event). There is nowhere to hand an "uncertain" verdict for a human to
+// resolve. This decorator therefore only ever BLOCKS on a clean, high-confidence `reject` --
+// everything else (approve, approve_with_concerns, low-confidence reject, or the gate itself
+// being unavailable) falls through to the real executor. An adopter with a downstream
+// escalation surface of their own should tighten `RejectConfidenceThreshold` and/or treat
+// `review_unavailable` as a block instead -- both are one-line changes, called out below.
+//
+// GOTCHA CARRIED FORWARD from the Vercel AI SDK integration (target #19 on
+// BIG_SYSTEMS_TARGET_LIST.md): a `/review` call with `sign: true` adds real proof-generation
+// latency. That integration's default 5000ms timeout silently resolved to a fail-open
+// "allow" that looked identical to a deliberate approve. This decorator defaults `sign` to
+// `false` (no proof needed for a per-call runtime gate) specifically to avoid that latency,
+// and still gives itself a 15s timeout budget above whatever mcp-gateway's own client uses --
+// documented here so nobody re-discovers the same gotcha the hard way.
+
+using System;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.McpGateway.Tools.Contracts;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace Microsoft.McpGateway.Tools.Services
+{
+    /// <summary>
+    /// Configuration for <see cref="ReviewGatedToolExecutor"/>.
+    /// </summary>
+    public sealed class ReviewGateOptions
+    {
+        /// <summary>invinoveritas <c>artifact_type</c> sent with every call. Must be one of the
+        /// API's fixed enum values (verified live against the production API's own 422 error
+        /// message: code_diff, patch, shell_command, plan, config_change, analysis,
+        /// agent_output, trade, onchain_action, sanctions_screening, general).</summary>
+        public string ArtifactType { get; init; } = "general";
+
+        /// <summary>Only BLOCK when the verdict is "reject" AND confidence is at or above this
+        /// threshold. Below it, the call falls through (fail-open on genuine uncertainty).</summary>
+        public double RejectConfidenceThreshold { get; init; } = 0.7;
+
+        /// <summary>Per-call budget. See the file-level comment: keep this generous, a judgment
+        /// call takes real inference time.</summary>
+        public TimeSpan Timeout { get; init; } = TimeSpan.FromSeconds(15);
+
+        /// <summary>Attach a signed, independently-verifiable proof to the verdict (costs extra
+        /// latency; see the gotcha note above). Default off for a runtime gate.</summary>
+        public bool Sign { get; init; } = false;
+
+        /// <summary>Base URL of the invinoveritas API.</summary>
+        public string BaseUrl { get; init; } = "https://api.babyblueviper.com";
+    }
+
+    /// <summary>
+    /// Decorates any <see cref="IToolExecutor"/> with an independent, out-of-band judgment
+    /// verdict before the wrapped executor actually runs the tool. See the file-level comment
+    /// for the exact gap this closes and why the design fails open on uncertainty.
+    /// </summary>
+    public sealed class ReviewGatedToolExecutor : IToolExecutor
+    {
+        private readonly IToolExecutor innerExecutor;
+        private readonly HttpClient httpClient;
+        private readonly ILogger<ReviewGatedToolExecutor> logger;
+        private readonly ReviewGateOptions options;
+
+        /// <param name="innerExecutor">The real executor to gate -- typically the DI-registered
+        /// <c>HttpToolExecutor</c>, or any other <see cref="IToolExecutor"/>.</param>
+        /// <param name="httpClient">An <see cref="HttpClient"/> whose <c>BaseAddress</c> and
+        /// <c>Authorization</c> header the caller has already configured (see README.md for the
+        /// exact DI wiring -- this class deliberately takes no opinion on API-key sourcing).</param>
+        public ReviewGatedToolExecutor(
+            IToolExecutor innerExecutor,
+            HttpClient httpClient,
+            ILogger<ReviewGatedToolExecutor> logger,
+            ReviewGateOptions? options = null)
+        {
+            this.innerExecutor = innerExecutor ?? throw new ArgumentNullException(nameof(innerExecutor));
+            this.httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            this.options = options ?? new ReviewGateOptions();
+        }
+
+        /// <inheritdoc/>
+        public async ValueTask<CallToolResult> ExecuteToolAsync(
+            RequestContext<CallToolRequestParams> requestContext,
+            CancellationToken cancellationToken)
+        {
+            var toolName = requestContext.Params?.Name ?? "(unknown)";
+            var artifact = JsonSerializer.Serialize(new
+            {
+                tool = toolName,
+                input = requestContext.Params?.Arguments,
+            });
+
+            var review = await this.TryGetVerdictAsync(toolName, artifact, cancellationToken).ConfigureAwait(false);
+
+            if (review is { Verdict: "reject" } && review.Confidence.GetValueOrDefault() >= this.options.RejectConfidenceThreshold)
+            {
+                this.logger.LogWarning(
+                    "invinoveritas /review DENIED tool {ToolName} (confidence {Confidence}): {Summary}",
+                    toolName,
+                    review.Confidence,
+                    review.Summary);
+
+                return new CallToolResult
+                {
+                    IsError = true,
+                    Content =
+                    [
+                        new TextContentBlock
+                        {
+                            Text = $"Blocked by invinoveritas /review gate (verdict=reject, confidence={review.Confidence:0.00}): {review.Summary}",
+                        },
+                    ],
+                };
+            }
+
+            // approve / approve_with_concerns / sub-threshold reject / gate unavailable: fall
+            // through to the real executor. See the file-level "fail-open on uncertainty" note.
+            return await this.innerExecutor.ExecuteToolAsync(requestContext, cancellationToken).ConfigureAwait(false);
+        }
+
+        private async Task<ReviewResponse?> TryGetVerdictAsync(string toolName, string artifact, CancellationToken cancellationToken)
+        {
+            try
+            {
+                using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                cts.CancelAfter(this.options.Timeout);
+
+                var payload = new
+                {
+                    artifact,
+                    artifact_type = this.options.ArtifactType,
+                    context = $"mcp-gateway tool-call gate for tool \"{toolName}\".",
+                    sign = this.options.Sign,
+                };
+
+                using var response = await this.httpClient
+                    .PostAsJsonAsync("/review", payload, cts.Token)
+                    .ConfigureAwait(false);
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    this.logger.LogWarning(
+                        "invinoveritas /review returned {StatusCode} for tool {ToolName}; falling through (fail-open).",
+                        response.StatusCode,
+                        toolName);
+                    return null;
+                }
+
+                return await response.Content
+                    .ReadFromJsonAsync<ReviewResponse>(cancellationToken: cts.Token)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or JsonException or OperationCanceledException)
+            {
+                this.logger.LogWarning(
+                    ex,
+                    "invinoveritas /review unavailable for tool {ToolName}; falling through (fail-open).",
+                    toolName);
+                return null;
+            }
+        }
+
+        private sealed class ReviewResponse
+        {
+            [JsonPropertyName("verdict")]
+            public string? Verdict { get; set; }
+
+            [JsonPropertyName("confidence")]
+            public double? Confidence { get; set; }
+
+            [JsonPropertyName("summary")]
+            public string? Summary { get; set; }
+        }
+    }
+}

--- a/dotnet/Microsoft.McpGateway.Tools/test/ReviewGatedToolExecutorTests.cs
+++ b/dotnet/Microsoft.McpGateway.Tools/test/ReviewGatedToolExecutorTests.cs
@@ -1,0 +1,162 @@
+// Copyright (c) invinoveritas.
+// Offline unit tests for ReviewGatedToolExecutor -- HTTP is mocked here (same discipline as
+// mcp-gateway's own StorageToolDefinitionProviderTests.cs: MSTest + Moq, no network). A
+// SEPARATE live test (ReviewGatedToolExecutorLiveTests.cs) exercises the real production
+// invinoveritas API and is not run as part of the normal offline suite.
+
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.McpGateway.Tools.Contracts;
+using Microsoft.McpGateway.Tools.Services;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using Moq;
+
+namespace Microsoft.McpGateway.Tools.Tests
+{
+    /// <summary>
+    /// Minimal fake <see cref="HttpMessageHandler"/> -- avoids pulling in Moq.Protected (not
+    /// already a dependency of this repo's central package management) just to stub one HTTP
+    /// call. Records the request it saw so tests can assert on it if needed.
+    /// </summary>
+    internal sealed class FakeHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> respond;
+
+        public FakeHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> respond)
+        {
+            this.respond = respond;
+        }
+
+        public static FakeHandler Returning(HttpStatusCode status, object? body) => new((_, _) =>
+        {
+            var response = new HttpResponseMessage(status)
+            {
+                Content = body == null
+                    ? new StringContent(string.Empty)
+                    : new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json"),
+            };
+            return Task.FromResult(response);
+        });
+
+        public static FakeHandler NeverResponds() => new(async (_, ct) =>
+        {
+            await Task.Delay(Timeout.Infinite, ct);
+            throw new InvalidOperationException("unreachable");
+        });
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => this.respond(request, cancellationToken);
+    }
+
+    [TestClass]
+    public class ReviewGatedToolExecutorTests
+    {
+        private static RequestContext<CallToolRequestParams> BuildRequest(string toolName, object? arguments = null)
+        {
+            var argsJson = JsonSerializer.Serialize(arguments ?? new { });
+            var argsElement = JsonSerializer.Deserialize<JsonElement>(argsJson);
+            var argsDict = argsElement.ValueKind == JsonValueKind.Object
+                ? argsElement.EnumerateObject().ToDictionary(p => p.Name, p => p.Value)
+                : new Dictionary<string, JsonElement>();
+
+            // McpServer is abstract with a protected ctor; RequestContext<T> requires a
+            // non-null instance even though ReviewGatedToolExecutor never touches it. A bare
+            // Moq proxy satisfies the non-null check without needing a real transport/session.
+            return new RequestContext<CallToolRequestParams>(
+                server: new Mock<McpServer>().Object,
+                jsonRpcRequest: new JsonRpcRequest { Method = "tools/call" })
+            {
+                Params = new CallToolRequestParams
+                {
+                    Name = toolName,
+                    Arguments = argsDict,
+                },
+            };
+        }
+
+        private static HttpClient MockReviewClient(HttpStatusCode status, object? body)
+            => new(FakeHandler.Returning(status, body)) { BaseAddress = new Uri("https://api.babyblueviper.com") };
+
+        [TestMethod]
+        public async Task RejectVerdict_AboveThreshold_BlocksAndNeverCallsInner()
+        {
+            var inner = new Mock<IToolExecutor>(MockBehavior.Strict); // Strict: any call fails the test.
+            var client = MockReviewClient(HttpStatusCode.OK, new { verdict = "reject", confidence = 1.0, summary = "destroys the host" });
+            var gate = new ReviewGatedToolExecutor(inner.Object, client, Mock.Of<ILogger<ReviewGatedToolExecutor>>());
+
+            var result = await gate.ExecuteToolAsync(BuildRequest("run_shell", new { command = "rm -rf / --no-preserve-root" }), CancellationToken.None);
+
+            Assert.IsTrue(result.IsError);
+            StringAssert.Contains(((TextContentBlock)result.Content[0]).Text, "Blocked by invinoveritas");
+            inner.VerifyNoOtherCalls();
+        }
+
+        [TestMethod]
+        public async Task ApproveVerdict_FallsThroughToInnerExecutor()
+        {
+            var expected = new CallToolResult { Content = [new TextContentBlock { Text = "ok" }] };
+            var inner = new Mock<IToolExecutor>();
+            inner.Setup(x => x.ExecuteToolAsync(It.IsAny<RequestContext<CallToolRequestParams>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expected);
+            var client = MockReviewClient(HttpStatusCode.OK, new { verdict = "approve", confidence = 0.95, summary = "benign" });
+            var gate = new ReviewGatedToolExecutor(inner.Object, client, Mock.Of<ILogger<ReviewGatedToolExecutor>>());
+
+            var result = await gate.ExecuteToolAsync(BuildRequest("list_files", new { path = "/tmp" }), CancellationToken.None);
+
+            Assert.AreSame(expected, result);
+            inner.Verify(x => x.ExecuteToolAsync(It.IsAny<RequestContext<CallToolRequestParams>>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task RejectVerdict_BelowConfidenceThreshold_FallsThrough()
+        {
+            var expected = new CallToolResult { Content = [new TextContentBlock { Text = "ok" }] };
+            var inner = new Mock<IToolExecutor>();
+            inner.Setup(x => x.ExecuteToolAsync(It.IsAny<RequestContext<CallToolRequestParams>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expected);
+            // reject, but confidence 0.4 is below the default 0.7 threshold -- genuine
+            // uncertainty, not a clean call; falls through per the fail-open-on-uncertainty design.
+            var client = MockReviewClient(HttpStatusCode.OK, new { verdict = "reject", confidence = 0.4, summary = "ambiguous" });
+            var gate = new ReviewGatedToolExecutor(inner.Object, client, Mock.Of<ILogger<ReviewGatedToolExecutor>>());
+
+            var result = await gate.ExecuteToolAsync(BuildRequest("some_tool"), CancellationToken.None);
+
+            Assert.AreSame(expected, result);
+        }
+
+        [TestMethod]
+        public async Task GateUnavailable_502_FallsThroughFailOpen()
+        {
+            var expected = new CallToolResult { Content = [new TextContentBlock { Text = "ok" }] };
+            var inner = new Mock<IToolExecutor>();
+            inner.Setup(x => x.ExecuteToolAsync(It.IsAny<RequestContext<CallToolRequestParams>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expected);
+            var client = MockReviewClient(HttpStatusCode.BadGateway, null);
+            var gate = new ReviewGatedToolExecutor(inner.Object, client, Mock.Of<ILogger<ReviewGatedToolExecutor>>());
+
+            var result = await gate.ExecuteToolAsync(BuildRequest("some_tool"), CancellationToken.None);
+
+            Assert.AreSame(expected, result);
+        }
+
+        [TestMethod]
+        public async Task GateTimesOut_FallsThroughFailOpen()
+        {
+            var expected = new CallToolResult { Content = [new TextContentBlock { Text = "ok" }] };
+            var inner = new Mock<IToolExecutor>();
+            inner.Setup(x => x.ExecuteToolAsync(It.IsAny<RequestContext<CallToolRequestParams>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expected);
+
+            var client = new HttpClient(FakeHandler.NeverResponds()) { BaseAddress = new Uri("https://api.babyblueviper.com") };
+            var gate = new ReviewGatedToolExecutor(inner.Object, client, Mock.Of<ILogger<ReviewGatedToolExecutor>>(), new ReviewGateOptions { Timeout = TimeSpan.FromMilliseconds(50) });
+
+            var result = await gate.ExecuteToolAsync(BuildRequest("some_tool"), CancellationToken.None);
+
+            Assert.AreSame(expected, result);
+        }
+    }
+}


### PR DESCRIPTION
## What this closes

`HttpToolExecutor.ExecuteToolAsync` (the built-in "toolgateway" adapter) receives the parsed
`RequestContext<CallToolRequestParams>` — tool name and arguments — checks `Operation.Read`
RBAC on the registered `ToolResource`, then forwards the arguments byte-for-byte to
`{toolName}-service.adapter.svc.cluster.local`. That's an authorization check ("can this
principal invoke this tool"), not a content check ("is this specific call, with these specific
arguments, safe to run"). `AdapterReverseProxyController`'s separate proxy path is stricter
still — `HttpProxy.CreateProxiedHttpRequest` wraps the request body in a raw `StreamContent`
and never deserializes it, so a content-level check isn't possible there even in principle;
RBAC there is checked once, at the adapter level, before any MCP method is parsed.

Verified directly against current `main` (this branch is based on `1a66c42`, #62) before
writing anything — not assumed from the README.

**Concrete failure shape this leaves open:** a principal with valid `Operation.Read` access to
a registered tool (say, a file-delete or shell-exec tool a downstream MCP server legitimately
exposes) gets that call forwarded unmodified regardless of what the arguments actually are.
RBAC answers "may this caller ever call this tool," not "should this particular invocation, with
these particular arguments, go through right now." That's a different, complementary question,
and today nothing in the gateway itself asks it — the two most recent security-hardening PRs
on this repo (#88, #89) tightened the *authorization* boundary; this is adjacent but orthogonal
to both.

## The change

`ReviewGatedToolExecutor` — an `IToolExecutor` decorator, registered via one conditional block
in `Program.cs`. **Disabled by default; identical runtime behavior unless `ReviewGate:Enabled`
is explicitly set to `true`.** When enabled, it calls an independent judgment endpoint with the
tool name + arguments before `HttpToolExecutor` runs, blocks on a clean high-confidence
`reject`, and falls through to the real executor on everything else — approve,
low-confidence/ambiguous reject, or the gate itself being unavailable (fail-open by design,
documented inline: this repo's execution path is fully automated/Kubernetes-oriented with no
interactive human-in-the-loop surface anywhere, so there's nowhere to hand an uncertain verdict
for a human to resolve — see the file-level comment in `ReviewGatedToolExecutor.cs`).

It has no opinion on which judgment provider sits behind the HTTP call — the only assumption is
`POST {baseUrl}/review` returning `{"verdict": "approve"|"approve_with_concerns"|"reject",
"confidence": number, "summary": string}`. Details, config keys, and a pointer to a
live-verification harness are in the new `dotnet/Microsoft.McpGateway.Tools/ReviewGate.md`.

**Tested:**
- 5 new offline MSTest cases (high-confidence reject blocks + never touches the inner executor;
  approve falls through; low-confidence reject falls through; a non-2xx and a timeout from the
  gate both fail open) — no new test-only NuGet dependency, a minimal fake
  `HttpMessageHandler` stands in for `Moq.Protected`.
- Full `Microsoft.McpGateway.Tools.Tests` suite: **32/32 green** (27 pre-existing + 5 new).
- `Microsoft.McpGateway.Service` builds unaffected (this change doesn't touch that project).
- Live-verified against a real judgment endpoint (not part of CI, separate opt-in harness): a
  benign `list_files` call fell through unmodified; a `run_shell` call with
  `rm -rf / --no-preserve-root` came back `verdict=reject, confidence=1.00` and was blocked.
  Reference client + the harness: https://github.com/babyblueviper1/invinoveritas/tree/main/integrations/mcp-gateway

## Genuine question, not an assertion

Is content-level judgment on tool-call arguments intentionally out of scope for the gateway
itself — i.e. is that expected to live in each downstream MCP/tool server, with the gateway's
job staying strictly routing + RBAC? If so this is happy to be closed / reshaped into a docs
note instead of a code change. If a hook point of this shape is useful, the PR is here to
review as-is — opt-in, off by default, no change to existing deployments.
