### PR TITLE
Restrict workload identity on adapters and tools to authorized roles

### DIFF
--- a/docs/entra-app-roles.md
+++ b/docs/entra-app-roles.md
@@ -60,3 +60,27 @@ The in-process built-in tools run shell commands and read/write files inside the
   ```
 
   `mcp.admin` is always permitted in addition to any configured roles. Leaving `RequiredRoles` empty keeps built-ins admin-only.
+
+## 5. Authorize Workload Identity on Adapters and Tools (`useWorkloadIdentity`)
+
+Setting `useWorkloadIdentity: true` binds the deployed pod to the cluster's **shared** federated identity (the `workload-sa` service account annotated with `azure.workload.identity/client-id`). Any container in that pod can then mint Entra ID access tokens for that identity and reach whatever Azure resources it is granted. Because the identity is shared by every workload in the namespace and is not owned by the requester, this is gated on the **caller's role** at create *and* update time, with **no creator bypass**.
+
+- **Default (fail-closed):** only callers holding `mcp.admin` may set `useWorkloadIdentity: true`. Other callers receive `403 Forbidden`; adapters and tools that do not request workload identity are unaffected.
+- To grant this without full admin, create a dedicated app role (e.g. `mcp.workload`), assign it (Section 2), then configure it on the gateway:
+
+  ```jsonc
+  // appsettings.json
+  {
+    "WorkloadIdentitySettings": {
+      "RequiredRoles": [ "mcp.workload" ]
+    }
+  }
+  ```
+
+  The same setting via environment variables (e.g. in the pod spec) uses the array index form:
+
+  ```
+  WorkloadIdentitySettings__RequiredRoles__0=mcp.workload
+  ```
+
+  `mcp.admin` is always permitted in addition to any configured roles. Leaving `RequiredRoles` empty keeps workload identity admin-only.

--- a/dotnet/Microsoft.McpGateway.Management/src/Authorization/IWorkloadIdentityAuthorizer.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Authorization/IWorkloadIdentityAuthorizer.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Security.Claims;
+
+namespace Microsoft.McpGateway.Management.Authorization
+{
+    /// <summary>
+    /// Authorizes binding a deployed adapter/tool workload to the cluster's
+    /// shared workload identity. Like <see cref="IBuiltinToolAuthorizer"/> —
+    /// and unlike <see cref="IPermissionProvider"/> — this is a capability
+    /// check against the caller's roles rather than a per-resource ACL, so
+    /// there is no creator bypass: the federated identity is shared by every
+    /// workload in the namespace and is not owned by the requester.
+    /// </summary>
+    public interface IWorkloadIdentityAuthorizer
+    {
+        /// <summary>
+        /// Returns <see langword="true"/> when <paramref name="principal"/> is
+        /// permitted to request <c>useWorkloadIdentity</c> on a deployment.
+        /// </summary>
+        bool IsAuthorized(ClaimsPrincipal principal);
+    }
+}

--- a/dotnet/Microsoft.McpGateway.Management/src/Authorization/WorkloadIdentityAuthorizer.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Authorization/WorkloadIdentityAuthorizer.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Security.Claims;
+using Microsoft.Extensions.Options;
+using Microsoft.McpGateway.Management.Extensions;
+
+namespace Microsoft.McpGateway.Management.Authorization
+{
+    /// <summary>
+    /// Default <see cref="IWorkloadIdentityAuthorizer"/>: a caller may bind a
+    /// workload to the shared federated identity when they hold
+    /// <c>mcp.admin</c> or any role configured in
+    /// <see cref="WorkloadIdentitySettings.RequiredRoles"/>. Fail-closed —
+    /// with no configuration only administrators are permitted.
+    /// </summary>
+    public sealed class WorkloadIdentityAuthorizer : IWorkloadIdentityAuthorizer
+    {
+        private const string AdminRole = "mcp.admin";
+
+        private readonly HashSet<string> _allowedRoles;
+
+        public WorkloadIdentityAuthorizer(IOptions<WorkloadIdentitySettings> options)
+        {
+            ArgumentNullException.ThrowIfNull(options);
+
+            _allowedRoles = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { AdminRole };
+            foreach (var role in options.Value?.RequiredRoles ?? Enumerable.Empty<string>())
+            {
+                if (!string.IsNullOrWhiteSpace(role))
+                {
+                    _allowedRoles.Add(role.Trim());
+                }
+            }
+        }
+
+        public bool IsAuthorized(ClaimsPrincipal principal)
+        {
+            ArgumentNullException.ThrowIfNull(principal);
+            return principal.GetUserRoles().Any(role => _allowedRoles.Contains(role));
+        }
+    }
+}

--- a/dotnet/Microsoft.McpGateway.Management/src/Authorization/WorkloadIdentitySettings.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Authorization/WorkloadIdentitySettings.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.McpGateway.Management.Authorization
+{
+    /// <summary>
+    /// Authorization configuration for binding deployed workloads to the
+    /// cluster's shared workload identity. Bound from the
+    /// "WorkloadIdentitySettings" section.
+    /// </summary>
+    public class WorkloadIdentitySettings
+    {
+        /// <summary>
+        /// Roles permitted to request <c>useWorkloadIdentity</c> when creating
+        /// or updating an adapter/tool, in addition to <c>mcp.admin</c> (which
+        /// is always allowed). When empty (the default), workload identity is
+        /// restricted to administrators only.
+        /// </summary>
+        public IList<string> RequiredRoles { get; set; } = [];
+    }
+}

--- a/dotnet/Microsoft.McpGateway.Management/src/Service/AdapterManagementService.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Service/AdapterManagementService.cs
@@ -12,12 +12,13 @@ using Microsoft.McpGateway.Management.Store;
 
 namespace Microsoft.McpGateway.Management.Service
 {
-    public class AdapterManagementService(IAdapterDeploymentManager adapterDeploymentManager, IAdapterResourceStore store, IPermissionProvider permissionProvider, ILogger<AdapterManagementService> logger) : IAdapterManagementService
+    public class AdapterManagementService(IAdapterDeploymentManager adapterDeploymentManager, IAdapterResourceStore store, IPermissionProvider permissionProvider, IWorkloadIdentityAuthorizer workloadIdentityAuthorizer, ILogger<AdapterManagementService> logger) : IAdapterManagementService
     {
         private const string NamePattern = "^[a-z0-9-]+$";
         private readonly IAdapterDeploymentManager _deploymentManager = adapterDeploymentManager ?? throw new ArgumentNullException(nameof(adapterDeploymentManager));
         private readonly IAdapterResourceStore _store = store ?? throw new ArgumentNullException(nameof(store));
         private readonly IPermissionProvider _permissionProvider = permissionProvider ?? throw new ArgumentNullException(nameof(permissionProvider));
+        private readonly IWorkloadIdentityAuthorizer _workloadIdentityAuthorizer = workloadIdentityAuthorizer ?? throw new ArgumentNullException(nameof(workloadIdentityAuthorizer));
         private readonly ILogger _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
         public async Task<AdapterResource> CreateAsync(ClaimsPrincipal accessContext, AdapterData request, CancellationToken cancellationToken)
@@ -27,6 +28,8 @@ namespace Microsoft.McpGateway.Management.Service
 
             if (!Regex.IsMatch(request.Name, NamePattern))
                 throw new ArgumentException("Name must contain only lowercase letters, numbers, and dashes.");
+
+            EnsureWorkloadIdentityAllowed(accessContext, request);
 
             var existing = await _store.TryGetAsync(request.Name, cancellationToken).ConfigureAwait(false);
             if (existing != null)
@@ -75,11 +78,19 @@ namespace Microsoft.McpGateway.Management.Service
                 ?? throw new ArgumentException("The adapter does not exist and cannot be updated.");
 
             await EnsureAccessAsync(accessContext, existing, Operation.Write).ConfigureAwait(false);
+            EnsureWorkloadIdentityAllowed(accessContext, request);
 
             // Throw if any change on Unchangeable fields
             if (existing.Name != request.Name)
             {
                 throw new ArgumentException("The adapter does not allow change on the submitted field.");
+            }
+
+            // The workload identity label is part of the StatefulSet selector, which Kubernetes
+            // does not allow patching, so the flag can only be set when the adapter is created.
+            if (existing.UseWorkloadIdentity != request.UseWorkloadIdentity)
+            {
+                throw new ArgumentException("UseWorkloadIdentity cannot be changed after creation. Delete and recreate the adapter instead.");
             }
 
             var updated = AdapterResource.Create(request, existing.CreatedBy, existing.CreatedAt);
@@ -150,6 +161,25 @@ namespace Microsoft.McpGateway.Management.Service
             var operationName = operation.ToString().ToLowerInvariant();
             logger.LogWarning("User {userId} is denied {operation} access for adapter {resourceId}.", accessContext.GetUserId(), operationName, resource.Name.Sanitize());
             throw new UnauthorizedAccessException("You do not have permission to perform the operation.");
+        }
+
+        /// <summary>
+        /// Binding a workload to the cluster's shared federated identity lets the deployed
+        /// container mint tokens for that identity, so it is gated on the caller's role
+        /// rather than on ownership of the adapter being created or updated.
+        /// </summary>
+        private void EnsureWorkloadIdentityAllowed(ClaimsPrincipal accessContext, AdapterData request)
+        {
+            // Evaluated unconditionally so the authorization check is never reached through a
+            // request-controlled branch (avoids CodeQL cs/user-controlled-bypass-of-sensitive-method).
+            var authorized = _workloadIdentityAuthorizer.IsAuthorized(accessContext);
+            if (!request.UseWorkloadIdentity || authorized)
+            {
+                return;
+            }
+
+            logger.LogWarning("User {userId} is denied workload identity for adapter {resourceId}.", accessContext.GetUserId(), request.Name.Sanitize());
+            throw new UnauthorizedAccessException("You do not have permission to enable workload identity.");
         }
     }
 }

--- a/dotnet/Microsoft.McpGateway.Management/src/Service/ToolManagementService.cs
+++ b/dotnet/Microsoft.McpGateway.Management/src/Service/ToolManagementService.cs
@@ -30,17 +30,20 @@ namespace Microsoft.McpGateway.Management.Service
         private readonly IAdapterDeploymentManager _deploymentManager;
         private readonly IToolResourceStore _store;
         private readonly IPermissionProvider _permissionProvider;
+        private readonly IWorkloadIdentityAuthorizer _workloadIdentityAuthorizer;
         private readonly ILogger _logger;
 
         public ToolManagementService(
             IAdapterDeploymentManager adapterDeploymentManager,
             IToolResourceStore store,
             IPermissionProvider permissionProvider,
+            IWorkloadIdentityAuthorizer workloadIdentityAuthorizer,
             ILogger<ToolManagementService> logger)
         {
             _deploymentManager = adapterDeploymentManager ?? throw new ArgumentNullException(nameof(adapterDeploymentManager));
             _store = store ?? throw new ArgumentNullException(nameof(store));
             _permissionProvider = permissionProvider ?? throw new ArgumentNullException(nameof(permissionProvider));
+            _workloadIdentityAuthorizer = workloadIdentityAuthorizer ?? throw new ArgumentNullException(nameof(workloadIdentityAuthorizer));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
@@ -53,6 +56,7 @@ namespace Microsoft.McpGateway.Management.Service
                 throw new ArgumentException("Name must contain only lowercase letters, numbers, and dashes.");
 
             ValidateToolDefinition(request.ToolDefinition);
+            EnsureWorkloadIdentityAllowed(accessContext, request);
 
             var existing = await _store.TryGetAsync(request.Name, cancellationToken).ConfigureAwait(false);
             if (existing != null)
@@ -105,11 +109,19 @@ namespace Microsoft.McpGateway.Management.Service
                 ?? throw new ArgumentException("The tool does not exist and cannot be updated.");
 
             await EnsureAccessAsync(accessContext, existing, Operation.Write).ConfigureAwait(false);
+            EnsureWorkloadIdentityAllowed(accessContext, request);
 
             // Throw if any change on unchangeable fields
             if (existing.Name != request.Name)
             {
                 throw new ArgumentException("The tool does not allow change on the submitted field.");
+            }
+
+            // The workload identity label is part of the StatefulSet selector, which Kubernetes
+            // does not allow patching, so the flag can only be set when the tool is created.
+            if (existing.UseWorkloadIdentity != request.UseWorkloadIdentity)
+            {
+                throw new ArgumentException("UseWorkloadIdentity cannot be changed after creation. Delete and recreate the tool instead.");
             }
 
             var updated = ToolResource.Create(request, existing.CreatedBy, existing.CreatedAt);
@@ -179,6 +191,25 @@ namespace Microsoft.McpGateway.Management.Service
 
             if (string.IsNullOrEmpty(toolDefinition.Path) || !PathPattern.IsMatch(toolDefinition.Path))
                 throw new ArgumentException("Path must start with '/' and contain only alphanumeric characters, slashes, dashes, underscores, and dots.");
+        }
+
+        /// <summary>
+        /// Binding a workload to the cluster's shared federated identity lets the deployed
+        /// container mint tokens for that identity, so it is gated on the caller's role
+        /// rather than on ownership of the tool being created or updated.
+        /// </summary>
+        private void EnsureWorkloadIdentityAllowed(ClaimsPrincipal accessContext, ToolData request)
+        {
+            // Evaluated unconditionally so the authorization check is never reached through a
+            // request-controlled branch (avoids CodeQL cs/user-controlled-bypass-of-sensitive-method).
+            var authorized = _workloadIdentityAuthorizer.IsAuthorized(accessContext);
+            if (!request.UseWorkloadIdentity || authorized)
+            {
+                return;
+            }
+
+            _logger.LogWarning("User {userId} is denied workload identity for tool {resourceId}.", accessContext.GetUserId(), request.Name.Sanitize());
+            throw new UnauthorizedAccessException("You do not have permission to enable workload identity.");
         }
 
         private async Task EnsureAccessAsync(ClaimsPrincipal accessContext, ToolResource resource, Operation operation)

--- a/dotnet/Microsoft.McpGateway.Management/test/AdapterManagementServiceTests.cs
+++ b/dotnet/Microsoft.McpGateway.Management/test/AdapterManagementServiceTests.cs
@@ -22,6 +22,7 @@ namespace Microsoft.McpGateway.Management.Tests
         private readonly Mock<IAdapterDeploymentManager> _deploymentManagerMock;
         private readonly Mock<IAdapterResourceStore> _storeMock;
         private readonly Mock<IPermissionProvider> _permissionProviderMock;
+        private readonly Mock<IWorkloadIdentityAuthorizer> _workloadIdentityAuthorizerMock;
         private readonly Mock<ILogger<AdapterManagementService>> _loggerMock;
     private readonly AdapterManagementService _service;
         private readonly ClaimsPrincipal _accessContext;
@@ -31,6 +32,7 @@ namespace Microsoft.McpGateway.Management.Tests
             _deploymentManagerMock = new Mock<IAdapterDeploymentManager>();
             _storeMock = new Mock<IAdapterResourceStore>();
             _permissionProviderMock = new Mock<IPermissionProvider>();
+            _workloadIdentityAuthorizerMock = new Mock<IWorkloadIdentityAuthorizer>();
             _loggerMock = new Mock<ILogger<AdapterManagementService>>();
             _permissionProviderMock.Setup(x => x.CheckAccessAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<IManagedResource>(), Operation.Read))
                 .ReturnsAsync(true);
@@ -38,7 +40,8 @@ namespace Microsoft.McpGateway.Management.Tests
                 .ReturnsAsync(true);
             _permissionProviderMock.Setup(x => x.CheckAccessAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<IEnumerable<AdapterResource>>(), Operation.Read))
                 .ReturnsAsync((ClaimsPrincipal _, IEnumerable<AdapterResource> resources, Operation _) => resources.ToArray());
-            _service = new AdapterManagementService(_deploymentManagerMock.Object, _storeMock.Object, _permissionProviderMock.Object, _loggerMock.Object);
+            _workloadIdentityAuthorizerMock.Setup(x => x.IsAuthorized(It.IsAny<ClaimsPrincipal>())).Returns(true);
+            _service = new AdapterManagementService(_deploymentManagerMock.Object, _storeMock.Object, _permissionProviderMock.Object, _workloadIdentityAuthorizerMock.Object, _loggerMock.Object);
             _accessContext = new ClaimsPrincipal(new ClaimsIdentity([new(ClaimTypes.NameIdentifier, "user1")]));
         }
 
@@ -370,7 +373,7 @@ namespace Microsoft.McpGateway.Management.Tests
         [TestMethod]
         public void Constructor_ShouldThrowArgumentNullException_WhenDeploymentManagerIsNull()
         {
-            var act = () => new AdapterManagementService(null!, _storeMock.Object, _permissionProviderMock.Object, _loggerMock.Object);
+            var act = () => new AdapterManagementService(null!, _storeMock.Object, _permissionProviderMock.Object, _workloadIdentityAuthorizerMock.Object, _loggerMock.Object);
 
             act.Should().Throw<ArgumentNullException>().WithParameterName("adapterDeploymentManager");
         }
@@ -378,7 +381,7 @@ namespace Microsoft.McpGateway.Management.Tests
         [TestMethod]
         public void Constructor_ShouldThrowArgumentNullException_WhenStoreIsNull()
         {
-            var act = () => new AdapterManagementService(_deploymentManagerMock.Object, null!, _permissionProviderMock.Object, _loggerMock.Object);
+            var act = () => new AdapterManagementService(_deploymentManagerMock.Object, null!, _permissionProviderMock.Object, _workloadIdentityAuthorizerMock.Object, _loggerMock.Object);
 
             act.Should().Throw<ArgumentNullException>().WithParameterName("store");
         }
@@ -386,17 +389,81 @@ namespace Microsoft.McpGateway.Management.Tests
         [TestMethod]
         public void Constructor_ShouldThrowArgumentNullException_WhenPermissionProviderIsNull()
         {
-            var act = () => new AdapterManagementService(_deploymentManagerMock.Object, _storeMock.Object, null!, _loggerMock.Object);
+            var act = () => new AdapterManagementService(_deploymentManagerMock.Object, _storeMock.Object, null!, _workloadIdentityAuthorizerMock.Object, _loggerMock.Object);
 
             act.Should().Throw<ArgumentNullException>().WithParameterName("permissionProvider");
         }
 
         [TestMethod]
+        public void Constructor_ShouldThrowArgumentNullException_WhenWorkloadIdentityAuthorizerIsNull()
+        {
+            var act = () => new AdapterManagementService(_deploymentManagerMock.Object, _storeMock.Object, _permissionProviderMock.Object, null!, _loggerMock.Object);
+
+            act.Should().Throw<ArgumentNullException>().WithParameterName("workloadIdentityAuthorizer");
+        }
+
+        [TestMethod]
         public void Constructor_ShouldThrowArgumentNullException_WhenLoggerIsNull()
         {
-            var act = () => new AdapterManagementService(_deploymentManagerMock.Object, _storeMock.Object, _permissionProviderMock.Object, null!);
+            var act = () => new AdapterManagementService(_deploymentManagerMock.Object, _storeMock.Object, _permissionProviderMock.Object, _workloadIdentityAuthorizerMock.Object, null!);
 
             act.Should().Throw<ArgumentNullException>().WithParameterName("logger");
+        }
+
+        [TestMethod]
+        public async Task CreateAsync_ShouldThrowUnauthorized_WhenWorkloadIdentityRequestedByUnauthorizedCaller()
+        {
+            _workloadIdentityAuthorizerMock.Setup(x => x.IsAuthorized(It.IsAny<ClaimsPrincipal>())).Returns(false);
+            var request = new AdapterData { Name = "wi-adapter", ImageName = "image", ImageVersion = "v1", UseWorkloadIdentity = true };
+            _storeMock.Setup(x => x.TryGetAsync("wi-adapter", It.IsAny<CancellationToken>())).ReturnsAsync((AdapterResource?)null);
+
+            Func<Task> act = () => _service.CreateAsync(_accessContext, request, CancellationToken.None);
+
+            await act.Should().ThrowAsync<UnauthorizedAccessException>();
+            _deploymentManagerMock.Verify(x => x.CreateDeploymentAsync(It.IsAny<AdapterData>(), It.IsAny<ResourceType>(), It.IsAny<CancellationToken>()), Times.Never);
+            _storeMock.Verify(x => x.UpsertAsync(It.IsAny<AdapterResource>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [TestMethod]
+        public async Task CreateAsync_ShouldCreateAdapter_WhenWorkloadIdentityNotRequestedByUnauthorizedCaller()
+        {
+            _workloadIdentityAuthorizerMock.Setup(x => x.IsAuthorized(It.IsAny<ClaimsPrincipal>())).Returns(false);
+            var request = new AdapterData { Name = "plain-adapter", ImageName = "image", ImageVersion = "v1", UseWorkloadIdentity = false };
+            _storeMock.Setup(x => x.TryGetAsync("plain-adapter", It.IsAny<CancellationToken>())).ReturnsAsync((AdapterResource?)null);
+
+            var result = await _service.CreateAsync(_accessContext, request, CancellationToken.None);
+
+            result.Name.Should().Be("plain-adapter");
+            _deploymentManagerMock.Verify(x => x.CreateDeploymentAsync(It.IsAny<AdapterData>(), ResourceType.Mcp, It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task UpdateAsync_ShouldThrowUnauthorized_WhenWorkloadIdentityRequestedByUnauthorizedCaller()
+        {
+            _workloadIdentityAuthorizerMock.Setup(x => x.IsAuthorized(It.IsAny<ClaimsPrincipal>())).Returns(false);
+            var existing = AdapterResource.Create(new AdapterData { Name = "wi-adapter", ImageName = "image", ImageVersion = "v1" }, "user1", DateTimeOffset.UtcNow);
+            _storeMock.Setup(x => x.TryGetAsync("wi-adapter", It.IsAny<CancellationToken>())).ReturnsAsync(existing);
+            var request = new AdapterData { Name = "wi-adapter", ImageName = "image", ImageVersion = "v1", UseWorkloadIdentity = true };
+
+            Func<Task> act = () => _service.UpdateAsync(_accessContext, request, CancellationToken.None);
+
+            await act.Should().ThrowAsync<UnauthorizedAccessException>();
+            _deploymentManagerMock.Verify(x => x.UpdateDeploymentAsync(It.IsAny<AdapterData>(), It.IsAny<ResourceType>(), It.IsAny<CancellationToken>()), Times.Never);
+            _storeMock.Verify(x => x.UpsertAsync(It.IsAny<AdapterResource>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [TestMethod]
+        public async Task UpdateAsync_ShouldThrowArgumentException_WhenWorkloadIdentityToggledByAuthorizedCaller()
+        {
+            var existing = AdapterResource.Create(new AdapterData { Name = "wi-adapter", ImageName = "image", ImageVersion = "v1" }, "user1", DateTimeOffset.UtcNow);
+            _storeMock.Setup(x => x.TryGetAsync("wi-adapter", It.IsAny<CancellationToken>())).ReturnsAsync(existing);
+            var request = new AdapterData { Name = "wi-adapter", ImageName = "image", ImageVersion = "v1", UseWorkloadIdentity = true };
+
+            Func<Task> act = () => _service.UpdateAsync(_accessContext, request, CancellationToken.None);
+
+            await act.Should().ThrowAsync<ArgumentException>().WithMessage("UseWorkloadIdentity cannot be changed*");
+            _deploymentManagerMock.Verify(x => x.UpdateDeploymentAsync(It.IsAny<AdapterData>(), It.IsAny<ResourceType>(), It.IsAny<CancellationToken>()), Times.Never);
+            _storeMock.Verify(x => x.UpsertAsync(It.IsAny<AdapterResource>(), It.IsAny<CancellationToken>()), Times.Never);
         }
     }
 

--- a/dotnet/Microsoft.McpGateway.Management/test/ToolManagementServiceTests.cs
+++ b/dotnet/Microsoft.McpGateway.Management/test/ToolManagementServiceTests.cs
@@ -23,6 +23,7 @@ namespace Microsoft.McpGateway.Management.Tests
         private readonly Mock<IAdapterDeploymentManager> _deploymentManagerMock;
         private readonly Mock<IToolResourceStore> _storeMock;
         private readonly Mock<IPermissionProvider> _permissionProviderMock;
+        private readonly Mock<IWorkloadIdentityAuthorizer> _workloadIdentityAuthorizerMock;
         private readonly Mock<ILogger<ToolManagementService>> _loggerMock;
         private readonly ToolManagementService _service;
         private readonly ClaimsPrincipal _accessContext;
@@ -32,6 +33,7 @@ namespace Microsoft.McpGateway.Management.Tests
             _deploymentManagerMock = new Mock<IAdapterDeploymentManager>();
             _storeMock = new Mock<IToolResourceStore>();
             _permissionProviderMock = new Mock<IPermissionProvider>();
+            _workloadIdentityAuthorizerMock = new Mock<IWorkloadIdentityAuthorizer>();
             _loggerMock = new Mock<ILogger<ToolManagementService>>();
             _permissionProviderMock.Setup(x => x.CheckAccessAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<IManagedResource>(), Operation.Read))
                 .ReturnsAsync(true);
@@ -39,7 +41,8 @@ namespace Microsoft.McpGateway.Management.Tests
                 .ReturnsAsync(true);
             _permissionProviderMock.Setup(x => x.CheckAccessAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<IEnumerable<ToolResource>>(), Operation.Read))
                 .ReturnsAsync((ClaimsPrincipal _, IEnumerable<ToolResource> resources, Operation _) => resources.ToArray());
-            _service = new ToolManagementService(_deploymentManagerMock.Object, _storeMock.Object, _permissionProviderMock.Object, _loggerMock.Object);
+            _workloadIdentityAuthorizerMock.Setup(x => x.IsAuthorized(It.IsAny<ClaimsPrincipal>())).Returns(true);
+            _service = new ToolManagementService(_deploymentManagerMock.Object, _storeMock.Object, _permissionProviderMock.Object, _workloadIdentityAuthorizerMock.Object, _loggerMock.Object);
             _accessContext = new ClaimsPrincipal(new ClaimsIdentity([new(ClaimTypes.NameIdentifier, "user1")]));
         }
 
@@ -406,7 +409,7 @@ namespace Microsoft.McpGateway.Management.Tests
         [TestMethod]
         public void Constructor_ShouldThrowArgumentNullException_WhenDeploymentManagerIsNull()
         {
-            var act = () => new ToolManagementService(null!, _storeMock.Object, _permissionProviderMock.Object, _loggerMock.Object);
+            var act = () => new ToolManagementService(null!, _storeMock.Object, _permissionProviderMock.Object, _workloadIdentityAuthorizerMock.Object, _loggerMock.Object);
 
             act.Should().Throw<ArgumentNullException>().WithParameterName("adapterDeploymentManager");
         }
@@ -414,7 +417,7 @@ namespace Microsoft.McpGateway.Management.Tests
         [TestMethod]
         public void Constructor_ShouldThrowArgumentNullException_WhenStoreIsNull()
         {
-            var act = () => new ToolManagementService(_deploymentManagerMock.Object, null!, _permissionProviderMock.Object, _loggerMock.Object);
+            var act = () => new ToolManagementService(_deploymentManagerMock.Object, null!, _permissionProviderMock.Object, _workloadIdentityAuthorizerMock.Object, _loggerMock.Object);
 
             act.Should().Throw<ArgumentNullException>().WithParameterName("store");
         }
@@ -422,17 +425,84 @@ namespace Microsoft.McpGateway.Management.Tests
         [TestMethod]
         public void Constructor_ShouldThrowArgumentNullException_WhenPermissionProviderIsNull()
         {
-            var act = () => new ToolManagementService(_deploymentManagerMock.Object, _storeMock.Object, null!, _loggerMock.Object);
+            var act = () => new ToolManagementService(_deploymentManagerMock.Object, _storeMock.Object, null!, _workloadIdentityAuthorizerMock.Object, _loggerMock.Object);
 
             act.Should().Throw<ArgumentNullException>().WithParameterName("permissionProvider");
         }
 
         [TestMethod]
+        public void Constructor_ShouldThrowArgumentNullException_WhenWorkloadIdentityAuthorizerIsNull()
+        {
+            var act = () => new ToolManagementService(_deploymentManagerMock.Object, _storeMock.Object, _permissionProviderMock.Object, null!, _loggerMock.Object);
+
+            act.Should().Throw<ArgumentNullException>().WithParameterName("workloadIdentityAuthorizer");
+        }
+
+        [TestMethod]
         public void Constructor_ShouldThrowArgumentNullException_WhenLoggerIsNull()
         {
-            var act = () => new ToolManagementService(_deploymentManagerMock.Object, _storeMock.Object, _permissionProviderMock.Object, null!);
+            var act = () => new ToolManagementService(_deploymentManagerMock.Object, _storeMock.Object, _permissionProviderMock.Object, _workloadIdentityAuthorizerMock.Object, null!);
 
             act.Should().Throw<ArgumentNullException>().WithParameterName("logger");
+        }
+
+        [TestMethod]
+        public async Task CreateAsync_ShouldThrowUnauthorized_WhenWorkloadIdentityRequestedByUnauthorizedCaller()
+        {
+            _workloadIdentityAuthorizerMock.Setup(x => x.IsAuthorized(It.IsAny<ClaimsPrincipal>())).Returns(false);
+            var request = CreateToolData("wi-tool");
+            request.UseWorkloadIdentity = true;
+            _storeMock.Setup(x => x.TryGetAsync("wi-tool", It.IsAny<CancellationToken>())).ReturnsAsync((ToolResource?)null);
+
+            Func<Task> act = () => _service.CreateAsync(_accessContext, request, CancellationToken.None);
+
+            await act.Should().ThrowAsync<UnauthorizedAccessException>();
+            _deploymentManagerMock.Verify(x => x.CreateDeploymentAsync(It.IsAny<AdapterData>(), It.IsAny<ResourceType>(), It.IsAny<CancellationToken>()), Times.Never);
+            _storeMock.Verify(x => x.UpsertAsync(It.IsAny<ToolResource>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [TestMethod]
+        public async Task CreateAsync_ShouldCreateTool_WhenWorkloadIdentityNotRequestedByUnauthorizedCaller()
+        {
+            _workloadIdentityAuthorizerMock.Setup(x => x.IsAuthorized(It.IsAny<ClaimsPrincipal>())).Returns(false);
+            var request = CreateToolData("plain-tool");
+            _storeMock.Setup(x => x.TryGetAsync("plain-tool", It.IsAny<CancellationToken>())).ReturnsAsync((ToolResource?)null);
+
+            var result = await _service.CreateAsync(_accessContext, request, CancellationToken.None);
+
+            result.Name.Should().Be("plain-tool");
+            _deploymentManagerMock.Verify(x => x.CreateDeploymentAsync(It.IsAny<AdapterData>(), ResourceType.Tool, It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task UpdateAsync_ShouldThrowUnauthorized_WhenWorkloadIdentityRequestedByUnauthorizedCaller()
+        {
+            _workloadIdentityAuthorizerMock.Setup(x => x.IsAuthorized(It.IsAny<ClaimsPrincipal>())).Returns(false);
+            var existing = ToolResource.Create(CreateToolData("wi-tool"), "user1", DateTimeOffset.UtcNow);
+            _storeMock.Setup(x => x.TryGetAsync("wi-tool", It.IsAny<CancellationToken>())).ReturnsAsync(existing);
+            var request = CreateToolData("wi-tool");
+            request.UseWorkloadIdentity = true;
+
+            Func<Task> act = () => _service.UpdateAsync(_accessContext, request, CancellationToken.None);
+
+            await act.Should().ThrowAsync<UnauthorizedAccessException>();
+            _deploymentManagerMock.Verify(x => x.UpdateDeploymentAsync(It.IsAny<AdapterData>(), It.IsAny<ResourceType>(), It.IsAny<CancellationToken>()), Times.Never);
+            _storeMock.Verify(x => x.UpsertAsync(It.IsAny<ToolResource>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [TestMethod]
+        public async Task UpdateAsync_ShouldThrowArgumentException_WhenWorkloadIdentityToggledByAuthorizedCaller()
+        {
+            var existing = ToolResource.Create(CreateToolData("wi-tool"), "user1", DateTimeOffset.UtcNow);
+            _storeMock.Setup(x => x.TryGetAsync("wi-tool", It.IsAny<CancellationToken>())).ReturnsAsync(existing);
+            var request = CreateToolData("wi-tool");
+            request.UseWorkloadIdentity = true;
+
+            Func<Task> act = () => _service.UpdateAsync(_accessContext, request, CancellationToken.None);
+
+            await act.Should().ThrowAsync<ArgumentException>().WithMessage("UseWorkloadIdentity cannot be changed*");
+            _deploymentManagerMock.Verify(x => x.UpdateDeploymentAsync(It.IsAny<AdapterData>(), It.IsAny<ResourceType>(), It.IsAny<CancellationToken>()), Times.Never);
+            _storeMock.Verify(x => x.UpsertAsync(It.IsAny<ToolResource>(), It.IsAny<CancellationToken>()), Times.Never);
         }
     }
 }

--- a/dotnet/Microsoft.McpGateway.Management/test/WorkloadIdentityAuthorizerTests.cs
+++ b/dotnet/Microsoft.McpGateway.Management/test/WorkloadIdentityAuthorizerTests.cs
@@ -1,0 +1,93 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using Microsoft.McpGateway.Management.Authorization;
+
+namespace Microsoft.McpGateway.Management.Tests
+{
+    /// <summary>
+    /// Tests for the workload identity capability gate: only callers holding
+    /// <c>mcp.admin</c> or a configured role may bind a deployment to the
+    /// cluster's shared federated identity, and there is no creator bypass.
+    /// </summary>
+    [TestClass]
+    public class WorkloadIdentityAuthorizerTests
+    {
+        private static ClaimsPrincipal Caller(params string[] roles)
+        {
+            var claims = new List<Claim> { new(ClaimTypes.NameIdentifier, "user1") };
+            claims.AddRange(roles.Select(r => new Claim(ClaimTypes.Role, r)));
+            return new ClaimsPrincipal(new ClaimsIdentity(claims, "test"));
+        }
+
+        private static WorkloadIdentityAuthorizer Create(params string[] requiredRoles) =>
+            new(Options.Create(new WorkloadIdentitySettings { RequiredRoles = requiredRoles.ToList() }));
+
+        [TestMethod]
+        public void IsAuthorized_AllowsAdmin_WhenNoRolesConfigured()
+        {
+            Create().IsAuthorized(Caller("mcp.admin")).Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void IsAuthorized_AdminCheckIsCaseInsensitive()
+        {
+            Create().IsAuthorized(Caller("MCP.Admin")).Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void IsAuthorized_DeniesNonAdmin_WhenNoRolesConfigured()
+        {
+            Create().IsAuthorized(Caller("mcp.engineer")).Should().BeFalse();
+        }
+
+        [TestMethod]
+        public void IsAuthorized_DeniesCaller_WithNoRoles()
+        {
+            Create().IsAuthorized(Caller()).Should().BeFalse();
+        }
+
+        [TestMethod]
+        public void IsAuthorized_AllowsConfiguredRole()
+        {
+            Create("mcp.workload").IsAuthorized(Caller("mcp.workload")).Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void IsAuthorized_AllowsConfiguredRole_CaseInsensitive()
+        {
+            Create("mcp.workload").IsAuthorized(Caller("MCP.Workload")).Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void IsAuthorized_StillAllowsAdmin_WhenOtherRolesConfigured()
+        {
+            Create("mcp.workload").IsAuthorized(Caller("mcp.admin")).Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void IsAuthorized_DeniesUnlistedRole()
+        {
+            Create("mcp.workload").IsAuthorized(Caller("mcp.engineer")).Should().BeFalse();
+        }
+
+        [TestMethod]
+        public void IsAuthorized_Throws_OnNullPrincipal()
+        {
+            var act = () => Create().IsAuthorized(null!);
+
+            act.Should().Throw<ArgumentNullException>();
+        }
+
+        [TestMethod]
+        public void Constructor_Throws_OnNullOptions()
+        {
+            var act = () => new WorkloadIdentityAuthorizer(null!);
+
+            act.Should().Throw<ArgumentNullException>();
+        }
+    }
+}

--- a/dotnet/Microsoft.McpGateway.Service/src/Controllers/ManagementController.cs
+++ b/dotnet/Microsoft.McpGateway.Service/src/Controllers/ManagementController.cs
@@ -30,6 +30,10 @@ namespace Microsoft.McpGateway.Service.Controllers
             {
                 return BadRequest(ex.Message);
             }
+            catch (UnauthorizedAccessException)
+            {
+                return Forbid();
+            }
         }
 
         // GET /adapters/{name}

--- a/dotnet/Microsoft.McpGateway.Service/src/Controllers/ToolManagementController.cs
+++ b/dotnet/Microsoft.McpGateway.Service/src/Controllers/ToolManagementController.cs
@@ -33,6 +33,10 @@ namespace Microsoft.McpGateway.Service.Controllers
             {
                 return BadRequest(ex.Message);
             }
+            catch (UnauthorizedAccessException)
+            {
+                return Forbid();
+            }
         }
 
         // GET /tools/{name}

--- a/dotnet/Microsoft.McpGateway.Service/src/Program.cs
+++ b/dotnet/Microsoft.McpGateway.Service/src/Program.cs
@@ -177,6 +177,12 @@ builder.Services.AddSingleton<IPermissionProvider, SimplePermissionProvider>();
 // holding mcp.admin may reference or invoke built-ins.
 builder.Services.Configure<BuiltinToolSettings>(builder.Configuration.GetSection("BuiltinToolSettings"));
 builder.Services.AddSingleton<IBuiltinToolAuthorizer, BuiltinToolAuthorizer>();
+
+// Authorization for binding a deployed adapter/tool to the cluster's shared workload
+// identity. Fail-closed: with no WorkloadIdentitySettings:RequiredRoles configured, only
+// callers holding mcp.admin may request useWorkloadIdentity.
+builder.Services.Configure<WorkloadIdentitySettings>(builder.Configuration.GetSection("WorkloadIdentitySettings"));
+builder.Services.AddSingleton<IWorkloadIdentityAuthorizer, WorkloadIdentityAuthorizer>();
 builder.Services.AddSingleton<IAdapterDeploymentManager>(c =>
 {
     var config = builder.Configuration.GetSection("ContainerRegistrySettings");

--- a/openapi/mcp-gateway.openapi.json
+++ b/openapi/mcp-gateway.openapi.json
@@ -576,7 +576,7 @@
           "useWorkloadIdentity": {
             "type": "boolean",
             "default": false,
-            "description": "Whether to use Azure Workload Identity for authentication"
+            "description": "Whether to use Azure Workload Identity for authentication. Requires the mcp.admin role or a role listed in WorkloadIdentitySettings:RequiredRoles; otherwise the request is rejected with 403."
           }
         }
       },


### PR DESCRIPTION
Deployments that set `useWorkloadIdentity` bind the pod to the namespace's shared federated service account. Requesting it is now a role-gated capability rather than something any authenticated caller can set.

## Change

- New `IWorkloadIdentityAuthorizer` / `WorkloadIdentityAuthorizer`, following the existing `IBuiltinToolAuthorizer` pattern: fail-closed to `mcp.admin`, extendable via `WorkloadIdentitySettings:RequiredRoles`. No creator bypass, since the identity is shared by the namespace rather than owned by the requester.
- `AdapterManagementService` and `ToolManagementService` enforce the check on create and update. `ManagementController.CreateAdapter` and `ToolManagementController.CreateTool` now map the denial to 403, matching the other endpoints on those controllers.
- `UseWorkloadIdentity` is now rejected as an unchangeable field on update. The label lives in the StatefulSet selector, which Kubernetes does not allow patching, so the previous behaviour persisted a value that could never reach the running pod. Callers get a 400 and must recreate the resource.

Requests that do not set `useWorkloadIdentity` are unaffected, and no configuration change is required unless a non-admin role needs the capability. Setup is documented in `docs/entra-app-roles.md`.

## Tests

New `WorkloadIdentityAuthorizerTests` (10 cases) plus create/update coverage in `AdapterManagementServiceTests` and `ToolManagementServiceTests` asserting that a denied request reaches neither the deployment manager nor the store.

No regression against `main`:

| Project | `main` | This branch |
| --- | --- | --- |
| Management | 156 passed / 8 skipped / 164 | 176 passed / 8 skipped / 184 |
| Service | 38 / 38 | 38 / 38 |
| Tools | 27 / 27 | 27 / 27 |

The 20 additional tests are exactly the ones added here; no existing test changed behaviour.

## Validation

Verified end to end on a local Kubernetes cluster following the README local deployment flow:

- adapter and tool create/update honour the role gate (13/13 control-plane cases)
- a denied request leaves no StatefulSet behind
- the resulting pod carries `azure.workload.identity/use` matching the authorized value
- the adapter data plane (`POST /adapters/{name}/mcp`) and the tool gateway router (`POST /mcp`) both continue to work
