### PR TITLE
Fix stream consumption in MCP adapter proxy

### DIFF
--- a/dotnet/Microsoft.McpGateway.Service/src/HttpProxy.cs
+++ b/dotnet/Microsoft.McpGateway.Service/src/HttpProxy.cs
@@ -53,6 +53,11 @@ namespace Microsoft.McpGateway.Service
                     requestMessage.Content?.Headers.TryAddWithoutValidation(header.Key, [.. header.Value]);
             }
 
+            if (requestMessage.Content is not null)
+            {
+                requestMessage.Content.Headers.ContentLength = context.Request.ContentLength;
+            }
+
             var principal = context.User;
             if (principal?.Identity?.IsAuthenticated == true)
             {

--- a/dotnet/Microsoft.McpGateway.Service/src/HttpProxy.cs
+++ b/dotnet/Microsoft.McpGateway.Service/src/HttpProxy.cs
@@ -25,6 +25,10 @@ namespace Microsoft.McpGateway.Service
             var hasBody = context.Request.ContentLength > 0 ||
                           context.Request.ContentLength is null && !HttpMethods.IsGet(context.Request.Method) && !HttpMethods.IsHead(context.Request.Method) && !HttpMethods.IsDelete(context.Request.Method) && !HttpMethods.IsOptions(context.Request.Method);
 
+            if (hasBody && !context.Request.Body.CanSeek)
+            {
+                context.Request.EnableBuffering();
+            }
             var requestMessage = new HttpRequestMessage
             {
                 Method = new HttpMethod(context.Request.Method),

--- a/dotnet/Microsoft.McpGateway.Service/test/HttpProxyTests.cs
+++ b/dotnet/Microsoft.McpGateway.Service/test/HttpProxyTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Security.Claims;
+using System.Text;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
@@ -55,6 +56,84 @@ namespace Microsoft.McpGateway.Service.Tests
             var request = HttpProxy.CreateProxiedHttpRequest(context);
 
             request.Headers.Contains(ForwardedIdentityHeaders.GatewaySecret).Should().BeFalse();
+        }
+
+        [TestMethod]
+        public async Task CreateProxiedHttpRequest_WithRequestBody_CanBeReadTwice()
+        {
+            var body = """{"jsonrpc":"2.0","method":"tools/list"}""";
+            var bodyBytes = Encoding.UTF8.GetBytes(body);
+
+            var context = CreateAuthenticatedContext("/adapters/test/mcp");
+            context.Request.ContentLength = bodyBytes.Length;
+            context.Request.Body = new MemoryStream(bodyBytes);
+
+            var request = HttpProxy.CreateProxiedHttpRequest(context);
+
+            using var firstCopy = new MemoryStream();
+            await request.Content!.CopyToAsync(firstCopy);
+
+            using var secondCopy = new MemoryStream();
+            await request.Content.CopyToAsync(secondCopy);
+
+            Encoding.UTF8.GetString(secondCopy.ToArray())
+                .Should()
+                .Be(body);
+        }
+
+        [TestMethod]
+        public async Task CreateProxiedHttpRequest_WithNonSeekableBody_CanBeReadTwice()
+        {
+            var body = """{"jsonrpc":"2.0","method":"tools/list"}""";
+            var bodyBytes = Encoding.UTF8.GetBytes(body);
+
+            var context = CreateAuthenticatedContext("/adapters/test/mcp");
+            context.Request.ContentLength = bodyBytes.Length;
+            context.Request.Body = new NonSeekableStream(bodyBytes);
+
+            var request = HttpProxy.CreateProxiedHttpRequest(context);
+
+            using var firstCopy = new MemoryStream();
+            await request.Content!.CopyToAsync(firstCopy);
+
+            using var secondCopy = new MemoryStream();
+            await request.Content.CopyToAsync(secondCopy);
+        }
+
+        private sealed class NonSeekableStream(byte[] data) : Stream
+        {
+            private readonly MemoryStream inner = new(data);
+
+            public override bool CanRead => true;
+            public override bool CanSeek => false;
+            public override bool CanWrite => false;
+            public override long Length => inner.Length;
+
+            public override long Position
+            {
+                get => inner.Position;
+                set => throw new NotSupportedException();
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+                => inner.Read(buffer, offset, count);
+
+            public override ValueTask<int> ReadAsync(
+                Memory<byte> buffer,
+                CancellationToken cancellationToken = default)
+                => inner.ReadAsync(buffer, cancellationToken);
+
+            public override long Seek(long offset, SeekOrigin origin)
+                => throw new NotSupportedException();
+
+            public override void SetLength(long value)
+                => throw new NotSupportedException();
+
+            public override void Flush()
+                => throw new NotSupportedException();
+
+            public override void Write(byte[] buffer, int offset, int count)
+                => throw new NotSupportedException();
         }
 
         private static DefaultHttpContext CreateAuthenticatedContext(string path)

--- a/dotnet/Microsoft.McpGateway.Service/test/HttpProxyTests.cs
+++ b/dotnet/Microsoft.McpGateway.Service/test/HttpProxyTests.cs
@@ -99,6 +99,53 @@ namespace Microsoft.McpGateway.Service.Tests
             using var secondCopy = new MemoryStream();
             await request.Content.CopyToAsync(secondCopy);
         }
+        [TestMethod]
+        public async Task CreateProxiedHttpRequest_WithUnknownLengthNonSeekableBody_PreservesUnknownLength()
+        {
+            var body = """{"jsonrpc":"2.0","method":"tools/list"}""";
+            var bodyBytes = Encoding.UTF8.GetBytes(body);
+
+            var context = CreateAuthenticatedContext("/adapters/test/mcp");
+            context.Request.ContentLength = null;
+            context.Request.Body = new NonSeekableStream(bodyBytes);
+
+            var request = HttpProxy.CreateProxiedHttpRequest(context);
+
+            request.Content.Should().NotBeNull();
+            request.Content!.Headers.ContentLength.Should().BeNull();
+
+            using var copy = new MemoryStream();
+            await request.Content.CopyToAsync(copy);
+
+            Encoding.UTF8.GetString(copy.ToArray())
+                .Should()
+                .Be(body);
+        }
+
+        [TestMethod]
+        public async Task CreateProxiedHttpRequest_WithBufferedSeekableBodyReportingZeroLength_PreservesUnknownLength()
+        {
+            // Reproduces the FileBufferingReadStream shape used by HttpRequest.EnableBuffering():
+            // CanSeek == true, but Length lies as 0 until the underlying content has been read/buffered.
+            var body = """{"jsonrpc":"2.0","method":"tools/list"}""";
+            var bodyBytes = Encoding.UTF8.GetBytes(body);
+
+            var context = CreateAuthenticatedContext("/adapters/test/mcp");
+            context.Request.ContentLength = null;
+            context.Request.Body = new LazyLengthSeekableStream(bodyBytes);
+
+            var request = HttpProxy.CreateProxiedHttpRequest(context);
+
+            request.Content.Should().NotBeNull();
+            request.Content!.Headers.ContentLength.Should().BeNull();
+
+            using var copy = new MemoryStream();
+            await request.Content.CopyToAsync(copy);
+
+            Encoding.UTF8.GetString(copy.ToArray())
+                .Should()
+                .Be(body);
+        }
 
         private sealed class NonSeekableStream(byte[] data) : Stream
         {
@@ -125,6 +172,63 @@ namespace Microsoft.McpGateway.Service.Tests
 
             public override long Seek(long offset, SeekOrigin origin)
                 => throw new NotSupportedException();
+
+            public override void SetLength(long value)
+                => throw new NotSupportedException();
+
+            public override void Flush()
+                => throw new NotSupportedException();
+
+            public override void Write(byte[] buffer, int offset, int count)
+                => throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// Mimics Microsoft.AspNetCore.WebUtilities.FileBufferingReadStream: seekable,
+        /// but reports Length == 0 until data has actually been read into the buffer.
+        /// This is the shape that caused StreamContent to compute Content-Length: 0
+        /// for unknown-length bodies after EnableBuffering() was introduced.
+        /// </summary>
+        private sealed class LazyLengthSeekableStream(byte[] data) : Stream
+        {
+            private readonly MemoryStream inner = new(data);
+            private bool hasBeenRead;
+
+            public override bool CanRead => true;
+            public override bool CanSeek => true;
+            public override bool CanWrite => false;
+            public override long Length => hasBeenRead ? inner.Length : 0;
+
+            public override long Position
+            {
+                get => inner.Position;
+                set => inner.Position = value;
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                var read = inner.Read(buffer, offset, count);
+                if (read > 0)
+                {
+                    hasBeenRead = true;
+                }
+                return read;
+            }
+
+            public override async ValueTask<int> ReadAsync(
+                Memory<byte> buffer,
+                CancellationToken cancellationToken = default)
+            {
+                var read = await inner.ReadAsync(buffer, cancellationToken);
+                if (read > 0)
+                {
+                    hasBeenRead = true;
+                }
+                return read;
+            }
+
+            public override long Seek(long offset, SeekOrigin origin)
+                => inner.Seek(offset, origin);
 
             public override void SetLength(long value)
                 => throw new NotSupportedException();


### PR DESCRIPTION
## Summary

Fixes #48.

The adapter proxy directly wrapped non-seekable incoming request bodies
in `StreamContent`. When the request content was consumed more than once,
this resulted in:

`System.InvalidOperationException: The stream was already consumed. It cannot be read again.`

This change enables buffering for non-seekable request bodies before creating
the proxied `StreamContent`.

## Tests

- Added regression coverage for non-seekable request bodies.
- `dotnet test`
- 251 tests passed
- 0 failed