### PR TITLE
Forward the shared gateway secret only to the tool gateway

### DIFF
--- a/dotnet/Microsoft.McpGateway.Service/src/Controllers/AdapterReverseProxyController.cs
+++ b/dotnet/Microsoft.McpGateway.Service/src/Controllers/AdapterReverseProxyController.cs
@@ -57,7 +57,9 @@ namespace Microsoft.McpGateway.Service.Controllers
                 return;
             }
 
-            var proxiedRequest = HttpProxy.CreateProxiedHttpRequest(HttpContext, (uri) => ReplaceUriAddress(uri, targetAddress));
+            // Only the first-party tool gateway route (no adapter name on the URL) is trusted with the
+            // shared gateway secret. Adapter pods are user supplied and must never receive it.
+            var proxiedRequest = HttpProxy.CreateProxiedHttpRequest(HttpContext, (uri) => ReplaceUriAddress(uri, targetAddress), forwardGatewaySecret: name is null);
 
             using var client = httpClientFactory.CreateClient(Constants.HttpClientNames.AdapterProxyClient);
             var response = await client.SendAsync(proxiedRequest, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);

--- a/dotnet/Microsoft.McpGateway.Service/src/HttpProxy.cs
+++ b/dotnet/Microsoft.McpGateway.Service/src/HttpProxy.cs
@@ -11,7 +11,16 @@ namespace Microsoft.McpGateway.Service
 {
     public static class HttpProxy
     {
-        public static HttpRequestMessage CreateProxiedHttpRequest(HttpContext context, Func<Uri, Uri>? targetOverride = null)
+        /// <summary>
+        /// Builds the outbound request used to proxy <paramref name="context"/> to a backend pod.
+        /// </summary>
+        /// <param name="forwardGatewaySecret">
+        /// Whether to attach the shared <c>X-Gateway-Secret</c> credential. The tool gateway requires it
+        /// before it will trust the forwarded identity headers, so it may only be sent to first-party
+        /// internal targets; user-deployed adapter pods must never receive it. Defaults to
+        /// <see langword="false"/> so new call sites fail closed.
+        /// </param>
+        public static HttpRequestMessage CreateProxiedHttpRequest(HttpContext context, Func<Uri, Uri>? targetOverride = null, bool forwardGatewaySecret = false)
         {
             var hasBody = context.Request.ContentLength > 0 ||
                           context.Request.ContentLength is null && !HttpMethods.IsGet(context.Request.Method) && !HttpMethods.IsHead(context.Request.Method) && !HttpMethods.IsDelete(context.Request.Method) && !HttpMethods.IsOptions(context.Request.Method);
@@ -54,9 +63,12 @@ namespace Microsoft.McpGateway.Service
                     requestMessage.Headers.TryAddWithoutValidation(ForwardedIdentityHeaders.Roles, string.Join(',', roles));
             }
 
-            var gatewaySecret = context.RequestServices.GetService<IConfiguration>()?.GetValue<string>("GatewaySettings:Secret");
-            if (!string.IsNullOrEmpty(gatewaySecret))
-                requestMessage.Headers.TryAddWithoutValidation(ForwardedIdentityHeaders.GatewaySecret, gatewaySecret);
+            if (forwardGatewaySecret)
+            {
+                var gatewaySecret = context.RequestServices.GetService<IConfiguration>()?.GetValue<string>("GatewaySettings:Secret");
+                if (!string.IsNullOrEmpty(gatewaySecret))
+                    requestMessage.Headers.TryAddWithoutValidation(ForwardedIdentityHeaders.GatewaySecret, gatewaySecret);
+            }
 
             requestMessage.Headers.TryAddWithoutValidation("Forwarded", $"for={context.Connection.RemoteIpAddress};proto={context.Request.Scheme};host={context.Request.Host.Value}");
             return requestMessage;

--- a/dotnet/Microsoft.McpGateway.Service/test/HttpProxyTests.cs
+++ b/dotnet/Microsoft.McpGateway.Service/test/HttpProxyTests.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.McpGateway.Management.Authorization;
+
+namespace Microsoft.McpGateway.Service.Tests
+{
+    [TestClass]
+    public class HttpProxyTests
+    {
+        private const string GatewaySecret = "the-shared-secret";
+
+        [TestMethod]
+        public void CreateProxiedHttpRequest_WithAdapterTarget_DoesNotForwardGatewaySecret()
+        {
+            var context = CreateAuthenticatedContext("/adapters/victim/mcp");
+
+            var request = HttpProxy.CreateProxiedHttpRequest(context);
+
+            request.Headers.Contains(ForwardedIdentityHeaders.GatewaySecret).Should().BeFalse();
+        }
+
+        [TestMethod]
+        public void CreateProxiedHttpRequest_WithToolGatewayTarget_ForwardsGatewaySecret()
+        {
+            var context = CreateAuthenticatedContext("/mcp");
+
+            var request = HttpProxy.CreateProxiedHttpRequest(context, forwardGatewaySecret: true);
+
+            request.Headers.GetValues(ForwardedIdentityHeaders.GatewaySecret).Single().Should().Be(GatewaySecret);
+        }
+
+        [TestMethod]
+        public void CreateProxiedHttpRequest_WithAdapterTarget_StillForwardsIdentityHeaders()
+        {
+            var context = CreateAuthenticatedContext("/adapters/victim/mcp");
+
+            var request = HttpProxy.CreateProxiedHttpRequest(context);
+
+            request.Headers.GetValues(ForwardedIdentityHeaders.UserId).Single().Should().Be("user-1");
+            request.Headers.GetValues(ForwardedIdentityHeaders.Roles).Single().Should().Be("mcp.admin");
+        }
+
+        [TestMethod]
+        public void CreateProxiedHttpRequest_WithClientSuppliedGatewaySecret_StripsItFromAdapterRequest()
+        {
+            var context = CreateAuthenticatedContext("/adapters/victim/mcp");
+            context.Request.Headers[ForwardedIdentityHeaders.GatewaySecret] = "attacker-supplied";
+
+            var request = HttpProxy.CreateProxiedHttpRequest(context);
+
+            request.Headers.Contains(ForwardedIdentityHeaders.GatewaySecret).Should().BeFalse();
+        }
+
+        private static DefaultHttpContext CreateAuthenticatedContext(string path)
+        {
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?> { ["GatewaySettings:Secret"] = GatewaySecret })
+                .Build();
+
+            var services = new ServiceCollection();
+            services.AddSingleton<IConfiguration>(configuration);
+
+            var context = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(new ClaimsIdentity(
+                    [new Claim(ClaimTypes.NameIdentifier, "user-1"), new Claim(ClaimTypes.Role, "mcp.admin")],
+                    "Test")),
+                RequestServices = services.BuildServiceProvider()
+            };
+
+            context.Request.Method = "POST";
+            context.Request.Scheme = "http";
+            context.Request.Host = new HostString("gateway.local");
+            context.Request.Path = path;
+            context.Request.ContentLength = 0;
+
+            return context;
+        }
+    }
+}


### PR DESCRIPTION
Security fix.

`HttpProxy.CreateProxiedHttpRequest` attached the shared `X-Gateway-Secret` header to every proxied request, including requests forwarded to user-deployed adapter pods, which have no need for it. The header is only meaningful to the tool gateway.

## Change

- `CreateProxiedHttpRequest` takes a new `bool forwardGatewaySecret = false` parameter and only attaches the header when it is set. The default is `false` so any future call site fails closed.
- `AdapterReverseProxyController.ForwardStreamableHttpRequest` passes `forwardGatewaySecret: name is null`, i.e. only the first-party tool gateway route (`POST /mcp`) opts in. The decision is made on the route rather than on the resolved backend name, because adapter names are not reserved.
- Forwarded identity headers (`X-Mcp-UserId` / `X-Mcp-Roles`) are unchanged for all targets, and inbound client-supplied `X-Gateway-Secret` continues to be stripped.

No configuration or deployment changes are required.

## Tests

New `HttpProxyTests` (4 cases): the header is absent for an adapter target, present for the tool gateway target, identity headers still reach adapters, and a client-supplied value is still stripped.

`Microsoft.McpGateway.Service.Tests` 38/38 pass. Full solution: Tools 27/27, Service 38/38, Management 156 pass / 8 skipped.

Also validated end to end on a local Kubernetes cluster: with the change, an adapter pod that echoes its inbound headers no longer sees `X-Gateway-Secret` (and it no longer appears in `GET /adapters/{name}/logs`), while `POST /mcp` still succeeds against the tool gateway.
